### PR TITLE
renamed numberOfWorkers to instances in ComputeResource in job.proto

### DIFF
--- a/twister2/api/src/java/edu/iu/dsc/tws/api/job/Twister2Job.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/job/Twister2Job.java
@@ -120,7 +120,7 @@ public final class Twister2Job {
   private int countNumberOfWorkers() {
     int totalWorkers = 0;
     for (JobAPI.ComputeResource computeResource: computeResources) {
-      totalWorkers += computeResource.getNumberOfWorkers();
+      totalWorkers += computeResource.getInstances() * computeResource.getWorkersPerPod();
     }
     return totalWorkers;
   }
@@ -143,7 +143,7 @@ public final class Twister2Job {
       JobAPI.ComputeResource cr = computeResources.get(i);
       jobStr += String.format("\nComputeResource[%d]: cpu: %.1f, ram: %d MB, disk: %.1f GB, "
           + "instances: %d, workersPerPod: %d", i, cr.getCpu(), cr.getRamMegaBytes(),
-          cr.getDiskGigaBytes(), cr.getNumberOfWorkers(), cr.getWorkersPerPod());
+          cr.getDiskGigaBytes(), cr.getInstances(), cr.getWorkersPerPod());
     }
 
     return jobStr;
@@ -178,16 +178,16 @@ public final class Twister2Job {
 
     public Twister2JobBuilder addComputeResource(double cpu,
                                                  int ramMegaBytes,
-                                                 int numberOfWorkers) {
-      addComputeResource(cpu, ramMegaBytes, 0, numberOfWorkers, 1);
+                                                 int instances) {
+      addComputeResource(cpu, ramMegaBytes, 0, instances, 1);
       return this;
     }
 
     public Twister2JobBuilder addComputeResource(double cpu,
                                                  int ramMegaBytes,
                                                  double diskGigaBytes,
-                                                 int numberOfWorkers) {
-      addComputeResource(cpu, ramMegaBytes, diskGigaBytes, numberOfWorkers, 1);
+                                                 int instances) {
+      addComputeResource(cpu, ramMegaBytes, diskGigaBytes, instances, 1);
       return this;
     }
 
@@ -195,13 +195,13 @@ public final class Twister2Job {
     public Twister2JobBuilder addComputeResource(double cpu,
                                                  int ramMegaBytes,
                                                  double diskGigaBytes,
-                                                 int numberOfWorkers,
+                                                 int instances,
                                                  int workersPerPod) {
       JobAPI.ComputeResource computeResource = JobAPI.ComputeResource.newBuilder()
           .setCpu(cpu)
           .setRamMegaBytes(ramMegaBytes)
           .setDiskGigaBytes(diskGigaBytes)
-          .setNumberOfWorkers(numberOfWorkers)
+          .setInstances(instances)
           .setWorkersPerPod(workersPerPod)
           .setIndex(computeResourceIndex++)
           .build();

--- a/twister2/config/src/yaml/conf/kubernetes/client.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/client.yaml
@@ -7,20 +7,23 @@ twister2.job.name: "t2-job"
 
 # A Twister2 job can have multiple sets of compute resources
 # Four fields are mandatory: cpu, ram, disk and instances
-# workersPerPod shows the number of workers on each pod in Kubernetes. May be omitted in other clusters.
-# instances must be divisible by workersPerPod, when workersPerPod is given
+# instances shows the number of compute resources to be started with this specification
+# workersPerPod shows the number of workers on each pod in Kubernetes.
+#    May be omitted in other clusters. default value is 1.
 worker.compute.resources:
 - cpu: 0.4  # number of cores for each worker, may be fractional such as 0.5 or 2.4
   ram: 1024 # ram for each worker as Mega bytes
   disk: 1.0 # volatile disk for each worker as Giga bytes
-  instances: 6 # number of worker instances with this specification
+  instances: 3 # number of compute resource instances with this specification
   workersPerPod: 2 # number of workers on each pod in Kubernetes. May be omitted in other clusters.
+                   # number of workers using this compute resource: instances * workersPerPod
 
 - cpu: 0.5  # number of cores for each worker, may be fractional such as 0.5 or 2.4
   ram: 1024 # ram for each worker as mega bytes
   disk: 1.0 # volatile disk for each worker as giga bytes. May be zero.
-  instances: 4 # number of worker instances with this specification
+  instances: 2 # number of compute resource instances with this specification
   workersPerPod: 2 # number of workers on each pod in Kubernetes. May be omitted in other clusters.
+                   # number of workers using this compute resource: instances * workersPerPod
 
 # worker class to run
 twister2.job.worker.class: "edu.iu.dsc.tws.examples.internal.rsched.BasicK8sWorker"

--- a/twister2/config/src/yaml/conf/mesos/client.yaml
+++ b/twister2/config/src/yaml/conf/mesos/client.yaml
@@ -16,19 +16,20 @@ twister2.job.name: "basic-mesos"
 
 # A Twister2 job can have multiple sets of compute resources
 # Four fields are mandatory: cpu, ram, disk and instances
-# workersPerPod shows the number of workers on each pod in Kubernetes. May be omitted in other clusters.
-# instances must be divisible by workersPerPod, when workersPerPod is given
+# instances shows the number of compute resources to be started with this specification
+# workersPerPod shows the number of workers on each pod in Kubernetes.
+#    May be omitted in other clusters. default value is 1.
 worker.compute.resources:
 - cpu: 0.4  # number of cores for each worker, may be fractional such as 0.5 or 2.4
   ram: 1024 # ram for each worker as Mega bytes
   disk: 1.0 # volatile disk for each worker as Giga bytes
-  instances: 6 # number of worker instances with this specification
+  instances: 6 # number of compute resource instances with this specification
 #  workersPerPod: 2 # number of workers on each pod in Kubernetes. May be omitted in other clusters.
 
 - cpu: 0.5  # number of cores for each worker, may be fractional such as 0.5 or 2.4
   ram: 1024 # ram for each worker as mega bytes
   disk: 1.0 # volatile disk for each worker as giga bytes. May be zero.
-  instances: 4 # number of worker instances with this specification
+  instances: 4 # number of compute resource instances with this specification
 #  workersPerPod: 2 # number of workers on each pod in Kubernetes. May be omitted in other clusters.
 
 # nfs server address

--- a/twister2/proto/job.proto
+++ b/twister2/proto/job.proto
@@ -31,14 +31,16 @@ message Config {
 // cpu as a double, can be fractional
 // RAM as mega bytes
 // Disk as giga bytes. Disk is volatile disk.
-// number_of_workers to have this compute resource
-// workers_per_pod: in kubernetes, number of workes in each pod for this resource
+// instances: number of instances that will be created from this compute resource
+// workers_per_pod: in kubernetes, on each compute resource (on each pod)
+//                  this many workers will be started
+//                  number of workers running on this resource type is: instances * workers_per_pod
 // index: a unique index is assigned to each resource starting from 0
 message ComputeResource {
     double cpu = 1;
     int32 ram_mega_bytes = 2;
     double disk_giga_bytes = 3;
-    int32 number_of_workers = 4;
+    int32 instances = 4;
     int32 workers_per_pod = 5;
 
     oneof indexRequired {

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesLauncher.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesLauncher.java
@@ -442,20 +442,6 @@ public class KubernetesLauncher implements ILauncher, IJobTerminator {
    */
   private boolean configParametersOK(JobAPI.Job job) {
 
-    // number of workers has to be divisible by workersPerPod in each ComputeResource
-    // all pods will have equal number of containers
-    // all pods will be identical
-    for (JobAPI.ComputeResource computeResource: job.getComputeResourceList()) {
-      int workersPerPod = computeResource.getWorkersPerPod();
-      int numberOfWorkers = computeResource.getNumberOfWorkers();
-      if (numberOfWorkers % workersPerPod != 0) {
-        LOG.log(Level.SEVERE, String.format("workersPerPod has to be divisible by worker instances."
-            + " workersPerPod: " + workersPerPod + " numberOfWorkers: " + numberOfWorkers
-            + "\n++++++++++++++++++ Aborting submission ++++++++++++++++++"));
-        return false;
-      }
-    }
-
     // when OpenMPI is enabled, all pods need to have equal numbers workers
     // we check whether all workersPerPod values are equal to first ComputeResource workersPerPod
     if (SchedulerContext.useOpenMPI(config)) {

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesUtils.java
@@ -315,7 +315,7 @@ public final class KubernetesUtils {
     int podsCount = 0;
 
     for (JobAPI.ComputeResource computeResource: job.getComputeResourceList()) {
-      podsCount += computeResource.getNumberOfWorkers() / computeResource.getWorkersPerPod();
+      podsCount += computeResource.getInstances();
     }
 
     return podsCount;
@@ -334,7 +334,7 @@ public final class KubernetesUtils {
     for (int i = 0; i < resourceList.size(); i++) {
 
       JobAPI.ComputeResource computeResource = resourceList.get(i);
-      int podsCount = computeResource.getNumberOfWorkers() / computeResource.getWorkersPerPod();
+      int podsCount = computeResource.getInstances();
       int index = computeResource.getIndex();
 
       for (int j = 0; j < podsCount; j++) {

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/RequestObjectBuilder.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/RequestObjectBuilder.java
@@ -108,7 +108,7 @@ public final class RequestObjectBuilder {
     // by default they are started sequentially
     setSpec.setPodManagementPolicy("Parallel");
 
-    int numberOfPods = computeResource.getNumberOfWorkers() / computeResource.getWorkersPerPod();
+    int numberOfPods = computeResource.getInstances();
     setSpec.setReplicas(numberOfPods);
 
     // add selector for the job

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerUtils.java
@@ -165,7 +165,8 @@ public final class K8sWorkerUtils {
 
     int workerCount = 0;
     for (int i = 0; i < currentStatefulSetIndex; i++) {
-      workerCount += JobUtils.getComputeResource(job, i).getNumberOfWorkers();
+      JobAPI.ComputeResource computeResource = JobUtils.getComputeResource(job, i);
+      workerCount += computeResource.getInstances() * computeResource.getWorkersPerPod();
     }
 
     return workerCount;


### PR DESCRIPTION
I renamed the field numberOfWorkers to instances in ComputeResource in job.proto. This is more clear I think. I changed all affected classes and config files. 