### PR TITLE
Removing an incorrect log at read error

### DIFF
--- a/twister2/common/src/java/edu/iu/dsc/tws/common/net/tcp/BaseNetworkChannel.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/net/tcp/BaseNetworkChannel.java
@@ -208,7 +208,6 @@ public abstract class BaseNetworkChannel {
       return -1;
     }
     if (read < 0) {
-      LOG.log(Level.SEVERE, "channel read returned negative " + read);
       return read;
     } else {
       return remaining - read;

--- a/twister2/common/src/java/edu/iu/dsc/tws/common/net/tcp/Client.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/net/tcp/Client.java
@@ -252,6 +252,8 @@ public class Client implements SelectHandler {
     channel.clear();
     progress.removeAllInterest(ch);
 
+    LOG.log(Level.SEVERE, "Error on channel " + ch);
+
     try {
       ch.close();
     } catch (IOException e) {


### PR DESCRIPTION
The log is incorrect as it gives an incorrect impression that some error occurred, while it only indicates a closed connection