### PR TITLE
fixing broadcast streaming and batch verification issue in task examples

### DIFF
--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/task/BenchTaskWorker.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/task/BenchTaskWorker.java
@@ -45,6 +45,8 @@ public abstract class BenchTaskWorker extends TaskWorker {
 
   protected static JobParameters jobParameters;
 
+  protected static Object inputData;
+
   @Override
   public void execute() {
     experimentData = new ExperimentData();
@@ -62,6 +64,8 @@ public abstract class BenchTaskWorker extends TaskWorker {
       experimentData.setOperationMode(OperationMode.BATCH);
       experimentData.setIterations(jobParameters.getIterations());
     }
+    inputData = generateData();
+    experimentData.setInput(inputData);
     buildTaskGraph();
     dataFlowTaskGraph = taskGraphBuilder.build();
     executionPlan = taskExecutor.plan(dataFlowTaskGraph);
@@ -85,7 +89,7 @@ public abstract class BenchTaskWorker extends TaskWorker {
 
     @Override
     public void execute() {
-      Object val = generateData();
+      Object val = inputData;
       int iterations = jobParameters.getIterations();
       while (count <= iterations) {
         if (count == iterations) {
@@ -117,7 +121,7 @@ public abstract class BenchTaskWorker extends TaskWorker {
 
     @Override
     public void execute() {
-      Object val = generateData();
+      Object val = inputData;
       int iterations = jobParameters.getIterations();
       while (count <= iterations) {
         if (count == iterations) {
@@ -148,7 +152,7 @@ public abstract class BenchTaskWorker extends TaskWorker {
 
     @Override
     public void execute() {
-      Object val = generateData();
+      Object val = inputData;
       experimentData.setInput(val);
       int iterations = jobParameters.getIterations();
       while (count <= iterations) {
@@ -176,10 +180,9 @@ public abstract class BenchTaskWorker extends TaskWorker {
 
     @Override
     public void execute() {
-      Object val = generateData();
+      Object val = inputData;
       int iterations = jobParameters.getIterations();
       while (count <= iterations) {
-        experimentData.setInput(val);
         if (context.write(edge, count, val)) {
           //
         }

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/task/batch/BTBroadCastExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/task/batch/BTBroadCastExample.java
@@ -49,21 +49,21 @@ public class BTBroadCastExample extends BenchTaskWorker {
     @Override
     public boolean execute(IMessage message) {
       count++;
-      if (count % jobParameters.getPrintInterval() == 0) {
-        Object object = message.getContent();
-        if (object instanceof Iterator) {
-          while (((Iterator) object).hasNext()) {
-            experimentData.setOutput(((Iterator) object).next());
-            LOG.log(Level.INFO, String.format("Received messages to %d: %d",
-                context.taskId(), count));
-            try {
-              verify(OperationNames.BROADCAST);
-            } catch (VerificationException e) {
-              LOG.info("Exception Message : " + e.getMessage());
-            }
+      //  if (count % jobParameters.getPrintInterval() == 0) {
+      Object object = message.getContent();
+      if (object instanceof Iterator) {
+        while (((Iterator) object).hasNext()) {
+          experimentData.setOutput(((Iterator) object).next());
+          LOG.log(Level.INFO, String.format("Received messages to %d: %d",
+              context.taskId(), count));
+          try {
+            verify(OperationNames.BROADCAST);
+          } catch (VerificationException e) {
+            LOG.info("Exception Message : " + e.getMessage());
           }
         }
       }
+      // }
       return true;
     }
   }

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/verification/ExperimentVerification.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/verification/ExperimentVerification.java
@@ -463,9 +463,9 @@ public class ExperimentVerification implements IVerification {
             String msg = String.format("Expected Result : %s Generated Result : %s",
                 resString, outputRes);
             if (isVerified) {
-              LOG.severe(msg);
-            } else {
               LOG.info(msg);
+            } else {
+              LOG.severe("Results Not Verified : " + msg);
               throw new VerificationException(msg);
             }
           }


### PR DESCRIPTION
the input experiment data was done at the execute method in the BenchTaskWorker. 