### PR TITLE
job master sends KILLED message to dashboard when the job is killed

### DIFF
--- a/twister2/common/src/java/edu/iu/dsc/tws/common/worker/IWorkerMessenger.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/worker/IWorkerMessenger.java
@@ -14,7 +14,7 @@ package edu.iu.dsc.tws.common.worker;
 import com.google.protobuf.Message;
 
 /**
- * A messenger interface to send messages from the driver to the workers in a job
+ * A messenger interface to send messages from a worker to the driver in a job
  */
 public interface IWorkerMessenger {
 

--- a/twister2/config/src/yaml/conf/kubernetes/system.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/system.yaml
@@ -89,4 +89,4 @@ twister2.worker.controller.max.wait.time.on.barrier: 100000
 
 # Dashboard server host address and port
 # if this parameter is not specified, then job master will not try to connect to Dashboard
-# twister2.dashboard.host: "http://localhost:8080"
+twister2.dashboard.host: "http://149.165.150.81:8080"

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/dashclient/models/JobState.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/dashclient/models/JobState.java
@@ -28,5 +28,5 @@ package edu.iu.dsc.tws.master.dashclient.models;
  */
 
 public enum JobState {
-  STARTING, STARTED, COMPLETED, FAILED
+  STARTING, STARTED, COMPLETED, FAILED, KILLED
 }

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/server/JobMaster.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/server/JobMaster.java
@@ -114,7 +114,7 @@ public class JobMaster {
    * a flag to show that whether the job is done
    * when it is converted to true, the job master exits
    */
-  private boolean workersCompleted = false;
+  private boolean jobCompleted = false;
 
   /**
    * Job Terminator object.
@@ -156,6 +156,21 @@ public class JobMaster {
    */
   private BarrierMonitor barrierMonitor;
 
+  /**
+   * a variable that shows whether JobMaster will run jobTerminate
+   * when it is killed with a shutdown hook
+   */
+  private boolean clearResourcesWhenKilled;
+
+  /**
+   * JobMaster constructor
+   * @param config
+   * @param masterAddress
+   * @param port
+   * @param jobTerminator
+   * @param job
+   * @param nodeInfo
+   */
   public JobMaster(Config config,
                    String masterAddress,
                    int port,
@@ -315,7 +330,7 @@ public class JobMaster {
     LOG.info("JobMaster [" + masterAddress + "] started and waiting worker messages on port: "
         + masterPort);
 
-    while (!workersCompleted) {
+    while (!jobCompleted) {
       looper.loopBlocking();
     }
 
@@ -335,17 +350,19 @@ public class JobMaster {
   }
 
   /**
-   * this method is executed when the worker completed message received from all workers
+   * this method finishes the job
+   * It is executed when the worker completed message received from all workers or
+   * When JobMaster is killed with shutdown hook
    */
-  public void allWorkersCompleted() {
+  public void completeJob() {
 
-    // if Dashboard is used, tell it that the job has completed
+    // if Dashboard is used, tell it that the job has completed or killed
     if (dashClient != null) {
       dashClient.jobStateChange(JobState.COMPLETED);
     }
 
     LOG.info("All " + numberOfWorkers + " workers have completed. JobMaster is stopping.");
-    workersCompleted = true;
+    jobCompleted = true;
     looper.wakeup();
 
     if (jobTerminator != null) {
@@ -353,10 +370,37 @@ public class JobMaster {
     }
   }
 
-  public void addShutdownHook() {
+  /**
+   * when JobMaster is killed, it can either terminate the job and clear all job resources
+   * or just lets the Dashboard know that it is killed
+   *
+   * when it runs in the client, it should be set as true
+   * when it runs in the cluster, it should usually be set as false
+   * because, probably a job terminator is called and it cleared the resources
+   * @param clearJobResourcesWhenKilled
+   */
+  public void addShutdownHook(boolean clearJobResourcesWhenKilled) {
+    this.clearResourcesWhenKilled = clearJobResourcesWhenKilled;
+
     Thread hookThread = new Thread() {
       public void run() {
-        allWorkersCompleted();
+
+        // if Dashboard is used, tell it that the job is killed
+        if (dashClient != null) {
+          // TODO: this will be changed with KILLED
+//          dashClient.jobStateChange(JobState.KILLED);
+          dashClient.jobStateChange(JobState.COMPLETED);
+        }
+
+        if (JobMaster.this.clearResourcesWhenKilled) {
+          jobCompleted = true;
+          looper.wakeup();
+
+          if (jobTerminator != null) {
+            jobTerminator.terminateJob(job.getJobName());
+          }
+        }
+
       }
     };
 

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/server/WorkerMonitor.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/server/WorkerMonitor.java
@@ -230,7 +230,7 @@ public class WorkerMonitor implements MessageHandler {
       // if so, stop the job master
       // if all workers have completed, no need to send the response message back to the client
       if (haveAllWorkersCompleted()) {
-        jobMaster.allWorkersCompleted();
+        jobMaster.completeJob();
       }
 
       return;

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesLauncher.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesLauncher.java
@@ -246,7 +246,7 @@ public class KubernetesLauncher implements ILauncher, IJobTerminator {
 
     JobMasterAPI.NodeInfo nodeInfo = NodeInfoUtils.createNodeInfo(hostAdress, null, null);
     JobMaster jobMaster = new JobMaster(config, hostAdress, this, job, nodeInfo);
-    jobMaster.addShutdownHook();
+    jobMaster.addShutdownHook(true);
     jobMaster.startJobMasterThreaded();
 //    jobMaster.startJobMasterBlocking();
 

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/master/JobMasterStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/master/JobMasterStarter.java
@@ -78,6 +78,7 @@ public final class JobMasterStarter {
 
     // start JobMaster
     JobMaster jobMaster = new JobMaster(config, podIP, jobTerminator, job, nodeInfo);
+    jobMaster.addShutdownHook(false);
     jobMaster.startJobMasterBlocking();
   }
 

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/nomad/NomadLauncher.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/nomad/NomadLauncher.java
@@ -101,7 +101,7 @@ public class NomadLauncher implements ILauncher {
         JobMasterAPI.NodeInfo jobMasterNodeInfo = null;
         jobMaster =
             new JobMaster(config, hostAddress, new NomadTerminator(), job, jobMasterNodeInfo);
-        jobMaster.addShutdownHook();
+        jobMaster.addShutdownHook(true);
         jmThread = jobMaster.startJobMasterThreaded();
       } catch (UnknownHostException e) {
         LOG.log(Level.SEVERE, "Exception when getting local host address: ", e);

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPILauncher.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPILauncher.java
@@ -210,7 +210,7 @@ public class MPILauncher implements ILauncher {
             "default", "default");
         jobMaster =
             new JobMaster(config, hostAddress, port, new NomadTerminator(), job, jobMasterNodeInfo);
-        jobMaster.addShutdownHook();
+        jobMaster.addShutdownHook(true);
         jmThread = jobMaster.startJobMasterThreaded();
       } catch (UnknownHostException e) {
         LOG.log(Level.SEVERE, "Exception when getting local host address: ", e);

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPIWorker.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPIWorker.java
@@ -365,7 +365,7 @@ public final class MPIWorker {
       JobMasterAPI.NodeInfo jobMasterNodeInfo = null;
       JobMaster jobMaster =
           new JobMaster(cfg, hostAddress, port, new NomadTerminator(), job, jobMasterNodeInfo);
-      jobMaster.addShutdownHook();
+      jobMaster.addShutdownHook(false);
       Thread jmThread = jobMaster.startJobMasterThreaded();
 
       try {


### PR DESCRIPTION
When a job does not complete successfully but rather killed forcefully with twister2 kill command, we need to tell Dashboard that the job has been killed. 

The shutdown hook on JobMaster needs to be called when it is started as a separate entity in the cluster. 
Then, it will tell dashboard when it is killed that the job is killed. 

I will update the call to jobStateChange method in shutdownHook method when KILLED added to dashboard. Now, it is just sending COMPLETED message. 