### PR TITLE
moved jobID generation to Twister2Job

### DIFF
--- a/twister2/api/src/java/edu/iu/dsc/tws/api/Twister2Job.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/Twister2Job.java
@@ -15,6 +15,7 @@ package edu.iu.dsc.tws.api;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.logging.Logger;
 
 import com.google.protobuf.ByteString;
@@ -97,7 +98,13 @@ public final class Twister2Job {
 
     jobBuilder.setConfig(configBuilder);
     jobBuilder.setJobName(jobName);
+
+    // if jobID is not set, set it
+    if (jobID == null) {
+      jobID = String.format("%s-%s", jobName, UUID.randomUUID().toString());
+    }
     jobBuilder.setJobId(jobID);
+
     jobBuilder.setWorkerClassName(workerClass);
 
     // driverClass is optional, set it if specified

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/bootstrap/ZKWControllerExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/bootstrap/ZKWControllerExample.java
@@ -38,7 +38,6 @@ import edu.iu.dsc.tws.proto.system.job.JobAPI;
 import edu.iu.dsc.tws.proto.utils.ComputeResourceUtils;
 import edu.iu.dsc.tws.proto.utils.NodeInfoUtils;
 import edu.iu.dsc.tws.proto.utils.WorkerInfoUtils;
-import edu.iu.dsc.tws.rsched.utils.JobUtils;
 import static java.lang.Thread.sleep;
 
 /**
@@ -290,7 +289,6 @@ public final class ZKWControllerExample {
         .put(ZKContext.SERVER_ADDRESSES, zkAddresses)
         .build();
 
-    config = JobUtils.resolveJobId(config, jobName);
     return config;
   }
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/jobmaster/JobMasterClientExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/jobmaster/JobMasterClientExample.java
@@ -50,7 +50,6 @@ import edu.iu.dsc.tws.proto.system.job.JobAPI;
 import edu.iu.dsc.tws.proto.utils.NodeInfoUtils;
 import edu.iu.dsc.tws.proto.utils.WorkerInfoUtils;
 import edu.iu.dsc.tws.rsched.core.WorkerRuntime;
-import edu.iu.dsc.tws.rsched.utils.JobUtils;
 
 public final class JobMasterClientExample {
   private static final Logger LOG = Logger.getLogger(JobMasterClientExample.class.getName());
@@ -175,7 +174,7 @@ public final class JobMasterClientExample {
         .putAll(config)
         .put(JobMasterContext.JOB_MASTER_IP, jmIP)
         .build();
-    return JobUtils.resolveJobId(cnfg, Context.jobName(cnfg));
+    return cnfg;
   }
 
   /**

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/jobmaster/JobMasterExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/jobmaster/JobMasterExample.java
@@ -48,7 +48,6 @@ import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesContext;
 import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesController;
 import edu.iu.dsc.tws.rsched.schedulers.k8s.driver.K8sScaler;
 import edu.iu.dsc.tws.rsched.schedulers.k8s.master.JobTerminator;
-import edu.iu.dsc.tws.rsched.utils.JobUtils;
 
 public final class JobMasterExample {
   private static final Logger LOG = Logger.getLogger(JobMasterExample.class.getName());
@@ -77,7 +76,6 @@ public final class JobMasterExample {
     String configDir = "";
     String twister2Home = Paths.get(configDir).toAbsolutePath().toString();
     Config config = ConfigLoader.loadConfig(twister2Home, "conf", "kubernetes");
-    config = updateConfig(config);
     LOG.info("Loaded: " + config.size() + " configuration parameters.");
 
     Twister2Job twister2Job = Twister2Job.loadTwister2Job(config, null);
@@ -111,13 +109,6 @@ public final class JobMasterExample {
         + "\njobName: " + job.getJobName()
     );
 
-  }
-
-  /**
-   * construct a Config object
-   */
-  public static Config updateConfig(Config config) {
-    return JobUtils.resolveJobId(config, Context.jobName(config));
   }
 
   public static void printUsage() {

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/mesos/MesosScheduler.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/mesos/MesosScheduler.java
@@ -26,7 +26,6 @@ import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
 
 import edu.iu.dsc.tws.api.config.Config;
-import edu.iu.dsc.tws.api.config.Context;
 import edu.iu.dsc.tws.api.scheduler.SchedulerContext;
 import edu.iu.dsc.tws.proto.system.job.JobAPI;
 import edu.iu.dsc.tws.rsched.utils.JobUtils;
@@ -55,8 +54,7 @@ public class MesosScheduler implements Scheduler {
     totalTaskCount = MesosContext.numberOfContainers(config);
     this.job = myJob;
     this.jobName = myJob.getJobName();
-    Config configCopy = JobUtils.resolveJobId(config, jobName);
-    this.jobId = configCopy.getStringValue(Context.JOB_ID);
+    this.jobId = myJob.getJobId();
   }
 
   @Override

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/nomad/NomadController.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/nomad/NomadController.java
@@ -39,7 +39,6 @@ import com.hashicorp.nomad.javasdk.NomadException;
 import com.hashicorp.nomad.javasdk.ServerQueryResponse;
 
 import edu.iu.dsc.tws.api.config.Config;
-import edu.iu.dsc.tws.api.config.Context;
 import edu.iu.dsc.tws.api.scheduler.IController;
 import edu.iu.dsc.tws.api.scheduler.SchedulerContext;
 import edu.iu.dsc.tws.master.JobMasterContext;
@@ -280,8 +279,7 @@ public class NomadController implements IController {
     // lets construct the mpi command to launch
     List<String> mpiCommand = workerProcessCommand(getScriptPath(config, configDirectoryName));
     Map<String, Object> map = workerCommandArguments(config, workingDirectory, job);
-    Config configCopy = JobUtils.resolveJobId(config, job.getJobName());
-    String jobId = configCopy.getStringValue(Context.JOB_ID);
+    String jobId = job.getJobId();
     String runIncLient = null;
     if (JobMasterContext.jobMasterRunsInClient(config)) {
       runIncLient = "true";

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/utils/JobUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/utils/JobUtils.java
@@ -27,7 +27,6 @@ import java.io.File;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 import java.util.logging.Logger;
 
 import com.google.protobuf.ByteString;
@@ -167,21 +166,6 @@ public final class JobUtils {
     return Paths.get(home, jobFileName + ".job").toAbsolutePath().toString();
   }
 
-  public static Config resolveJobId(Config config, String jobName) {
-    Config.Builder builder = Config.newBuilder().putAll(config);
-
-    String jobId = config.getStringValue(Context.JOB_ID);
-
-    if (jobId == null) {
-      jobId = String.format("%s-%s", jobName, UUID.randomUUID().toString());
-      builder.put(Context.JOB_ID, jobId);
-    }
-
-    LOG.info("Job ID assigned : " + jobId);
-
-    return builder.build();
-  }
-
   /**
    * write the values from Job object to config object
    */
@@ -192,6 +176,7 @@ public final class JobUtils {
 
     builder.put(SchedulerContext.WORKER_CLASS, job.getWorkerClassName());
     builder.put(Context.TWISTER2_WORKER_INSTANCES, job.getNumberOfWorkers());
+    builder.put(Context.JOB_ID, job.getJobId());
 
     return builder.build();
   }


### PR DESCRIPTION
I moved jobID generation to Twister2Job class. 
jobID can be either set from configuration file, or automatically generated when serializing Job object. 
jobID is available from both Config object or job object. 
