### PR TITLE
Ahmet/bug fix or improvement

### DIFF
--- a/twister2/master/src/java/edu/iu/dsc/tws/master/JobMasterContext.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/JobMasterContext.java
@@ -120,4 +120,11 @@ public class JobMasterContext extends Context {
     return cfg.getBooleanValue(JOB_MASTER_USED, true);
   }
 
+  public static Config updateDashboardHost(Config cfg, String dashAddress) {
+    return Config.newBuilder().
+        putAll(cfg).
+        put(DASHBOARD_HOST, dashAddress).
+        build();
+  }
+
 }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesController.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesController.java
@@ -320,6 +320,29 @@ public class KubernetesController {
   }
 
   /**
+   * get the IP address of the given service
+   * otherwise return null
+   */
+  public String getServiceIP(String serviceName) {
+    V1ServiceList serviceList = null;
+    try {
+      serviceList = coreApi.listNamespacedService(namespace,
+          null, null, null, null, null, null, null, null, null);
+    } catch (ApiException e) {
+      LOG.log(Level.SEVERE, "Exception when getting service list.", e);
+      throw new RuntimeException(e);
+    }
+
+    for (V1Service service : serviceList.getItems()) {
+      if (serviceName.equals(service.getMetadata().getName())) {
+        return service.getSpec().getClusterIP();
+      }
+    }
+
+    return null;
+  }
+
+  /**
    * sending a command to shell
    */
   public static boolean runProcess(String[] command) {

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesLauncher.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesLauncher.java
@@ -186,13 +186,15 @@ public class KubernetesLauncher implements ILauncher, IJobTerminator {
    */
   private boolean startJobMasterOnClient(JobAPI.Job job) {
 
-    String hostAdress = null;
-    try {
-      hostAdress = InetAddress.getLocalHost().getHostAddress();
-    } catch (UnknownHostException e) {
-      LOG.log(Level.SEVERE, "Exception when getting local host address: ", e);
-      return false;
-    }
+//    String hostAdress = null;
+//    try {
+//      hostAdress = InetAddress.getLocalHost().getHostAddress();
+//    } catch (UnknownHostException e) {
+//      LOG.log(Level.SEVERE, "Exception when getting local host address: ", e);
+//      return false;
+//    }
+
+    String hostAdress = RequestObjectBuilder.getJobMasterIP();
 
     JobMasterAPI.NodeInfo nodeInfo = NodeInfoUtils.createNodeInfo(hostAdress, null, null);
     K8sScaler k8sScaler = new K8sScaler(config, job, controller);

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/utils/ResourceSchedulerUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/utils/ResourceSchedulerUtils.java
@@ -11,7 +11,13 @@
 //  limitations under the License.
 package edu.iu.dsc.tws.rsched.utils;
 
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
 import java.nio.file.Paths;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public final class ResourceSchedulerUtils {
@@ -73,5 +79,45 @@ public final class ResourceSchedulerUtils {
     }
 
     return true;
+  }
+
+  public static String getHostIP() {
+    String hostIP = ResourceSchedulerUtils.getOutgoingHostIP();
+
+    if (hostIP != null) {
+      return hostIP;
+    }
+
+    // if the host is not connected to Internet, it returns null
+    // get address from localhost
+    try {
+      return InetAddress.getLocalHost().getHostAddress();
+    } catch (UnknownHostException e) {
+      LOG.log(Level.SEVERE, "Exception when getting local host address: ", e);
+      return null;
+    }
+  }
+
+  /**
+   * get the IP address of the host machine
+   * a machine may have multiple IP addresses
+   * we want the IP address that is reachable from outside
+   * we don't want 127.xxx
+   * implementation is based on the suggestion from:
+   * stackoverflow.com/questions/9481865/getting-the-ip-address-of-the-current-machine-using-java
+   *
+   * this only works if the host is connected to outside Internet
+   *
+   * @return hostIP address tha is used to communicate with outside world
+   */
+  public static String getOutgoingHostIP() {
+
+    try (Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress("google.com", 80));
+      return socket.getLocalAddress().getHostAddress();
+    } catch (IOException e) {
+      LOG.log(Level.SEVERE, "Could not connect to google.com to get localHost IP.", e);
+      return null;
+    }
   }
 }


### PR DESCRIPTION
Made two improvements:
1. Submitting client IP discovery added. Ubuntu returns 127.0.1.1 as locolhost in Java. That is not reachable from workers. The outgoing IP address of the submitting client is determined. 
2. Dashboard is not reachable from its service name when Job Master runs in the client in Kubernetes. I queried Kubernetes master for its IP address and used it when Job Master runs in the submitting client. 