### PR TITLE
implemented worker reconnection to JobMaster after JM restart

### DIFF
--- a/twister2/common/src/java/edu/iu/dsc/tws/common/net/tcp/Client.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/net/tcp/Client.java
@@ -88,6 +88,15 @@ public class Client implements SelectHandler {
     fixedBuffers = fixBuffers;
   }
 
+  /**
+   * this method must be called when the client is disconnected
+   * @param host
+   * @param port
+   */
+  public void setHostAndPort(String host, int port) {
+    address = new InetSocketAddress(host, port);
+  }
+
   public boolean connect() {
     try {
       socketChannel = SocketChannel.open();

--- a/twister2/common/src/java/edu/iu/dsc/tws/common/net/tcp/request/RRClient.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/net/tcp/request/RRClient.java
@@ -86,6 +86,10 @@ public class RRClient {
     client = new Client(host, port, cfg, looper, new Handler(), false);
   }
 
+  public void setHostAndPort(String host, int port) {
+    client.setHostAndPort(host, port);
+  }
+
   public boolean connect() {
     return client.connect();
   }

--- a/twister2/config/src/yaml/conf/common/logger.properties
+++ b/twister2/config/src/yaml/conf/common/logger.properties
@@ -40,7 +40,7 @@ handlers=edu.iu.dsc.tws.common.logging.Twister2FileLogHandler, java.util.logging
 # Here, the level for each package is specified.
 # The global level is used by default, so levels
 # specified here simply act as an override.
-edu.iu.dsc.tws.level=ALL
+edu.iu.dsc.tws.level=INFO
 
 # we set zookeeper and curator library log levels to WARNING
 # they tend to log many messages in INFO

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/rsched/BasicK8sWorker.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/rsched/BasicK8sWorker.java
@@ -103,8 +103,8 @@ public class BasicK8sWorker implements IWorker, IAllJoinedListener, IScalerListe
         WorkerResourceUtils.getWorkersPerNode(workerList);
     printWorkersPerNode(workersPerNode);
 
-    waitAndComplete();
-//    testScalingMessaging(workerController);
+//    waitAndComplete();
+    testScalingMessaging(workerController);
 //    listHdfsDir();
 //    sleepSomeTime(50);
 //    echoServer(workerController.getWorkerInfo());

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/rsched/DriverExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/rsched/DriverExample.java
@@ -38,9 +38,10 @@ public class  DriverExample implements IDriver {
 
     waitAllWorkersToJoin();
 
-//    broadcastExample(messenger);
 //    scalingExampleCLI(scaler);
     scalingExample(scaler, messenger);
+    broadcastExample(messenger);
+    sendCompleteMessage(messenger);
 
     LOG.info("Driver has finished execution.");
   }
@@ -128,35 +129,29 @@ public class  DriverExample implements IDriver {
       e.printStackTrace();
     }
 
-    int toRemove = 3;
-    LOG.info("removing " + toRemove + " workers.");
-    scaler.scaleDownWorkers(toRemove);
+//    int toRemove = 3;
+//    LOG.info("removing " + toRemove + " workers.");
+//    scaler.scaleDownWorkers(toRemove);
+//
+//    try {
+//      LOG.info(String.format("Sleeping %s seconds ....", sleepDuration));
+//      Thread.sleep(sleepDuration);
+//    } catch (InterruptedException e) {
+//      e.printStackTrace();
+//    }
+//
+//    LOG.info("Adding " + toAdd + " new workers.");
+//    scaler.scaleUpWorkers(toAdd);
+//
+//    waitAllWorkersToJoin();
+//
+//    try {
+//      LOG.info(String.format("Sleeping %s seconds ....", sleepDuration));
+//      Thread.sleep(sleepDuration);
+//    } catch (InterruptedException e) {
+//      e.printStackTrace();
+//    }
 
-    try {
-      LOG.info(String.format("Sleeping %s seconds ....", sleepDuration));
-      Thread.sleep(sleepDuration);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
-
-    LOG.info("Adding " + toAdd + " new workers.");
-    scaler.scaleUpWorkers(toAdd);
-
-    waitAllWorkersToJoin();
-
-    try {
-      LOG.info(String.format("Sleeping %s seconds ....", sleepDuration));
-      Thread.sleep(sleepDuration);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
-
-    JobMasterAPI.WorkerStateChange stateChange = JobMasterAPI.WorkerStateChange.newBuilder()
-        .setState(JobMasterAPI.WorkerState.COMPLETED)
-        .build();
-
-    LOG.info("Broadcasting the message: " + stateChange);
-    messenger.broadcastToAllWorkers(stateChange);
   }
 
   private void broadcastExample(IDriverMessenger messenger) {
@@ -189,6 +184,15 @@ public class  DriverExample implements IDriver {
     } catch (InterruptedException e) {
       e.printStackTrace();
     }
+  }
+
+  public void sendCompleteMessage(IDriverMessenger messenger) {
+    JobMasterAPI.WorkerStateChange stateChange = JobMasterAPI.WorkerStateChange.newBuilder()
+        .setState(JobMasterAPI.WorkerState.COMPLETED)
+        .build();
+
+    LOG.info("Broadcasting COMPLETED message: " + stateChange);
+    messenger.broadcastToAllWorkers(stateChange);
   }
 
   @Override

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/WorkerRuntime.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/WorkerRuntime.java
@@ -127,7 +127,7 @@ public final class WorkerRuntime {
           @Override
           public void restarted(String jobMasterAddress) {
             LOG.info("JobMaster restarted. Worker will try to reconnect and re-register.");
-            jmWorkerAgent.reconnect();
+            jmWorkerAgent.reconnect(jobMasterAddress);
           }
         });
       }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/WorkerRuntime.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/WorkerRuntime.java
@@ -15,6 +15,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.config.Config;
+import edu.iu.dsc.tws.api.faulttolerance.FaultToleranceContext;
 import edu.iu.dsc.tws.api.resource.IAllJoinedListener;
 import edu.iu.dsc.tws.api.resource.IJobMasterFailureListener;
 import edu.iu.dsc.tws.api.resource.IReceiverFromDriver;
@@ -114,6 +115,22 @@ public final class WorkerRuntime {
 
       // initialize JMSenderToDriver
       senderToDriver = new JMSenderToDriver(jmWorkerAgent);
+
+      // add listener to renew connection after jm restart
+      if (FaultToleranceContext.faultTolerant(config)) {
+        zkWorkerController.addJMFailureListener(new IJobMasterFailureListener() {
+          @Override
+          public void failed() {
+
+          }
+
+          @Override
+          public void restarted(String jobMasterAddress) {
+            LOG.info("JobMaster restarted. Worker will try to reconnect and re-register.");
+            jmWorkerAgent.reconnect();
+          }
+        });
+      }
     }
 
     initialized = true;


### PR DESCRIPTION
I implemented worker re-connections to the job master after job master restarts. 
1. First disconnect the worker if the worker assumes it is still connected
2. Update job master address if it is changed
2. Reconnect the worker to job master
3. Re-register the worker to the job master

Limitations:
If there are messages waiting to be sent to job master during job master failure and restart, they are lost. 