### PR TITLE
Adding isScalable to IScaler

### DIFF
--- a/twister2/common/src/java/edu/iu/dsc/tws/common/driver/IScaler.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/driver/IScaler.java
@@ -18,6 +18,12 @@ package edu.iu.dsc.tws.common.driver;
 public interface IScaler {
 
   /**
+   * whether this job is scalable
+   * @return true if scalable
+   */
+  boolean isScalable();
+
+  /**
    * add new instances of workers to the job
    * @param instancesToAdd
    * @return true if successful

--- a/twister2/config/src/yaml/conf/kubernetes/network.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/network.yaml
@@ -1,9 +1,12 @@
-#twister2.network.channel.class: "edu.iu.dsc.tws.comms.dfw.mpi.TWSMPIChannel"
-twister2.network.channel.class: "edu.iu.dsc.tws.comms.dfw.tcp.TWSTCPChannel"
-
 #############################################################################
 # OpenMPI settings
 #############################################################################
+# If the channel is set as TWSMPIChannel,
+# the job is started as OpenMPI job
+# Otherwise, it is a regular twister2 job. OpenMPI is not started in this case.
+
+# twister2.network.channel.class: "edu.iu.dsc.tws.comms.dfw.mpi.TWSMPIChannel"
+twister2.network.channel.class: "edu.iu.dsc.tws.comms.dfw.tcp.TWSTCPChannel"
 
 # A Secret object must be present in Kubernetes master
 # Its name must be specified here

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/DefaultScalar.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/DefaultScalar.java
@@ -14,6 +14,12 @@ package edu.iu.dsc.tws.rsched.schedulers;
 import edu.iu.dsc.tws.common.driver.IScaler;
 
 public class DefaultScalar implements IScaler {
+
+  @Override
+  public boolean isScalable() {
+    return false;
+  }
+
   @Override
   public boolean scaleUpWorkers(int instancesToAdd) {
     return false;

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/master/JobMasterStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/master/JobMasterStarter.java
@@ -44,6 +44,7 @@ public final class JobMasterStarter {
 
     String configDir = KubernetesConstants.CONFIG_MAP_VOLUME_MOUNT;
     Config config = K8sWorkerUtils.loadConfig(configDir);
+    config = K8sWorkerUtils.unsetWorkerIDAssigment(config);
 
     // read job description file
     String jobDescFileName = SchedulerContext.createJobDescriptionFileName(jobName);

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/mpi/MPIWorkerStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/mpi/MPIWorkerStarter.java
@@ -116,6 +116,7 @@ public final class MPIWorkerStarter {
     // job file configurations will override
     config = JobUtils.overrideConfigs(job, config);
     config = JobUtils.updateConfigs(job, config);
+    config = K8sWorkerUtils.unsetWorkerIDAssigment(config);
 
     InetAddress localHost = null;
     String podName = null;

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerStarter.java
@@ -86,6 +86,7 @@ public final class K8sWorkerStarter {
     // job file configurations will override
     config = JobUtils.overrideConfigs(job, config);
     config = JobUtils.updateConfigs(job, config);
+    config = K8sWorkerUtils.unsetWorkerIDAssigment(config);
 
     // get podIP from localhost
     InetAddress localHost = null;


### PR DESCRIPTION
Two things are implemented: 
* isScalable method added to IScaler interface. I checked this method and return false for openMPI jobs. They are non scalable. 
* I disabled worker ID assignment by Job Master in Kubernetes. Since, scaling down jobs does not work with JobMaster workerID assignment. 

Note: I think, it is ready to be merged. 