### PR TITLE
Ahmet/updating k8s dockerfile

### DIFF
--- a/docker/kubernetes/image/Dockerfile
+++ b/docker/kubernetes/image/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
   apt-get install -y --no-install-recommends oracle-java8-installer oracle-java8-set-default && \
   apt-get clean all
 
-ARG OPENMPI_VERSION="3.0.0"
+ARG OPENMPI_VERSION="3.1.2"
 ARG WITH_CUDA="false"
 
 # install ssh and basic dependencies
@@ -76,8 +76,8 @@ VOLUME $HOME
 
 ENV CLASSPATH="/twister2/lib/*"
 
-COPY image/rootfs /
-COPY lib/ /twister2/lib/
+COPY docker/kubernetes/image/rootfs /
+COPY bazel-bin/scripts/package/twister2-0.1.0/lib/ /twister2/lib/
 
 # check if open mpi was successfully built with cuda support.
 RUN if [ "$WITH_CUDA" = "true" ]; then \

--- a/docker/kubernetes/image/Dockerfile
+++ b/docker/kubernetes/image/Dockerfile
@@ -77,7 +77,8 @@ VOLUME $HOME
 ENV CLASSPATH="/twister2/lib/*"
 
 COPY docker/kubernetes/image/rootfs /
-COPY bazel-bin/scripts/package/twister2-0.1.0/lib/ /twister2/lib/
+COPY twister2-0.1.0/lib /twister2/lib
+COPY twister2-0.1.0/bin /twister2/bin
 
 # check if open mpi was successfully built with cuda support.
 RUN if [ "$WITH_CUDA" = "true" ]; then \

--- a/docker/kubernetes/readme.md
+++ b/docker/kubernetes/readme.md
@@ -1,0 +1,27 @@
+## Building Docker Image for Kubernetes
+
+First build Twister2 project. 
+
+This will generate the twister2 package file: 
+
+bazel-bin/scripts/package/twister2-0.1.0.tar.gz
+
+While on twister2 main directory, unpack this tar file:
+
+```bash
+$ tar xf bazel-bin/scripts/package/twister2-0.1.0.tar.gz
+```
+
+This will extract the files under twister2-0.1.0 directory. 
+
+Build Docker image by running the following command from twister2 main directory. 
+Update username with your user name. 
+
+```bash
+$ docker build -t username/twister2-k8s:0.1.0 -f docker/kubernetes/image/Dockerfile .
+```
+
+Push generated Docker image to Docker Hub
+```bash
+$ docker push username/twister2-k8s:0.1.0
+```


### PR DESCRIPTION
I updated openMPI version in Kubernetes Docker Image from 3.0.0 to 3.1.2. 
I simplified Docker image generation. Now, Docker image can be generated from twister2 main directory. 
I added a readme.md file to explain docker image generation with example commands. 

I tested it. It seems working. I think it is ready to be merged. 