### PR TITLE
Giving an option to copying the twister2-core to job directory

### DIFF
--- a/twister2/api/src/java/edu/iu/dsc/tws/api/scheduler/SchedulerContext.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/scheduler/SchedulerContext.java
@@ -83,6 +83,8 @@ public class SchedulerContext extends Context {
 
   public static final String DOWNLOAD_METHOD = "twister2.resource.uploader.download.method";
 
+  public static final String COPY_SYSTEM_PACKAGE = "twister2.resource.systempackage.copy";
+
   public static String uploaderClass(Config cfg) {
     return cfg.getStringValue(UPLOADER_CLASS);
   }
@@ -153,6 +155,10 @@ public class SchedulerContext extends Context {
 
   public static double persistentVolumePerWorker(Config cfg) {
     return cfg.getDoubleValue(PERSISTENT_VOLUME_PER_WORKER, PERSISTENT_VOLUME_PER_WORKER_DEFAULT);
+  }
+
+  public static boolean copySystemPackage(Config cfg) {
+    return cfg.getBooleanValue(COPY_SYSTEM_PACKAGE, true);
   }
 
   /**

--- a/twister2/comms/src/java/edu/iu/dsc/tws/comms/batch/BJoin.java
+++ b/twister2/comms/src/java/edu/iu/dsc/tws/comms/batch/BJoin.java
@@ -195,6 +195,9 @@ public class BJoin {
     return partitionLeft.progress() | partitionRight.progress();
   }
 
+  /**
+   * Close the operation
+   */
   public void close() {
     partitionLeft.close();
     partitionRight.close();

--- a/twister2/config/src/yaml/conf/common/resource.yaml
+++ b/twister2/config/src/yaml/conf/common/resource.yaml
@@ -1,2 +1,5 @@
 # use this property to debug the client submitting the job
 # twister2.client.debug: '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5006'
+
+# Weather we have a requirement to copy the system package
+twister2.resource.systempackage.copy: false

--- a/twister2/config/src/yaml/conf/standalone/exp.sh
+++ b/twister2/config/src/yaml/conf/standalone/exp.sh
@@ -35,7 +35,7 @@ fi
 # set the lib path to bundled mpi, if that mpirun is used
 lib_path="-Djava.library.path=${LD_LIBRARY_PATH}"
 if [ "$9" = "twister2-core/ompi/bin/mpirun" ]; then
-  lib_path="${lib_path}:twister2-core/ompi/lib"
+  lib_path="${lib_path}:${17}/ompi/lib"
 fi
 
 illegal_access_warn=

--- a/twister2/config/src/yaml/conf/standalone/exp.sh
+++ b/twister2/config/src/yaml/conf/standalone/exp.sh
@@ -34,7 +34,7 @@ fi
 
 # set the lib path to bundled mpi, if that mpirun is used
 lib_path="-Djava.library.path=${LD_LIBRARY_PATH}"
-if [ "$9" = "twister2-core/ompi/bin/mpirun" ]; then
+if [ "$9" = "ompi/bin/mpirun" ]; then
   lib_path="${lib_path}:${17}/ompi/lib"
 fi
 

--- a/twister2/config/src/yaml/conf/standalone/resource.yaml
+++ b/twister2/config/src/yaml/conf/standalone/resource.yaml
@@ -49,6 +49,3 @@ twister2.resource.class.uploader: "edu.iu.dsc.tws.rsched.uploaders.localfs.Local
 # this is the method that workers use to download the core and job packages
 # it could be  HTTP, HDFS, ..
 twister2.resource.uploader.download.method: "HTTP"
-
-## Weather we have a requirement to copy the system package
-twister2.resource.systempackage.copy: false

--- a/twister2/config/src/yaml/conf/standalone/resource.yaml
+++ b/twister2/config/src/yaml/conf/standalone/resource.yaml
@@ -22,7 +22,7 @@ twister2.resource.class.launcher: "edu.iu.dsc.tws.rsched.schedulers.standalone.M
 # mpi run file, this assumes a mpirun that is shipped with the product
 # change this to just mpirun if you are using a system wide installation of OpenMPI
 # or complete path of OpenMPI in case you have something custom
-twister2.resource.scheduler.mpi.mpirun.file: "twister2-core/ompi/bin/mpirun"
+twister2.resource.scheduler.mpi.mpirun.file: "ompi/bin/mpirun"
 
 # mpi scheduling policy. Two possible options are node and slot.
 # read more at https://www.open-mpi.org/faq/?category=running#mpirun-scheduling
@@ -33,7 +33,7 @@ twister2.resource.scheduler.mpi.mapby: "node"
 twister2.resource.scheduler.mpi.mapby.use-pe: false
 
 # Indicates whether bootstrap process needs to be run and distribute job file and core
-# between MPI nodes. Twister2 assumes job file is accessible to all nodes if this property is set
+# between nodes. Twister2 assumes job file is accessible to all nodes if this property is set
 # to true, else it will run the bootstrap process
 twister2.resource.sharedfs: true
 
@@ -50,4 +50,5 @@ twister2.resource.class.uploader: "edu.iu.dsc.tws.rsched.uploaders.localfs.Local
 # it could be  HTTP, HDFS, ..
 twister2.resource.uploader.download.method: "HTTP"
 
-
+## Weather we have a requirement to copy the system package
+twister2.resource.systempackage.copy: false

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/ResourceAllocator.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/ResourceAllocator.java
@@ -170,10 +170,8 @@ public class ResourceAllocator {
 
     // copy the core dist package to temp directory
     // do not copy if its a kubernetes cluster
-    String clusterType = SchedulerContext.clusterType(config);
-    if ("kubernetes".equalsIgnoreCase(clusterType)) {
-      LOG.log(Level.INFO, "This is a kubernetes cluster, not moving twister2 core package to temp");
-
+    if (!SchedulerContext.copySystemPackage(config)) {
+      LOG.log(Level.INFO, "No need to copy the systems package");
     } else {
       String twister2CorePackage = SchedulerContext.systemPackageUrl(config);
       if (twister2CorePackage == null) {

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPILauncher.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPILauncher.java
@@ -265,6 +265,7 @@ public class MPILauncher implements ILauncher {
         jobWorkingDirectory,
         corePackage,
         jobPackageURI,
-        Context.verbose(config));
+        Context.verbose(config),
+        SchedulerContext.copySystemPackage(config));
   }
 }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/StandaloneCommand.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/StandaloneCommand.java
@@ -53,7 +53,11 @@ public class StandaloneCommand extends MPICommand {
     mpiCommand.add(twister2Home);
     mpiCommand.add(twister2Home);
     mpiCommand.add(Paths.get(configDirectoryName, nodesFileName).toString());
-    mpiCommand.add(MPIContext.mpiRunFile(config));
+    if (SchedulerContext.copySystemPackage(config)) {
+      mpiCommand.add(MPIContext.mpiRunFile(config));
+    } else {
+      mpiCommand.add(SchedulerContext.twister2Home(config) + "/" + MPIContext.mpiRunFile(config));
+    }
     mpiCommand.add("-Xmx" + getMemory(job) + "m");
     mpiCommand.add("-Xms" + getMemory(job) + "m");
     mpiCommand.add(config.getIntegerValue("__job_master_port__", 0) + "");
@@ -79,6 +83,14 @@ public class StandaloneCommand extends MPICommand {
     } else {
       mpiCommand.add("allow_illegal_access_warn");
     }
+
+    // we are adding the submitting twister2 home at the end
+    if (SchedulerContext.copySystemPackage(config)) {
+      mpiCommand.add("twister2-core");
+    } else {
+      mpiCommand.add(SchedulerContext.twister2Home(config));
+    }
+
     return mpiCommand;
   }
 

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/StandaloneCommand.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/StandaloneCommand.java
@@ -54,18 +54,14 @@ public class StandaloneCommand extends MPICommand {
     mpiCommand.add(twister2Home);
     mpiCommand.add(Paths.get(configDirectoryName, nodesFileName).toString());
     String mpiRunFile = MPIContext.mpiRunFile(config);
-    if (SchedulerContext.copySystemPackage(config)) {
-      if ("ompi/bin/mpirun".equals(mpiRunFile)) {
+    if ("ompi/bin/mpirun".equals(mpiRunFile)) {
+      if (SchedulerContext.copySystemPackage(config)) {
         mpiCommand.add("twister2-core" + "/" + mpiRunFile);
       } else {
-        mpiCommand.add(mpiRunFile);
+        mpiCommand.add(SchedulerContext.twister2Home(config) + "/" + mpiRunFile);
       }
     } else {
-      if ("ompi/bin/mpirun".equals(mpiRunFile)) {
-        mpiCommand.add(SchedulerContext.twister2Home(config) + "/" + mpiRunFile);
-      } else {
-        mpiCommand.add(mpiRunFile);
-      }
+      mpiCommand.add(mpiRunFile);
     }
     mpiCommand.add("-Xmx" + getMemory(job) + "m");
     mpiCommand.add("-Xms" + getMemory(job) + "m");

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/StandaloneCommand.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/StandaloneCommand.java
@@ -53,10 +53,19 @@ public class StandaloneCommand extends MPICommand {
     mpiCommand.add(twister2Home);
     mpiCommand.add(twister2Home);
     mpiCommand.add(Paths.get(configDirectoryName, nodesFileName).toString());
+    String mpiRunFile = MPIContext.mpiRunFile(config);
     if (SchedulerContext.copySystemPackage(config)) {
-      mpiCommand.add(MPIContext.mpiRunFile(config));
+      if ("ompi/bin/mpirun".equals(mpiRunFile)) {
+        mpiCommand.add("twister2-core" + "/" + mpiRunFile);
+      } else {
+        mpiCommand.add(mpiRunFile);
+      }
     } else {
-      mpiCommand.add(SchedulerContext.twister2Home(config) + "/" + MPIContext.mpiRunFile(config));
+      if ("ompi/bin/mpirun".equals(mpiRunFile)) {
+        mpiCommand.add(SchedulerContext.twister2Home(config) + "/" + mpiRunFile);
+      } else {
+        mpiCommand.add(mpiRunFile);
+      }
     }
     mpiCommand.add("-Xmx" + getMemory(job) + "m");
     mpiCommand.add("-Xms" + getMemory(job) + "m");

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/utils/ResourceSchedulerUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/utils/ResourceSchedulerUtils.java
@@ -32,6 +32,17 @@ public final class ResourceSchedulerUtils {
       String corePackageName,
       String jobPackageURI,
       boolean isVerbose) {
+    return setupWorkingDirectory(jobName, workingDirectory,
+        corePackageName, jobPackageURI, isVerbose, true);
+  }
+
+  public static boolean setupWorkingDirectory(
+      String jobName,
+      String workingDirectory,
+      String corePackageName,
+      String jobPackageURI,
+      boolean isVerbose,
+      boolean copyCore) {
 
     String corePackagePath = Paths.get(jobPackageURI, corePackageName).toString();
     String corePackageDestination = Paths.get(workingDirectory,
@@ -46,7 +57,7 @@ public final class ResourceSchedulerUtils {
           + "uploaded place %s to working directory %s", jobPackageURI, dst));
     }
 
-    if (!extractPackage(
+    if (copyCore && !extractPackage(
         dst, corePackageDestination, true, isVerbose)) {
       LOG.severe(String.format("Failed to extract the core package %s to directory %s",
           corePackagePath, dst));


### PR DESCRIPTION
We are introducing an option to not copy the twister2-core package to the job directory. We can still use the previous mode, but by default, we are not copying, this gives a significant speedup at begining