### PR TITLE
Ahmet/bug fix or improvement

### DIFF
--- a/twister2/config/src/yaml/conf/kubernetes/client.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/client.yaml
@@ -11,20 +11,20 @@ twister2.job.name: "t2-job"
 # workersPerPod shows the number of workers on each pod in Kubernetes.
 #    May be omitted in other clusters. default value is 1.
 worker.compute.resources:
-- cpu: 0.4  # number of cores for each worker, may be fractional such as 0.5 or 2.4
+- cpu: 0.2  # number of cores for each worker, may be fractional such as 0.5 or 2.4
   ram: 1024 # ram for each worker as Mega bytes
   disk: 1.0 # volatile disk for each worker as Giga bytes
-  instances: 2 # number of compute resource instances with this specification
-  scalable: false # only one ComputeResource can be scalable in a job
+  instances: 8 # number of compute resource instances with this specification
+  scalable: true # only one ComputeResource can be scalable in a job
   workersPerPod: 1 # number of workers on each pod in Kubernetes. May be omitted in other clusters.
                    # number of workers using this compute resource: instances * workersPerPod
 
-- cpu: 0.5  # number of cores for each worker, may be fractional such as 0.5 or 2.4
-  ram: 1024 # ram for each worker as Mega bytes
-  disk: 1.0 # volatile disk for each worker as Giga bytes
-  instances: 2 # number of compute resource instances with this specification
-  scalable: true # only one ComputeResource can be scalable in a job
-  workersPerPod: 1 # number of workers on each pod in Kubernetes. May be omitted in other clusters.
+#- cpu: 0.5  # number of cores for each worker, may be fractional such as 0.5 or 2.4
+#  ram: 1024 # ram for each worker as Mega bytes
+#  disk: 1.0 # volatile disk for each worker as Giga bytes
+#  instances: 2 # number of compute resource instances with this specification
+#  scalable: false # only one ComputeResource can be scalable in a job
+#  workersPerPod: 1 # number of workers on each pod in Kubernetes. May be omitted in other clusters.
 
 # driver class to run
 twister2.job.driver.class: "edu.iu.dsc.tws.examples.internal.rsched.DriverExample"

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/server/JobMaster.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/server/JobMaster.java
@@ -128,11 +128,6 @@ public class JobMaster {
   private IJobTerminator jobTerminator;
 
   /**
-   * Number of workers expected
-   */
-  private int numberOfWorkers;
-
-  /**
    * NodeInfo object for Job Master
    * location of Job Master
    */
@@ -202,8 +197,6 @@ public class JobMaster {
     this.masterPort = port;
     this.clusterScaler = clusterScaler;
 
-    this.numberOfWorkers = job.getNumberOfWorkers();
-
     this.jobID = UUID.randomUUID().toString();
     this.dashboardHost = JobMasterContext.dashboardHost(config);
     if (dashboardHost == null) {
@@ -262,7 +255,7 @@ public class JobMaster {
     workerMonitor = new WorkerMonitor(this, rrServer, dashClient, job, driver,
         JobMasterContext.jobMasterAssignsWorkerIDs(config));
 
-    barrierMonitor = new BarrierMonitor(numberOfWorkers, rrServer);
+    barrierMonitor = new BarrierMonitor(workerMonitor, rrServer);
 
     JobMasterAPI.Ping.Builder pingBuilder = JobMasterAPI.Ping.newBuilder();
 
@@ -436,7 +429,8 @@ public class JobMaster {
       dashClient.jobStateChange(JobState.COMPLETED);
     }
 
-    LOG.info("All " + numberOfWorkers + " workers have completed. JobMaster is stopping.");
+    LOG.info("All " + workerMonitor.getNumberOfWorkers()
+        + " workers have completed. JobMaster is stopping.");
     jobCompleted = true;
     looper.wakeup();
 

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/server/WorkerMonitor.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/server/WorkerMonitor.java
@@ -58,12 +58,18 @@ public class WorkerMonitor implements MessageHandler {
   private DashboardClient dashClient;
   private IDriver driver;
 
+  /**
+   * numberOfWorkers in the job is tracked by this variable
+   * all other classes in job master should get the upto-date numberOfWorkers from this variable
+   * if is updated in the case of scale up and down
+   */
+  private int numberOfWorkers;
+
   // this is used to assign next ID to newly registering worker,
   // when job master assigns workerIDs
   private int nextWorkerID = 0;
 
   private boolean jobMasterAssignsWorkerIDs;
-  private int numberOfWorkers;
 
   private TreeMap<Integer, WorkerWithState> workers;
   private HashMap<Integer, RequestID> waitList;
@@ -80,6 +86,10 @@ public class WorkerMonitor implements MessageHandler {
 
     workers = new TreeMap<>();
     waitList = new HashMap<>();
+  }
+
+  public int getNumberOfWorkers() {
+    return numberOfWorkers;
   }
 
   /**

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesUtils.java
@@ -26,7 +26,7 @@ public final class KubernetesUtils {
   private static final Logger LOG = Logger.getLogger(KubernetesUtils.class.getName());
 
   // max length for the user provided Twister2 job name
-  private static final int MAX_JOB_NAME_LENGTH = 50;
+  private static final int MAX_JOB_NAME_LENGTH = 45;
 
   private KubernetesUtils() {
   }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/uploader/UploaderForJob.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/uploader/UploaderForJob.java
@@ -55,7 +55,7 @@ import io.kubernetes.client.util.Watch;
 public class UploaderForJob extends Thread {
   private static final Logger LOG = Logger.getLogger(UploaderForJob.class.getName());
 
-  public static final long MAX_WAIT_TIME_FOR_POD_START = 100 * 1000L; // in seconds
+  public static final long MAX_WAIT_TIME_FOR_POD_START = 300 * 1000L; // in seconds
 
   private CoreV1Api coreApi;
   private ApiClient apiClient;


### PR DESCRIPTION
numberOfWorkers in JobMaster managed from WorkerMonitor only. 
numberOfWorkers variable is deleted from JobMaster and BarrierMonitor classes. 
They get numberOfWorkers from WorkerMonitor when they need it. 

This was necessary since numberOfWorkers is not immutable any more with dynamic scaling. 

A note about using barriers with dynamic scaling:
When the first barrier message is received on the job master, 
BarrierMonitor gets the current numberOfWorkers from WorkerMonitor. 
It expects this many workers to arrive at the barrier. 
If the Driver scales up/down the number of workers during the barrier wait, 
the barrier may not function correctly. Expected number of workers may never arrive at the barrier. 
