### PR TITLE
installed openjdk instead of oracle jdk in kubernetes k8s image

### DIFF
--- a/docker/kubernetes/image/Dockerfile
+++ b/docker/kubernetes/image/Dockerfile
@@ -11,23 +11,21 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
 ##############################################################################
-# Install Java 8.
-# Based on:
-#    https://github.com/dockerfile/java/blob/master/oracle-java8/Dockerfile
-#    https://stackoverflow.com/questions/49914574/install-jdk-8-update-172-in-dockerfile-with-ubuntu-image
-#
+# Install OpenJDK-8
+RUN apt-get update && \
+    apt-get install -y openjdk-8-jdk && \
+    apt-get install -y ant && \
+    apt-get clean;
 
-RUN \
-   apt-get update && \
-   apt-get -y install software-properties-common && \
-   echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
-   add-apt-repository -y ppa:webupd8team/java && \
-   apt-get update && \
-   apt-get install -y oracle-java8-installer && \
-   rm -rf /var/cache/oracle-jdk8-installer
+# Fix certificate issues
+RUN apt-get update && \
+    apt-get install ca-certificates-java && \
+    apt-get clean && \
+    apt-get install -y curl && \
+    update-ca-certificates -f;
 
-# Define JAVA_HOME variable
-ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+# Setup JAVA_HOME -- useful for docker commandline
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 
 ###############################################################################
 # Install SSH and OpenMPI

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/mpi/MPIWorkerStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/mpi/MPIWorkerStarter.java
@@ -126,6 +126,11 @@ public final class MPIWorkerStarter {
 
     String podIP = localHost.getHostAddress();
     podName = localHost.getHostName();
+    // podName may be in the form of: t2-job-0-0.t2-srv-t2-job.default.svc.cluster.local
+    // get up to first dot: t2-job-0-0
+    if (podName.indexOf(".") > 0) {
+      podName = podName.substring(0, podName.indexOf("."));
+    }
 
     int workerPort = KubernetesContext.workerBasePort(config)
         + workerID * (SchedulerContext.numberOfAdditionalPorts(config) + 1);
@@ -142,7 +147,7 @@ public final class MPIWorkerStarter {
           : K8sWorkerUtils.getNodeInfoFromEncodedStr(encodedNodeInfoList, nodeIP);
     }
 
-    LOG.info("NodeInfoUtils for this worker: " + nodeInfo);
+    LOG.info(String.format("PodName: %s, NodeInfo for this worker: %s", podName, nodeInfo));
 
     computeResource = K8sWorkerUtils.getComputeResource(job, podName);
 


### PR DESCRIPTION
installed openjdk instead of oracle jdk in kubernetes k8s image, 
fixed a bug in MPIWorkerStarter