### PR TITLE
Executor, if tasks are not assigned return with a warning

### DIFF
--- a/twister2/executor/src/java/edu/iu/dsc/tws/executor/threading/BatchSharingExecutor.java
+++ b/twister2/executor/src/java/edu/iu/dsc/tws/executor/threading/BatchSharingExecutor.java
@@ -40,6 +40,12 @@ public class BatchSharingExecutor extends ThreadSharingExecutor {
   public boolean runExecution() {
     Map<Integer, INodeInstance> nodes = executionPlan.getNodes();
 
+    if (nodes.size() == 0) {
+      LOG.warning(String.format("Worker %d has zero assigned tasks, you may "
+          + "have more workers than tasks", workerId));
+      return true;
+    }
+
     // initialize finished
     // initFinishedInstances();
     tasks = new ArrayBlockingQueue<>(nodes.size() * 2);

--- a/twister2/executor/src/java/edu/iu/dsc/tws/executor/threading/StreamingShareingExecutor.java
+++ b/twister2/executor/src/java/edu/iu/dsc/tws/executor/threading/StreamingShareingExecutor.java
@@ -32,8 +32,8 @@ public class StreamingShareingExecutor extends ThreadSharingExecutor {
     Map<Integer, INodeInstance> nodes = executionPlan.getNodes();
 
     if (nodes.size() == 0) {
-      LOG.log(Level.WARNING,
-          String.format("[%d] We have zero nodes assigned for execution", workerId));
+      LOG.warning(String.format("Worker %d has zero assigned tasks, you may "
+          + "have more workers than tasks", workerId));
       return false;
     }
 


### PR DESCRIPTION
Fixing an issue where there was an exception when tasks are not assigned to a worker