### PR TITLE
killedWorker list sent in scale down message

### DIFF
--- a/twister2/master/src/java/edu/iu/dsc/tws/master/dashclient/DashboardClient.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/dashclient/DashboardClient.java
@@ -11,7 +11,6 @@
 //  limitations under the License.
 package edu.iu.dsc.tws.master.dashclient;
 
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -117,9 +116,9 @@ public class DashboardClient {
    * if it is higher, it means some instances of that resource added
    * @return
    */
-  public boolean scaledWorkers(int change, int numberOfWorkers, List<Integer> killedWorkers) {
+  public boolean scaledWorkers(int change, int numberOfWorkers) {
 
-    ScaledWorkers scaledWorkers = new ScaledWorkers(change, numberOfWorkers, killedWorkers);
+    ScaledWorkers scaledWorkers = new ScaledWorkers(change, numberOfWorkers);
 
     String path = "jobs/" + jobID + "/scale/";
 

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/dashclient/DashboardClient.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/dashclient/DashboardClient.java
@@ -11,6 +11,7 @@
 //  limitations under the License.
 package edu.iu.dsc.tws.master.dashclient;
 
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -116,9 +117,9 @@ public class DashboardClient {
    * if it is higher, it means some instances of that resource added
    * @return
    */
-  public boolean scaledWorkers(int change, int numberOfWorkers) {
+  public boolean scaledWorkers(int change, int numberOfWorkers, List<Integer> killedWorkers) {
 
-    ScaledWorkers scaledWorkers = new ScaledWorkers(change, numberOfWorkers);
+    ScaledWorkers scaledWorkers = new ScaledWorkers(change, numberOfWorkers, killedWorkers);
 
     String path = "jobs/" + jobID + "/scale/";
 

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/dashclient/messages/ScaledWorkers.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/dashclient/messages/ScaledWorkers.java
@@ -11,9 +11,13 @@
 //  limitations under the License.
 package edu.iu.dsc.tws.master.dashclient.messages;
 
+import java.util.LinkedList;
 import java.util.List;
+import java.util.logging.Logger;
 
 public class ScaledWorkers {
+  private static final Logger LOG = Logger.getLogger(ScaledWorkers.class.getName());
+
   private int change;
   private int numberOfWorkers;
   private List<Integer> killedWorkers;
@@ -21,10 +25,17 @@ public class ScaledWorkers {
   public ScaledWorkers() {
   }
 
-  public ScaledWorkers(int change, int numberOfWorkers, List<Integer> killedWorkers) {
+  public ScaledWorkers(int change, int numberOfWorkers) {
     this.change = change;
     this.numberOfWorkers = numberOfWorkers;
-    this.killedWorkers = killedWorkers;
+
+    killedWorkers = new LinkedList<>();
+    if (change < 0) {
+      for (int i = 0; i < (0 - change); i++) {
+        killedWorkers.add(numberOfWorkers + i);
+      }
+      LOG.info("killedWorkers: " + killedWorkers);
+    }
   }
 
   public void setChange(int change) {
@@ -35,11 +46,19 @@ public class ScaledWorkers {
     return change;
   }
 
+  public List<Integer> getKilledWorkers() {
+    return killedWorkers;
+  }
+
   public int getNumberOfWorkers() {
     return numberOfWorkers;
   }
 
   public void setNumberOfWorkers(int numberOfWorkers) {
     this.numberOfWorkers = numberOfWorkers;
+  }
+
+  public void setKilledWorkers(List<Integer> killedWorkers) {
+    this.killedWorkers = killedWorkers;
   }
 }

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/dashclient/messages/ScaledWorkers.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/dashclient/messages/ScaledWorkers.java
@@ -11,7 +11,6 @@
 //  limitations under the License.
 package edu.iu.dsc.tws.master.dashclient.messages;
 
-import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -25,17 +24,10 @@ public class ScaledWorkers {
   public ScaledWorkers() {
   }
 
-  public ScaledWorkers(int change, int numberOfWorkers) {
+  public ScaledWorkers(int change, int numberOfWorkers, List<Integer> killedWorkers) {
     this.change = change;
     this.numberOfWorkers = numberOfWorkers;
-
-    killedWorkers = new LinkedList<>();
-    if (change < 0) {
-      for (int i = 0; i < (0 - change); i++) {
-        killedWorkers.add(numberOfWorkers + i);
-      }
-      LOG.info("killedWorkers: " + killedWorkers);
-    }
+    this.killedWorkers = killedWorkers;
   }
 
   public void setChange(int change) {

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/server/JobMaster.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/server/JobMaster.java
@@ -388,12 +388,23 @@ public class JobMaster {
   }
 
   /**
-   * when JobMaster is killed, it can either terminate the job and clear all job resources
-   * or just lets the Dashboard know that it is killed
+   * A job can be terminated in two ways:
+   *   a) successful completion: all workers complete their work and send a COMPLETED message
+   *      to the Job Master. Job master clears all job resources from the cluster and
+   *      informs Dashboard. This is handled in the method: completeJob()
+   *   b) forced killing: user chooses to terminate the job explicitly by executing job kill command
+   *      not all workers successfully complete in this case.
+   *      JobMaster does not get COMPLETED message from all workers.
+   *      So completeJob() method is not called.
+   *      Instead, the JobMaster pod or the JobMaster process in the submitting is deleted.
+   *      ShutDown Hook gets executed.
    *
-   * when it runs in the client, it should be set as true
-   * when it runs in the cluster, it should usually be set as false
-   * because, probably a job terminator is called and it cleared the resources
+   *      In this case, it can either clear job resources or just send a message to Dashboard
+   *      based on the parameter that is provided when the shut down hook is registered.
+   *      If the job master runs in the client, it should clear resources.
+   *      when the job master runs in the cluster, it should not clear resources.
+   *      The resources should be cleared by the job killing process.
+   *
    * @param clearJobResourcesWhenKilled
    */
   public void addShutdownHook(boolean clearJobResourcesWhenKilled) {

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/server/WorkerMonitor.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/server/WorkerMonitor.java
@@ -23,11 +23,8 @@
 //  limitations under the License.
 package edu.iu.dsc.tws.master.server;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.NavigableSet;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -295,14 +292,6 @@ public class WorkerMonitor implements MessageHandler {
     rrServer.sendResponse(id, scaledResponse);
     LOG.fine("ScaledResponse sent to the driver: \n" + scaledResponse);
 
-    List<Integer> killedWorkers = new ArrayList<>();
-    if (scaledMessage.getChange() < 0) {
-      NavigableSet<Integer> descKeySet = workers.descendingKeySet();
-      for (int i = scaledMessage.getChange(); i < 0; i++) {
-        killedWorkers.add(descKeySet.pollFirst());
-      }
-    }
-
     // let all workers know about the scaled message
     // TODO: how about newly added workers,
     // should we make sure that those workers also get this message
@@ -318,8 +307,7 @@ public class WorkerMonitor implements MessageHandler {
 
     // send Scale message to the dashboard
     if (dashClient != null) {
-      dashClient.scaledWorkers(scaledMessage.getChange(),
-          scaledMessage.getNumberOfWorkers(), killedWorkers);
+      dashClient.scaledWorkers(scaledMessage.getChange(), scaledMessage.getNumberOfWorkers());
     }
 
   }


### PR DESCRIPTION
Modifications done on Job Master side code for scale down message: 
* Removed worker IDs are generated by calculation based on scaled down message.
* Removed workers are removed from workers list in WorkerMonitor.  
* Job Master shut down hook documentation explained more clearly
