### PR TITLE
additional worker ports implemented

### DIFF
--- a/twister2/common/src/java/edu/iu/dsc/tws/common/resource/WorkerInfoUtils.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/resource/WorkerInfoUtils.java
@@ -24,6 +24,7 @@
 package edu.iu.dsc.tws.common.resource;
 
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.proto.jobmaster.JobMasterAPI.NodeInfo;
@@ -38,14 +39,14 @@ public final class WorkerInfoUtils {
   public static WorkerInfo createWorkerInfo(int workerID,
                                             String workerIP,
                                             int workerPort) {
-    return createWorkerInfo(workerID, workerIP, workerPort, null, null);
+    return createWorkerInfo(workerID, workerIP, workerPort, null, null, null);
   }
 
   public static WorkerInfo createWorkerInfo(int workerID,
                                             String workerIP,
                                             int workerPort,
                                             NodeInfo nodeInfo) {
-    return createWorkerInfo(workerID, workerIP, workerPort, nodeInfo, null);
+    return createWorkerInfo(workerID, workerIP, workerPort, nodeInfo, null, null);
   }
 
   public static WorkerInfo createWorkerInfo(int workerID,
@@ -53,6 +54,15 @@ public final class WorkerInfoUtils {
                                             int workerPort,
                                             NodeInfo nodeInfo,
                                             JobAPI.ComputeResource computeResource) {
+    return createWorkerInfo(workerID, workerIP, workerPort, nodeInfo, computeResource, null);
+  }
+
+  public static WorkerInfo createWorkerInfo(int workerID,
+                                            String workerIP,
+                                            int workerPort,
+                                            NodeInfo nodeInfo,
+                                            JobAPI.ComputeResource computeResource,
+                                            Map<String, Integer> additionalPorts) {
 
     WorkerInfo.Builder builder = WorkerInfo.newBuilder();
     builder.setWorkerID(workerID);
@@ -67,6 +77,10 @@ public final class WorkerInfoUtils {
       builder.setComputeResource(computeResource);
     }
 
+    if (additionalPorts != null) {
+      builder.putAllAdditionalPort(additionalPorts);
+    }
+
     return builder.build();
   }
 
@@ -76,7 +90,8 @@ public final class WorkerInfoUtils {
         workerInfo.getWorkerIP(),
         workerInfo.getPort(),
         workerInfo.getNodeInfo(),
-        workerInfo.getComputeResource());
+        workerInfo.getComputeResource(),
+        workerInfo.getAdditionalPortMap());
   }
 
   /**

--- a/twister2/config/src/yaml/conf/kubernetes/client.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/client.yaml
@@ -34,6 +34,11 @@ twister2.job.worker.class: "edu.iu.dsc.tws.examples.internal.rsched.BasicK8sWork
 # twister2.job.worker.class: "edu.iu.dsc.tws.examples.internal.BasicNetworkTest"
 # twister2.job.worker.class: "edu.iu.dsc.tws.examples.batch.comms.batch.BReduceExample"
 
+# by default each worker has one port
+# additional ports can be requested for all workers in a job
+# please provide the requested port names as a list
+worker.additional.ports: ["port1", "port2", "port3"]
+
 ########################################################################
 # Kubernetes related settings
 ########################################################################

--- a/twister2/config/src/yaml/conf/kubernetes/network.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/network.yaml
@@ -14,8 +14,8 @@ kubernetes.secret.name: "twister2-openmpi-ssh-key"
 # the base port number workers will use internally to communicate with each other
 # when there are multiple workers in a pod, first worker will get this port number,
 # second worker will get the next port, and so on.
-# default value is 9999,
-# kubernetes.worker.base.port: 9999
+# default value is 9000,
+# kubernetes.worker.base.port: 9000
 
 # transport protocol for the worker. TCP or UDP
 # by default, it is TCP

--- a/twister2/proto/jobmaster.proto
+++ b/twister2/proto/jobmaster.proto
@@ -61,6 +61,7 @@ message WorkerInfo {
 
     NodeInfo nodeInfo = 4;
     tws.proto.job.ComputeResource computeResource = 5;
+    map<string, int32> additionalPort = 6;
 }
 
 // a worker informs the master that its state has changed

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/SchedulerContext.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/SchedulerContext.java
@@ -70,6 +70,8 @@ public class SchedulerContext extends Context {
   public static final String RACKS_LIST = "racks.list";
   public static final String DATACENTERS_LIST = "datacenters.list";
 
+  public static final String WORKER_ADDITIONAL_PORTS = "worker.additional.ports";
+
   public static String uploaderClass(Config cfg) {
     return cfg.getStringValue(UPLOADER_CLASS);
   }
@@ -146,6 +148,17 @@ public class SchedulerContext extends Context {
     return cfg.getStringValue("twister2.network.channel.class")
         .equals("edu.iu.dsc.tws.comms.dfw.mpi.TWSMPIChannel");
   }
+
+  public static List<String> workerAdditionalPorts(Config cfg) {
+    return cfg.getStringList(WORKER_ADDITIONAL_PORTS);
+  }
+
+  public static int numberOfAdditionalPorts(Config cfg) {
+    List<String> portNameList = workerAdditionalPorts(cfg);
+    return portNameList == null ? 0 : portNameList.size();
+  }
+
+
 
   public static JobMasterAPI.NodeInfo getNodeInfo(Config cfg, String nodeIP) {
 

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesContext.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesContext.java
@@ -23,7 +23,7 @@ public class KubernetesContext extends SchedulerContext {
   public static final String KUBERNETES_NAMESPACE_DEFAULT = "default";
   public static final String KUBERNETES_NAMESPACE = "kubernetes.namespace";
 
-  public static final int K8S_WORKER_BASE_PORT_DEFAULT = 9999;
+  public static final int K8S_WORKER_BASE_PORT_DEFAULT = 9000;
   public static final String K8S_WORKER_BASE_PORT = "kubernetes.worker.base.port";
 
   public static final boolean NODE_LOCATIONS_FROM_CONFIG_DEFAULT = true;

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/RequestObjectBuilder.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/RequestObjectBuilder.java
@@ -339,7 +339,8 @@ public final class RequestObjectBuilder {
 
     container.setVolumeMounts(volumeMounts);
 
-    int containerPort = KubernetesContext.workerBasePort(config) + containerIndex;
+    int containerPort = KubernetesContext.workerBasePort(config)
+        + containerIndex * (SchedulerContext.numberOfAdditionalPorts(config) + 1);
 
     V1ContainerPort port = new V1ContainerPort();
     port.name("port11"); // currently not used

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/mpi/MPIWorkerStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/mpi/MPIWorkerStarter.java
@@ -13,6 +13,7 @@ package edu.iu.dsc.tws.rsched.schedulers.k8s.mpi;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -121,39 +122,45 @@ public final class MPIWorkerStarter {
     String podName = null;
     try {
       localHost = InetAddress.getLocalHost();
-      String podIP = localHost.getHostAddress();
-      podName = localHost.getHostName();
-
-      int workerPort = KubernetesContext.workerBasePort(config) + workerID;
-
-      String nodeIP = PodWatchUtils.getNodeIP(KubernetesContext.namespace(config), jobName, podIP);
-      JobMasterAPI.NodeInfo nodeInfo = null;
-      if (nodeIP == null) {
-        LOG.warning("Could not get nodeIP for this pod. Using podIP as nodeIP.");
-        nodeInfo = NodeInfoUtils.createNodeInfo(podIP, null, null);
-      } else {
-
-        nodeInfo = KubernetesContext.nodeLocationsFromConfig(config)
-            ? KubernetesContext.getNodeInfo(config, nodeIP)
-            : K8sWorkerUtils.getNodeInfoFromEncodedStr(encodedNodeInfoList, nodeIP);
-      }
-
-      LOG.info("NodeInfoUtils for this worker: " + nodeInfo);
-
-      computeResource = K8sWorkerUtils.getComputeResource(job, podName);
-
-      workerInfo = WorkerInfoUtils.createWorkerInfo(
-          workerID, localHost.getHostAddress(), workerPort, nodeInfo, computeResource);
-
-      LOG.info("Worker information summary: \n"
-          + "MPI Rank(workerID): " + workerID + "\n"
-          + "MPI Size(number of workers): " + numberOfWorkers + "\n"
-          + "POD_IP: " + podIP + "\n"
-          + "HOSTNAME(podname): " + podName
-      );
     } catch (UnknownHostException e) {
       LOG.log(Level.SEVERE, "Cannot get localHost.", e);
     }
+
+    String podIP = localHost.getHostAddress();
+    podName = localHost.getHostName();
+
+    int workerPort = KubernetesContext.workerBasePort(config)
+        + workerID * (SchedulerContext.numberOfAdditionalPorts(config) + 1);
+
+    String nodeIP = PodWatchUtils.getNodeIP(KubernetesContext.namespace(config), jobName, podIP);
+    JobMasterAPI.NodeInfo nodeInfo = null;
+    if (nodeIP == null) {
+      LOG.warning("Could not get nodeIP for this pod. Using podIP as nodeIP.");
+      nodeInfo = NodeInfoUtils.createNodeInfo(podIP, null, null);
+    } else {
+
+      nodeInfo = KubernetesContext.nodeLocationsFromConfig(config)
+          ? KubernetesContext.getNodeInfo(config, nodeIP)
+          : K8sWorkerUtils.getNodeInfoFromEncodedStr(encodedNodeInfoList, nodeIP);
+    }
+
+    LOG.info("NodeInfoUtils for this worker: " + nodeInfo);
+
+    computeResource = K8sWorkerUtils.getComputeResource(job, podName);
+
+    // generate additional ports if requested
+    Map<String, Integer> additionalPorts =
+        K8sWorkerUtils.generateAdditionalPorts(config, workerPort);
+
+    workerInfo = WorkerInfoUtils.createWorkerInfo(
+        workerID, podIP, workerPort, nodeInfo, computeResource, additionalPorts);
+
+    LOG.info("Worker information summary: \n"
+        + "MPI Rank(workerID): " + workerID + "\n"
+        + "MPI Size(number of workers): " + numberOfWorkers + "\n"
+        + "POD_IP: " + podIP + "\n"
+        + "HOSTNAME(podname): " + podName
+    );
 
     // start JobMasterClient
     jobMasterClient = new JobMasterClient(config, workerInfo, jobMasterIP,

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerStarter.java
@@ -13,6 +13,7 @@ package edu.iu.dsc.tws.rsched.schedulers.k8s.worker;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Map;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.common.config.Config;
@@ -108,9 +109,13 @@ public final class K8sWorkerStarter {
     // get computeResource for this worker
     computeResource = K8sWorkerUtils.getComputeResource(job, podName);
 
-    // set workerInfo
+    // generate additional ports if requested
+    Map<String, Integer> additionalPorts =
+        K8sWorkerUtils.generateAdditionalPorts(config, workerPort);
+
+    // construct WorkerInfo
     workerInfo = WorkerInfoUtils.createWorkerInfo(
-        workerID, localHost.getHostAddress(), workerPort, nodeInfo, computeResource);
+        workerID, podIP, workerPort, nodeInfo, computeResource, additionalPorts);
 
     // initialize persistent volume
     K8sPersistentVolume pv = null;

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerUtils.java
@@ -16,6 +16,9 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -28,6 +31,7 @@ import edu.iu.dsc.tws.common.resource.NodeInfoUtils;
 import edu.iu.dsc.tws.master.JobMasterContext;
 import edu.iu.dsc.tws.proto.jobmaster.JobMasterAPI;
 import edu.iu.dsc.tws.proto.system.job.JobAPI;
+import edu.iu.dsc.tws.rsched.core.SchedulerContext;
 import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesConstants;
 import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesContext;
 import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesUtils;
@@ -219,6 +223,30 @@ public final class K8sWorkerUtils {
       throw new RuntimeException("Cannot get Job master IP from service name.", e);
     }
   }
+
+  /**
+   * generate the additional requested ports for this worker
+   * @param config
+   * @param workerPort
+   * @return
+   */
+  public static Map<String, Integer> generateAdditionalPorts(Config config, int workerPort) {
+
+    // if no port is requested, return null
+    List<String> portNames = SchedulerContext.workerAdditionalPorts(config);
+    if (portNames == null) {
+      return null;
+    }
+
+    HashMap<String, Integer> ports = new HashMap<>();
+    int i = 1;
+    for (String portName: portNames) {
+      ports.put(portName, workerPort + i++);
+    }
+
+    return ports;
+  }
+
 
 
   /**


### PR DESCRIPTION
Additional worker ports implemented:
Users can specify the port names in client.yaml as: 
worker.additional.ports: ["port1", "port2", "port3"]

A map is added to WorkerInfo proto. Users can get the port map from WorkerInfo object by calling the method: getAdditionalPortMap()

If the user does not specify any additional ports, only a single port is assigned to each worker. 