### PR TITLE
changing temp directory to save the job package in the client

### DIFF
--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/ResourceAllocator.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/ResourceAllocator.java
@@ -126,25 +126,20 @@ public class ResourceAllocator {
    * Create the job files to be uploaded into the cluster
    */
   private String prepareJobFiles(Config config, JobAPI.Job job) {
-    // lets first save the job file
-    // lets write the job into file, this will be used for job creation
-    String tempDirectory = SchedulerContext.jobClientTempDirectory(config) + "/" + job.getJobName();
-    try {
-      Files.createDirectories(Paths.get(tempDirectory));
-    } catch (IOException e) {
-      throw new RuntimeException("Failed to create the base temp directory for job", e);
-    }
 
     String jobJarFile = SchedulerContext.userJobJarFile(config);
     if (jobJarFile == null) {
       throw new RuntimeException("Job file cannot be null");
     }
 
+    // create a temp directory to save the job package
     Path tempDirPath = null;
+    String tempDirPrefix = "twister2-" + job.getJobName() + "-";
     try {
-      tempDirPath = Files.createTempDirectory(Paths.get(tempDirectory), job.getJobName());
+      tempDirPath = Files.createTempDirectory(tempDirPrefix);
     } catch (IOException e) {
-      throw new RuntimeException("Failed to create temp directory: " + tempDirectory, e);
+      throw new RuntimeException("Failed to create temp directory with the prefix: "
+          + tempDirPrefix, e);
     }
 
     // temp directory to put archive files
@@ -159,7 +154,7 @@ public class ResourceAllocator {
     } else {
       String twister2CorePackage = SchedulerContext.systemPackageUrl(config);
       if (twister2CorePackage == null) {
-        throw new RuntimeException("Core package is not specified in the confiuration");
+        throw new RuntimeException("Core package is not specified in the configuration");
       }
       LOG.log(Level.INFO, String.format("Copy core package: %s to %s",
           twister2CorePackage, tempDirPathString));

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/SchedulerContext.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/SchedulerContext.java
@@ -33,9 +33,6 @@ public class SchedulerContext extends Context {
   // Internal configuration for job package url
   public static final String JOB_PACKAGE_URI = "twister2.job.package.uri";
 
-  // Temp directory where the files are placed before packing them for upload
-  public static final String JOB_TEMP_DIR = "twister2.client.job.temp.dir";
-
   public static final String WORKER_COMPUTE_RESOURCES = "worker.compute.resources";
 
   /**
@@ -113,10 +110,6 @@ public class SchedulerContext extends Context {
 
   public static String jobPackageFileName(Config cfg) {
     return cfg.getStringValue(JOB_PACKAGE_FILENAME, JOB_PACKAGE_FILENAME_DEFAULT);
-  }
-
-  public static String jobClientTempDirectory(Config cfg) {
-    return cfg.getStringValue(JOB_TEMP_DIR, "/tmp");
   }
 
   public static String userJobJarFile(Config cfg) {


### PR DESCRIPTION
Currently we are creating the temporary directory as:
/tmp/<job-name>/<job-name>numerical-extension

If there multiple users on the same machine, and if the second user submits a job with the same name, then an exception is thrown. For example, let's assume user1 submits "hello-world-job". Following directory created: /tmp/hello-world-job/hello-world-job8912878721871287

Then, user2 tries to submit "hello-world-job", then an exception is thrown, since it can not write to the directory /tmp/hello-world-job. 

One way to fix this problem would be to make that directory writable by all users. I instead create the temp directory in the main temp folder. I also added "twister2" as a prefix to the folder. 
So new temporary directory will be something like: 
/tmp/twister2-hello-world-job-128923787632

I also removed hard coded "/tmp" directory. Instead, java will create this directory in the system default temp directory. Temp directory changes from OS to OS. So, this should be more resilient. 
