### PR TITLE
 Bug Fixed in inMessage

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -68,6 +68,7 @@
 * [Compatibility API's](compatibility/compatibility.md)  
   * [Apache Storm](compatibility/storm.md)
 * [Releases](release/README.md)  
+  * [Twister2 v0.2.1](release/twister2_release_0_2_1.md)
   * [Twister2 v0.2.0](release/twister2_release_0_2_0.md)
   * [Twister2 v0.1.0](release/twister2_release_0_1_0.md)
 * [Community](community/README.md)

--- a/twister2/comms/src/java/edu/iu/dsc/tws/comms/dfw/InMessage.java
+++ b/twister2/comms/src/java/edu/iu/dsc/tws/comms/dfw/InMessage.java
@@ -287,6 +287,8 @@ public class InMessage {
           keyType, dataType));
     }
     unPkNumberObjects++;
+    this.setUnPkCurrentObjectLength(-1);
+    this.setUnPkCurrentKeyLength(-1);
   }
 
 
@@ -298,6 +300,7 @@ public class InMessage {
       ((List<Object>) deserializedData).add(value);
     }
     unPkNumberObjects++;
+    this.setUnPkCurrentObjectLength(-1);
   }
 
   public void addBuiltMessage(ChannelMessage channelMessage) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/utils/bench/Timing.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/utils/bench/Timing.java
@@ -113,7 +113,8 @@ public final class Timing {
 
     double average = totalDiffs.divide(BigDecimal.valueOf(flagALongs.size()),
         RoundingMode.HALF_UP).doubleValue();
-    System.out.println(String.format("Average time [%s - %s] = %f", flagA, flagB, average));
+    System.out.println(String.format("Average time [%s - %s] = %f%s", flagA, flagB,
+        average, timingUnitMap.get(flagA).getLabel()));
     return average;
   }
 

--- a/util/test/tests/apps/tera_sort/tera_sort.json
+++ b/util/test/tests/apps/tera_sort/tera_sort.json
@@ -101,7 +101,7 @@
       "optional": false,
       "values": {
         "type": "fixed",
-        "value": "999999999"
+        "value": "10000000"
       }
     }
   ]


### PR DESCRIPTION
When an end of a message aligns with the end of the buffer, current message reads the previous message from data builders and consider it as a new message.