### PR TITLE
Add Runtime Context Class

### DIFF
--- a/twister2/executor/src/java/edu/iu/dsc/tws/executor/core/RuntimeContext.java
+++ b/twister2/executor/src/java/edu/iu/dsc/tws/executor/core/RuntimeContext.java
@@ -1,0 +1,65 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package edu.iu.dsc.tws.executor.core;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import edu.iu.dsc.tws.common.config.Config;
+import edu.iu.dsc.tws.common.config.Context;
+
+public class RuntimeContext extends Context {
+  public static final String PARENTPATH = "twister2.runtime.path";
+  private final Map<String, Object> keyValues = new HashMap<>();
+
+  public void put(String key, Object value) {
+    this.keyValues.put(key, value);
+
+  }
+
+  //used to build new config after adding runtime objects
+  public Config build(Config config) {
+    Config updatedConfig = Config.newBuilder()
+        .putAll(config)
+        .putAll(keyValues)
+        .build();
+    return updatedConfig;
+  }
+
+  public static String getParentpath(Config cfg) {
+    return cfg.getStringValue(PARENTPATH);
+  }
+}


### PR DESCRIPTION
Runtime Context is written in edu.iu.dsc.tws.executor.core. Currently, Parentpath address (used in checkpointing ) can be added.

After adding to the config, call the build method to build a new config and replace it with the current one.