### PR TITLE
generating jobID and using it for jobName

### DIFF
--- a/twister2/api/src/java/edu/iu/dsc/tws/api/Twister2Job.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/Twister2Job.java
@@ -15,7 +15,6 @@ package edu.iu.dsc.tws.api;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.logging.Logger;
 
 import com.google.protobuf.ByteString;
@@ -24,6 +23,7 @@ import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.config.Context;
 import edu.iu.dsc.tws.api.resource.IWorker;
 import edu.iu.dsc.tws.api.scheduler.SchedulerContext;
+import edu.iu.dsc.tws.api.util.JobIDUtils;
 import edu.iu.dsc.tws.api.util.KryoSerializer;
 import edu.iu.dsc.tws.proto.system.job.JobAPI;
 import edu.iu.dsc.tws.proto.utils.ComputeResourceUtils;
@@ -50,6 +50,11 @@ public final class Twister2Job {
    * Name of the job
    */
   private String jobID;
+
+  /**
+   * username to be used in jobID
+   */
+  private String userName;
 
   /**
    * IWorker class name
@@ -101,7 +106,7 @@ public final class Twister2Job {
 
     // if jobID is not set, set it
     if (jobID == null) {
-      jobID = String.format("%s-%s", jobName, UUID.randomUUID().toString());
+      jobID = JobIDUtils.generateJobID(jobName, userName);
     }
     jobBuilder.setJobId(jobID);
 
@@ -220,6 +225,14 @@ public final class Twister2Job {
    */
   public void setJobID(String id) {
     this.jobID = id;
+  }
+
+  /**
+   * we set userName through this interface
+   * Users do not set it, we set it later on in Twister2Submitter
+   */
+  public void setUserName(String userName) {
+    this.userName = userName;
   }
 
   public String getJobName() {

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/config/Context.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/config/Context.java
@@ -72,6 +72,7 @@ public class Context {
   public static final String JOB_NAME = "twister2.resource.job.name";
   public static final String JOB_OBJECT = "twister2.job.object";
   public static final String JOB_ID = "twister2.job.id";
+  public static final String USER_NAME = "twister2.user.name";
 
   // an internal property to represent the container id
   public static final String TWISTER2_CONTAINER_ID = "twister2.container.id";
@@ -168,6 +169,10 @@ public class Context {
 
   public static String jobId(Config cfg) {
     return cfg.getStringValue(JOB_ID);
+  }
+
+  public static String userName(Config cfg) {
+    return cfg.getStringValue(USER_NAME);
   }
 
   public static String dataConfigurationFile(Config cfg) {

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/scheduler/ILauncher.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/scheduler/ILauncher.java
@@ -35,7 +35,7 @@ public interface ILauncher extends AutoCloseable {
   /**
    * terminate the submitted job
    */
-  boolean terminateJob(String jobName);
+  boolean terminateJob(String jobID);
 
   /**
    * Launch the processes according to the requested resources.

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/scheduler/SchedulerContext.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/scheduler/SchedulerContext.java
@@ -170,8 +170,8 @@ public class SchedulerContext extends Context {
     return persistentVolumePerWorker(cfg) > 0;
   }
 
-  public static String createJobDescriptionFileName(String jobName) {
-    return jobName + ".job";
+  public static String createJobDescriptionFileName(String jobID) {
+    return jobID + ".job";
   }
 
   public static int workerEndSyncWaitTime(Config cfg) {

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/util/JobIDUtils.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/util/JobIDUtils.java
@@ -11,10 +11,7 @@
 //  limitations under the License.
 package edu.iu.dsc.tws.api.util;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.math.BigInteger;
 import java.util.Locale;
 
 public final class JobIDUtils {
@@ -140,34 +137,10 @@ public final class JobIDUtils {
    * @return
    */
   public static String timestamp() {
-    DateFormat sdf = new SimpleDateFormat("MM/dd/yyyy", Locale.ENGLISH);
-    Date startDate = null;
-    try {
-      startDate = sdf.parse("01/01/2019");
-    } catch (ParseException e) {
-      throw new RuntimeException("Totally unexpected error when creating Date object");
-    }
-    long diff = System.currentTimeMillis() - startDate.getTime();
-    return base36(diff);
-  }
-
-  /**
-   * convert given time stamp to base36 alpha numeric string
-   * @param ts
-   * @return
-   */
-  public static String base36(long ts) {
-    String digits = "0123456789abcdefghijklmnopqrstuvwxyz";
-    int base = digits.length();
-    long n = ts;
-    String s = "";
-
-    while (n > 0) {
-      long d = n % base;
-      s = digits.charAt((int) d) + s;
-      n = n / base;
-    }
-    return s;
+    // long value of January 01, 2019
+    long jan2019 = 1546290000000L;
+    long diff = System.currentTimeMillis() - jan2019;
+    return BigInteger.valueOf(diff).toString(36);
   }
 
 }

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/util/JobIDUtils.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/util/JobIDUtils.java
@@ -55,13 +55,17 @@ public final class JobIDUtils {
     }
 
     String timestamp = timestamp();
-    // leave out characters from the beginning
+    // leave out characters from the beginning if it is longer than max
     // this should not happen until the year 2105
     if (timestamp.length() > MAX_TIMESTAMP_LENGTH) {
       timestamp = timestamp.substring(timestamp.length() - MAX_TIMESTAMP_LENGTH);
     }
 
-    return String.format("%s-%s-%s", userNameInID, jobNameInID, timestamp);
+    if (userNameInID == null || "".equals(userNameInID)) {
+      return String.format("%s-%s", jobNameInID, timestamp);
+    } else {
+      return String.format("%s-%s-%s", userNameInID, jobNameInID, timestamp);
+    }
   }
 
 

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/util/JobIDUtils.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/util/JobIDUtils.java
@@ -17,8 +17,6 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
-import edu.iu.dsc.tws.api.exceptions.Twister2RuntimeException;
-
 public final class JobIDUtils {
 
   // JobID format: <username>-<jobName>-<timestamp>
@@ -147,7 +145,7 @@ public final class JobIDUtils {
     try {
       startDate = sdf.parse("01/01/2019");
     } catch (ParseException e) {
-      throw new Twister2RuntimeException("Totally unexpected error when creating Date object");
+      throw new RuntimeException("Totally unexpected error when creating Date object");
     }
     long diff = System.currentTimeMillis() - startDate.getTime();
     return base36(diff);

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/util/JobIDUtils.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/util/JobIDUtils.java
@@ -1,0 +1,171 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package edu.iu.dsc.tws.api.util;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import edu.iu.dsc.tws.api.exceptions.Twister2RuntimeException;
+
+public final class JobIDUtils {
+
+  // JobID format: <username>-<jobName>-<timestamp>
+  // max 49 characters= <9 chars>-<30 chars>-<8 chars>
+
+  // we limit jobID to 49, because we use jobID when creating resources in K8s clusters
+  // We use jobID as part of statefulset, service, and label names
+  // the names of these resources can be at most 63 characters in K8s
+  // We add some prefix or suffixes to jobID when creating these names
+  //
+  // statefulset pods has the following label
+  // controller-revision-hash=<pod-name>-<hash>
+  // hash part can be 10 characters
+  // so, the pod name can be at most 52 chars, since jm pod name has a 3 char suffix "-jm"
+  // jobID can have at most 49 chars
+  private static final int MAX_JOB_ID_LENGTH = 49;
+
+  private static final int MAX_USER_NAME_LENGTH = 9;
+  private static final int MAX_TIMESTAMP_LENGTH = 8;
+  private static final int MAX_JOB_NAME_LENGTH_IN_JOB_ID = 30;
+
+  private JobIDUtils() { }
+
+  public static String generateJobID(String jobName, String userName) {
+
+    String jobNameInID = jobName;
+    if (!nameConformsToK8sNamingRules(jobName, MAX_JOB_NAME_LENGTH_IN_JOB_ID)) {
+      jobNameInID = convertToK8sFormat(jobName, MAX_JOB_NAME_LENGTH_IN_JOB_ID);
+    }
+
+    String userNameInID = userName;
+    if (!nameConformsToK8sNamingRules(userName, MAX_USER_NAME_LENGTH)) {
+      userNameInID = convertToK8sFormat(userName, MAX_USER_NAME_LENGTH);
+    }
+
+    String timestamp = timestamp();
+    // leave out characters from the beginning
+    // this should not happen until the year 2105
+    if (timestamp.length() > MAX_TIMESTAMP_LENGTH) {
+      timestamp = timestamp.substring(timestamp.length() - MAX_TIMESTAMP_LENGTH);
+    }
+
+    return String.format("%s-%s-%s", userNameInID, jobNameInID, timestamp);
+  }
+
+
+  /**
+   * whether given jobName conforms to k8s naming rules and max length
+   * @param jName
+   * @return
+   */
+  public static boolean nameConformsToK8sNamingRules(String jName, int maxLength) {
+
+    // first we need to check the length of the name
+    if (jName.length() > maxLength) {
+      return false;
+    }
+
+    // first character is a lowercase letter from a to z
+    // last character is an alphanumeric character: [a-z0-9]
+    // in between alphanumeric characters and dashes
+    // first character is mandatory. It has to be at least 1 char in length
+    if (jName.matches("[a-z]([-a-z0-9]*[a-z0-9])?")) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * we perform the following actions:
+   *   shorten the length of the job name if needed
+   *   replace underscore and dot characters with dashes
+   *   convert all letters to lower case characters
+   *   delete non-alphanumeric characters excluding dots and dashes
+   *   replace the first char with "a", if it is not a letter in between a-z
+   *   replace the last char with "z", if it is dash
+   * @param name
+   * @return
+   */
+  public static String convertToK8sFormat(String name, int maxLength) {
+
+    // replace underscores with dashes if any
+    String modifiedName = name.replace("_", "-");
+    // replace dots with dashes if any
+    modifiedName = modifiedName.replace(".", "-");
+
+    // convert to lower case
+    modifiedName = modifiedName.toLowerCase(Locale.ENGLISH);
+
+    // delete all non-alphanumeric characters excluding dashes
+    modifiedName = modifiedName.replaceAll("[^a-z0-9\\-]", "");
+
+    // make sure the first char is a letter
+    // if not, replace it  with "a"
+    if (modifiedName.matches("[^a-z][-a-z0-9]*")) {
+      modifiedName = "a" + modifiedName.substring(1);
+    }
+
+    // make sure the last char is not dash
+    // if it is, replace it  with "z"
+    if (modifiedName.matches("[-a-z0-9]*[-]")) {
+      modifiedName = modifiedName.substring(0, modifiedName.length() - 1) + "z";
+    }
+
+    // shorten the job name if needed
+    if (modifiedName.length() > maxLength) {
+      modifiedName = modifiedName.substring(0, maxLength);
+    }
+
+    return modifiedName;
+  }
+
+  /**
+   * create an alpha numeric string from time stamp value
+   * current time - 01/01/2019
+   * @return
+   */
+  public static String timestamp() {
+    DateFormat sdf = new SimpleDateFormat("MM/dd/yyyy", Locale.ENGLISH);
+    Date startDate = null;
+    try {
+      startDate = sdf.parse("01/01/2019");
+    } catch (ParseException e) {
+      throw new Twister2RuntimeException("Totally unexpected error when creating Date object");
+    }
+    long diff = System.currentTimeMillis() - startDate.getTime();
+    return base36(diff);
+  }
+
+  /**
+   * convert given time stamp to base36 alpha numeric string
+   * @param ts
+   * @return
+   */
+  public static String base36(long ts) {
+    String digits = "0123456789abcdefghijklmnopqrstuvwxyz";
+    int base = digits.length();
+    long n = ts;
+    String s = "";
+
+    while (n > 0) {
+      long d = n % base;
+      s = digits.charAt((int) d) + s;
+      n = n / base;
+    }
+    return s;
+  }
+
+}

--- a/twister2/common/src/java/edu/iu/dsc/tws/common/zk/ZKBarrierManager.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/zk/ZKBarrierManager.java
@@ -27,10 +27,10 @@ public final class ZKBarrierManager {
   /**
    * create parent directory for ephemeral worker znodes
    */
-  public static void createBarrierDir(CuratorFramework client, String rootPath, String jobName)
+  public static void createBarrierDir(CuratorFramework client, String rootPath, String jobID)
       throws Twister2Exception {
 
-    String barrierDirPath = ZKUtils.barrierDir(rootPath, jobName);
+    String barrierDirPath = ZKUtils.barrierDir(rootPath, jobID);
 
     try {
       client
@@ -52,9 +52,9 @@ public final class ZKBarrierManager {
    */
   public static void createWorkerZNode(CuratorFramework client,
                                        String rootPath,
-                                       String jobName,
+                                       String jobID,
                                        int workerID) throws Twister2Exception {
-    String barrierPath = ZKUtils.barrierDir(rootPath, jobName);
+    String barrierPath = ZKUtils.barrierDir(rootPath, jobID);
     String workerPath = ZKUtils.workerPath(barrierPath, workerID);
 
     try {
@@ -77,9 +77,9 @@ public final class ZKBarrierManager {
    */
   public static void deleteWorkerZNode(CuratorFramework client,
                                        String rootPath,
-                                       String jobName,
+                                       String jobID,
                                        int workerID) throws Twister2Exception {
-    String barrierPath = ZKUtils.barrierDir(rootPath, jobName);
+    String barrierPath = ZKUtils.barrierDir(rootPath, jobID);
     String workerPath = ZKUtils.workerPath(barrierPath, workerID);
 
     try {
@@ -100,9 +100,9 @@ public final class ZKBarrierManager {
    */
   public static boolean existWorkerZNode(CuratorFramework client,
                                          String rootPath,
-                                         String jobName,
+                                         String jobID,
                                          int workerID) throws Twister2Exception {
-    String barrierPath = ZKUtils.barrierDir(rootPath, jobName);
+    String barrierPath = ZKUtils.barrierDir(rootPath, jobID);
     String workerPath = ZKUtils.workerPath(barrierPath, workerID);
 
     try {
@@ -119,11 +119,11 @@ public final class ZKBarrierManager {
    */
   public static void removeScaledDownZNodes(CuratorFramework client,
                                             String rootPath,
-                                            String jobName,
+                                            String jobID,
                                             int minID,
                                             int maxID) throws Twister2Exception {
 
-    String barrierDir = ZKUtils.barrierDir(rootPath, jobName);
+    String barrierDir = ZKUtils.barrierDir(rootPath, jobID);
 
     for (int workerID = minID; workerID < maxID; workerID++) {
       String workerPath = ZKUtils.workerPath(barrierDir, workerID);
@@ -143,9 +143,9 @@ public final class ZKBarrierManager {
 
   public static int getNumberOfWorkersAtBarrier(CuratorFramework client,
                                                 String rootPath,
-                                                String jobName) throws Twister2Exception {
+                                                String jobID) throws Twister2Exception {
 
-    String barrierDir = ZKUtils.barrierDir(rootPath, jobName);
+    String barrierDir = ZKUtils.barrierDir(rootPath, jobID);
 
     try {
       int numberOfWorkersAt = client.getChildren().forPath(barrierDir).size();
@@ -156,6 +156,5 @@ public final class ZKBarrierManager {
           + barrierDir, e);
     }
   }
-
 
 }

--- a/twister2/common/src/java/edu/iu/dsc/tws/common/zk/ZKEphemStateManager.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/zk/ZKEphemStateManager.java
@@ -45,10 +45,10 @@ public final class ZKEphemStateManager {
   /**
    * create parent directory for ephemeral worker znodes
    */
-  public static void createEphemDir(CuratorFramework client, String rootPath, String jobName)
+  public static void createEphemDir(CuratorFramework client, String rootPath, String jobID)
       throws Twister2Exception {
 
-    String ephemDirPath = ZKUtils.ephemDir(rootPath, jobName);
+    String ephemDirPath = ZKUtils.ephemDir(rootPath, jobID);
 
     try {
       client
@@ -67,10 +67,10 @@ public final class ZKEphemStateManager {
 
   public static PersistentNode createWorkerZnode(CuratorFramework client,
                                                  String rootPath,
-                                                 String jobName,
+                                                 String jobID,
                                                  int workerID) {
 
-    String ephemDirPath = ZKUtils.ephemDir(rootPath, jobName);
+    String ephemDirPath = ZKUtils.ephemDir(rootPath, jobID);
     String workerPath = ZKUtils.workerPath(ephemDirPath, workerID);
     byte[] znodeBody = ("" + workerID).getBytes(StandardCharsets.UTF_8);
 
@@ -86,9 +86,9 @@ public final class ZKEphemStateManager {
    */
   public static void removeEphemZNode(CuratorFramework client,
                                       String rootPath,
-                                      String jobName,
+                                      String jobID,
                                       int workerID) throws Twister2Exception {
-    String ephemDirPath = ZKUtils.ephemDir(rootPath, jobName);
+    String ephemDirPath = ZKUtils.ephemDir(rootPath, jobID);
 
     try {
       List<String> children = client.getChildren().forPath(ephemDirPath);

--- a/twister2/common/src/java/edu/iu/dsc/tws/common/zk/ZKEventsManager.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/zk/ZKEventsManager.java
@@ -37,10 +37,10 @@ public final class ZKEventsManager {
    * Assumes that there is no znode exists in the ZooKeeper
    * This method should be called by the submitting client
    */
-  public static void createEventsZNode(CuratorFramework client, String rootPath, String jobName)
+  public static void createEventsZNode(CuratorFramework client, String rootPath, String jobID)
       throws Twister2Exception {
 
-    String eventsDir = ZKUtils.eventsDir(rootPath, jobName);
+    String eventsDir = ZKUtils.eventsDir(rootPath, jobID);
 
     try {
       client
@@ -59,9 +59,9 @@ public final class ZKEventsManager {
 
   public static void initEventCounter(CuratorFramework client,
                                       String rootPath,
-                                      String jobName) throws Twister2Exception {
+                                      String jobID) throws Twister2Exception {
 
-    String eventsDir = ZKUtils.eventsDir(rootPath, jobName);
+    String eventsDir = ZKUtils.eventsDir(rootPath, jobID);
 
     try {
       eventCounter = client.getChildren().forPath(eventsDir).size();
@@ -76,16 +76,16 @@ public final class ZKEventsManager {
    * construct the next event path
    * increase the eventCounter by one
    */
-  public static String constructEventPath(String rootPath, String jobName) {
-    return ZKUtils.eventsDir(rootPath, jobName) + "/" + eventCounter++;
+  public static String constructEventPath(String rootPath, String jobID) {
+    return ZKUtils.eventsDir(rootPath, jobID) + "/" + eventCounter++;
   }
 
   public static void publishEvent(CuratorFramework client,
                                   String rootPath,
-                                  String jobName,
+                                  String jobID,
                                   JobMasterAPI.JobEvent jobEvent) throws Twister2Exception {
 
-    String eventPath = constructEventPath(rootPath, jobName);
+    String eventPath = constructEventPath(rootPath, jobID);
 
     try {
       client
@@ -104,9 +104,9 @@ public final class ZKEventsManager {
 
   public static int getNumberOfPastEvents(CuratorFramework client,
                                           String rootPath,
-                                          String jobName) throws Twister2Exception {
+                                          String jobID) throws Twister2Exception {
 
-    String eventsDir = ZKUtils.eventsDir(rootPath, jobName);
+    String eventsDir = ZKUtils.eventsDir(rootPath, jobID);
 
     try {
       int numberOfPastEvents = client.getChildren().forPath(eventsDir).size();
@@ -131,10 +131,10 @@ public final class ZKEventsManager {
    */
   public static TreeMap<Integer, JobMasterAPI.JobEvent> getAllEvents(CuratorFramework client,
                                                                      String rootPath,
-                                                                     String jobName)
+                                                                     String jobID)
       throws Twister2Exception {
 
-    String eventsDir = ZKUtils.eventsDir(rootPath, jobName);
+    String eventsDir = ZKUtils.eventsDir(rootPath, jobID);
 
     try {
       TreeMap<Integer, JobMasterAPI.JobEvent> events = new TreeMap<>(Collections.reverseOrder());

--- a/twister2/common/src/java/edu/iu/dsc/tws/common/zk/ZKJobMasterFinder.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/zk/ZKJobMasterFinder.java
@@ -52,9 +52,9 @@ public class ZKJobMasterFinder {
   private String jobMasterIP;
   private String jobMasterPort;
 
-  public ZKJobMasterFinder(Config config) {
+  public ZKJobMasterFinder(Config config, String jobID) {
     this.config = config;
-    jobMasterPath = ZKJobMasterRegistrar.constructJobMasterPath(config);
+    jobMasterPath = ZKJobMasterRegistrar.constructJobMasterPath(config, jobID);
   }
 
   /**

--- a/twister2/common/src/java/edu/iu/dsc/tws/common/zk/ZKJobMasterRegistrar.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/zk/ZKJobMasterRegistrar.java
@@ -33,7 +33,6 @@ import org.apache.curator.framework.recipes.nodes.PersistentNode;
 import org.apache.zookeeper.CreateMode;
 
 import edu.iu.dsc.tws.api.config.Config;
-import edu.iu.dsc.tws.api.config.Context;
 
 /**
  * it is a single node controller
@@ -54,11 +53,11 @@ public class ZKJobMasterRegistrar {
   private String jobMasterPath;
   private PersistentNode jobMasterNode;
 
-  public ZKJobMasterRegistrar(Config config, String jobMasterIP, int jobMasterPort) {
+  public ZKJobMasterRegistrar(Config config, String jobMasterIP, int jobMasterPort, String jobID) {
     this.config = config;
     this.jobMasterIP = jobMasterIP;
     this.jobMasterPort = jobMasterPort;
-    jobMasterPath = constructJobMasterPath(config);
+    jobMasterPath = constructJobMasterPath(config, jobID);
   }
 
   /**
@@ -66,8 +65,8 @@ public class ZKJobMasterRegistrar {
    * @param config
    * @return
    */
-  public static String constructJobMasterPath(Config config) {
-    return ZKContext.rootNode(config) + "/" + Context.jobName(config) + "-job-master";
+  public static String constructJobMasterPath(Config config, String jobID) {
+    return ZKContext.rootNode(config) + "/" + jobID + "-job-master";
   }
 
   /**

--- a/twister2/common/src/java/edu/iu/dsc/tws/common/zk/ZKPersStateManager.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/zk/ZKPersStateManager.java
@@ -56,7 +56,7 @@ public final class ZKPersStateManager {
   public static void createPersStateDir(CuratorFramework client, String rootPath, JobAPI.Job job)
       throws Twister2Exception {
 
-    String persStatePath = ZKUtils.persDir(rootPath, job.getJobName());
+    String persStatePath = ZKUtils.persDir(rootPath, job.getJobId());
 
     try {
       client
@@ -83,10 +83,10 @@ public final class ZKPersStateManager {
    */
   public static boolean initWorkerPersState(CuratorFramework client,
                                             String rootPath,
-                                            String jobName,
+                                            String jobID,
                                             WorkerInfo workerInfo) throws Twister2Exception {
 
-    String workersPersDir = ZKUtils.persDir(rootPath, jobName);
+    String workersPersDir = ZKUtils.persDir(rootPath, jobID);
     String workerPersPath = ZKUtils.workerPath(workersPersDir, workerInfo.getWorkerID());
 
     try {
@@ -123,10 +123,10 @@ public final class ZKPersStateManager {
    */
   public static boolean initJobMasterPersState(CuratorFramework client,
                                                String rootPath,
-                                               String jobName,
+                                               String jobID,
                                                String jmAddress) throws Twister2Exception {
 
-    String jmPersPath = ZKUtils.jmPersPath(rootPath, jobName);
+    String jmPersPath = ZKUtils.jmPersPath(rootPath, jobID);
 
     try {
       // if the worker znode exists,
@@ -164,11 +164,11 @@ public final class ZKPersStateManager {
    */
   public static void removeScaledDownZNodes(CuratorFramework client,
                                             String rootPath,
-                                            String jobName,
+                                            String jobID,
                                             int minID,
                                             int maxID) throws Twister2Exception {
 
-    String checkPath = ZKUtils.persDir(rootPath, jobName);
+    String checkPath = ZKUtils.persDir(rootPath, jobID);
 
     for (int workerID = minID; workerID < maxID; workerID++) {
       String workerCheckPath = ZKUtils.workerPath(checkPath, workerID);
@@ -189,11 +189,11 @@ public final class ZKPersStateManager {
 
   public static boolean updateWorkerStatus(CuratorFramework client,
                                            String rootPath,
-                                           String jobName,
+                                           String jobID,
                                            WorkerInfo workerInfo,
                                            WorkerState newStatus) throws Twister2Exception {
 
-    String workersPersDir = ZKUtils.persDir(rootPath, jobName);
+    String workersPersDir = ZKUtils.persDir(rootPath, jobID);
     String workerPersPath = ZKUtils.workerPath(workersPersDir, workerInfo.getWorkerID());
     WorkerWithState workerWithState = new WorkerWithState(workerInfo, newStatus);
 
@@ -221,9 +221,9 @@ public final class ZKPersStateManager {
 
   public static WorkerWithState getWorkerWithState(CuratorFramework client,
                                                    String rootPath,
-                                                   String jobName,
+                                                   String jobID,
                                                    int workerID) throws Twister2Exception {
-    String workersPersDir = ZKUtils.persDir(rootPath, jobName);
+    String workersPersDir = ZKUtils.persDir(rootPath, jobID);
     String workerPersPath = ZKUtils.workerPath(workersPersDir, workerID);
     return getWorkerWithState(client, workerPersPath);
   }
@@ -233,9 +233,9 @@ public final class ZKPersStateManager {
    */
   public static LinkedList<WorkerWithState> getWorkers(CuratorFramework client,
                                                        String rootPath,
-                                                       String jobName) throws Twister2Exception {
+                                                       String jobID) throws Twister2Exception {
 
-    String workersPersDir = ZKUtils.persDir(rootPath, jobName);
+    String workersPersDir = ZKUtils.persDir(rootPath, jobID);
 
     try {
       List<String> children = client.getChildren().forPath(workersPersDir);
@@ -259,10 +259,10 @@ public final class ZKPersStateManager {
    * read the body of persistent directory body
    * decode and return
    */
-  public static JobAPI.Job readJobZNode(CuratorFramework client, String rootPath, String jobName)
+  public static JobAPI.Job readJobZNode(CuratorFramework client, String rootPath, String jobID)
       throws Twister2Exception {
 
-    String persDir = ZKUtils.persDir(rootPath, jobName);
+    String persDir = ZKUtils.persDir(rootPath, jobID);
 
     try {
       byte[] jobBytes = client.getData().forPath(persDir);
@@ -287,7 +287,7 @@ public final class ZKPersStateManager {
   public static void updateJobZNode(CuratorFramework client, String rootPath, JobAPI.Job job)
       throws Twister2Exception {
 
-    String persDir = ZKUtils.persDir(rootPath, job.getJobName());
+    String persDir = ZKUtils.persDir(rootPath, job.getJobId());
     try {
       client
           .setData()

--- a/twister2/common/src/java/edu/iu/dsc/tws/common/zk/ZKUtils.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/zk/ZKUtils.java
@@ -100,36 +100,36 @@ public final class ZKUtils {
   /**
    * construct main job directory path for the job
    */
-  public static String jobDir(String rootPath, String jobName) {
-    return rootPath + "/" + jobName;
+  public static String jobDir(String rootPath, String jobID) {
+    return rootPath + "/" + jobID;
   }
 
   /**
    * construct ephemeral directory path for the job
    */
-  public static String ephemDir(String rootPath, String jobName) {
-    return jobDir(rootPath, jobName) + "/workers-ephem-state";
+  public static String ephemDir(String rootPath, String jobID) {
+    return jobDir(rootPath, jobID) + "/workers-ephem-state";
   }
 
   /**
    * construct persistent directory path for the job
    */
-  public static String persDir(String rootPath, String jobName) {
-    return jobDir(rootPath, jobName) + "/workers-pers-state";
+  public static String persDir(String rootPath, String jobID) {
+    return jobDir(rootPath, jobID) + "/workers-pers-state";
   }
 
   /**
    * construct events directory path for the job
    */
-  public static String eventsDir(String rootPath, String jobName) {
-    return jobDir(rootPath, jobName) + "/events";
+  public static String eventsDir(String rootPath, String jobID) {
+    return jobDir(rootPath, jobID) + "/events";
   }
 
   /**
    * construct barrier directory path for the job
    */
-  public static String barrierDir(String rootPath, String jobName) {
-    return jobDir(rootPath, jobName) + "/barrier";
+  public static String barrierDir(String rootPath, String jobID) {
+    return jobDir(rootPath, jobID) + "/barrier";
   }
 
   /**
@@ -142,15 +142,15 @@ public final class ZKUtils {
   /**
    * construct the job master path for a persistent znode that will store the job master state
    */
-  public static String jmPersPath(String rootPath, String jobName) {
-    return jobDir(rootPath, jobName) + "/jm-pers-state";
+  public static String jmPersPath(String rootPath, String jobID) {
+    return jobDir(rootPath, jobID) + "/jm-pers-state";
   }
 
   /**
    * construct the job master path for an ephemeral znode that will watch JM liveness
    */
-  public static String jmEphemPath(String rootPath, String jobName) {
-    return jobDir(rootPath, jobName) + "/jm-ephem-state";
+  public static String jmEphemPath(String rootPath, String jobID) {
+    return jobDir(rootPath, jobID) + "/jm-ephem-state";
   }
 
   /**
@@ -211,11 +211,11 @@ public final class ZKUtils {
   /**
    * check whether there is an active job
    */
-  public static boolean isThereJobZNodes(CuratorFramework clnt, String rootPath, String jobName) {
+  public static boolean isThereJobZNodes(CuratorFramework clnt, String rootPath, String jobID) {
 
     try {
       // check whether the job znode exists, if not, return false, nothing to do
-      String jobDir = jobDir(rootPath, jobName);
+      String jobDir = jobDir(rootPath, jobID);
       if (clnt.checkExists().forPath(jobDir) != null) {
         LOG.info("main jobZnode exists: " + jobDir);
         return true;
@@ -230,12 +230,12 @@ public final class ZKUtils {
   }
 
   /**
-   * delete all znodes related to the given jobName
+   * delete all znodes related to the given jobID
    */
-  public static boolean terminateJob(String zkServers, String rootPath, String jobName) {
+  public static boolean terminateJob(String zkServers, String rootPath, String jobID) {
     try {
       CuratorFramework clnt = connectToServer(zkServers);
-      boolean deleteResult = deleteJobZNodes(clnt, rootPath, jobName);
+      boolean deleteResult = deleteJobZNodes(clnt, rootPath, jobID);
       clnt.close();
       return deleteResult;
     } catch (Exception e) {
@@ -247,12 +247,12 @@ public final class ZKUtils {
   /**
    * delete job related znode from previous sessions
    */
-  public static boolean deleteJobZNodes(CuratorFramework clnt, String rootPath, String jobName) {
+  public static boolean deleteJobZNodes(CuratorFramework clnt, String rootPath, String jobID) {
 
     boolean allDeleted = true;
 
     // delete workers ephemeral znode directory
-    String jobPath = ephemDir(rootPath, jobName);
+    String jobPath = ephemDir(rootPath, jobID);
     try {
       if (clnt.checkExists().forPath(jobPath) != null) {
 
@@ -290,7 +290,7 @@ public final class ZKUtils {
 
     try {
       // delete job directory
-      String jobDir = jobDir(rootPath, jobName);
+      String jobDir = jobDir(rootPath, jobID);
       if (clnt.checkExists().forPath(jobDir) != null) {
         clnt.delete().guaranteed().deletingChildrenIfNeeded().forPath(jobDir);
         LOG.info("JobDirectory deleted from ZooKeeper: " + jobDir);

--- a/twister2/config/src/yaml/conf/common/core.yaml
+++ b/twister2/config/src/yaml/conf/common/core.yaml
@@ -1,4 +1,17 @@
 ###################################################################
+# User name that will be used in JobID
+###################################################################
+# JobID is constructed as:
+#   <username>-<jobName>-<timestamp>
+# if username is specified here, we use this value.
+# Otherwise we get username from shell environment.
+# if the username is longer than 9 characters, we use first 9 characters of it
+# long value of timestamp is converted to alphanumeric string format
+# timestamp long value = current time - 01/01/2019
+#
+# twister2.user.name:
+
+###################################################################
 # Twister2 Job Master related settings
 ###################################################################
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/bootstrap/ZKJobMasterFinderExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/bootstrap/ZKJobMasterFinderExample.java
@@ -26,7 +26,6 @@ package edu.iu.dsc.tws.examples.internal.bootstrap;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.config.Config;
-import edu.iu.dsc.tws.api.config.Context;
 import edu.iu.dsc.tws.common.zk.ZKContext;
 import edu.iu.dsc.tws.common.zk.ZKJobMasterFinder;
 
@@ -52,10 +51,10 @@ public final class ZKJobMasterFinderExample {
     }
 
     String zkAddress = args[0];
-    String jobName = "test-job";
-    Config cnfg = buildTestConfig(zkAddress, jobName);
+    String jobID = "test-job";
+    Config cnfg = buildTestConfig(zkAddress);
 
-    ZKJobMasterFinder finder = new ZKJobMasterFinder(cnfg);
+    ZKJobMasterFinder finder = new ZKJobMasterFinder(cnfg, jobID);
     finder.initialize();
 
     String jobMasterIPandPort = finder.getJobMasterIPandPort();
@@ -74,10 +73,9 @@ public final class ZKJobMasterFinderExample {
   /**
    * construct a test Config object
    */
-  public static Config buildTestConfig(String zkAddress, String jobName) {
+  public static Config buildTestConfig(String zkAddress) {
     return Config.newBuilder()
         .put(ZKContext.SERVER_ADDRESSES, zkAddress)
-        .put(Context.JOB_NAME, jobName)
         .build();
   }
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/bootstrap/ZKJobMasterRegistrarExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/bootstrap/ZKJobMasterRegistrarExample.java
@@ -26,7 +26,6 @@ package edu.iu.dsc.tws.examples.internal.bootstrap;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.config.Config;
-import edu.iu.dsc.tws.api.config.Context;
 import edu.iu.dsc.tws.common.zk.ZKContext;
 import edu.iu.dsc.tws.common.zk.ZKJobMasterRegistrar;
 import edu.iu.dsc.tws.master.JobMasterContext;
@@ -59,14 +58,15 @@ public final class ZKJobMasterRegistrarExample {
     }
 
     String zkAddress = args[0];
-    String jobName = "test-job";
-    Config cnfg = buildConfig(zkAddress, jobName);
+    String jobID = "test-job";
+    Config cnfg = buildConfig(zkAddress);
 
     String jobMasterIP = "x.y.z.t";
     // get the default port
     int jobMasterPort = JobMasterContext.jobMasterPort(cnfg);
 
-    ZKJobMasterRegistrar registrar = new ZKJobMasterRegistrar(cnfg, jobMasterIP, jobMasterPort);
+    ZKJobMasterRegistrar registrar =
+        new ZKJobMasterRegistrar(cnfg, jobMasterIP, jobMasterPort, jobID);
     boolean initialized = registrar.initialize();
     if (!initialized && registrar.sameZNodeExist()) {
       registrar.deleteJobMasterZNode();
@@ -88,10 +88,9 @@ public final class ZKJobMasterRegistrarExample {
   /**
    * construct a Config object
    */
-  public static Config buildConfig(String zkAddress, String jobName) {
+  public static Config buildConfig(String zkAddress) {
     return Config.newBuilder()
         .put(ZKContext.SERVER_ADDRESSES, zkAddress)
-        .put(Context.JOB_NAME, jobName)
         .build();
   }
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/jobmaster/JobMasterClientExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/jobmaster/JobMasterClientExample.java
@@ -110,7 +110,7 @@ public final class JobMasterClientExample {
         workerID, workerIP, workerPort, nodeInfo, computeResource, additionalPorts);
 
     JobMasterAPI.WorkerState initialState =
-        K8sWorkerUtils.initialStateAndUpdate(config, job.getJobName(), workerInfo);
+        K8sWorkerUtils.initialStateAndUpdate(config, job.getJobId(), workerInfo);
 
     WorkerRuntime.init(config, job, workerInfo, initialState);
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/jobmaster/JobMasterExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/jobmaster/JobMasterExample.java
@@ -96,11 +96,11 @@ public final class JobMasterExample {
     if ("start".equalsIgnoreCase(args[0])) {
 
       createJobZnodes(config, job);
-      initialState = JobMasterStarter.initialStateAndUpdate(config, job.getJobName(), host);
+      initialState = JobMasterStarter.initialStateAndUpdate(config, job.getJobId(), host);
 
     } else if ("restart".equalsIgnoreCase(args[0])) {
 
-      initialState = JobMasterStarter.initialStateAndUpdate(config, job.getJobName(), host);
+      initialState = JobMasterStarter.initialStateAndUpdate(config, job.getJobId(), host);
       job = JobMasterStarter.job;
 
       if (initialState != JobMasterAPI.JobMasterState.JM_RESTARTED) {
@@ -139,7 +139,7 @@ public final class JobMasterExample {
 
     LOG.info("Threaded Job Master started:"
         + "\nnumberOfWorkers: " + job.getNumberOfWorkers()
-        + "\njobName: " + job.getJobName()
+        + "\njobID: " + job.getJobId()
     );
 
   }
@@ -154,18 +154,18 @@ public final class JobMasterExample {
     CuratorFramework client = ZKUtils.connectToServer(ZKContext.serverAddresses(conf));
     String rootPath = ZKContext.rootNode(conf);
 
-    if (ZKUtils.isThereJobZNodes(client, rootPath, job.getJobName())) {
-      ZKUtils.deleteJobZNodes(client, rootPath, job.getJobName());
+    if (ZKUtils.isThereJobZNodes(client, rootPath, job.getJobId())) {
+      ZKUtils.deleteJobZNodes(client, rootPath, job.getJobId());
     }
 
     try {
-      ZKEphemStateManager.createEphemDir(client, rootPath, job.getJobName());
+      ZKEphemStateManager.createEphemDir(client, rootPath, job.getJobId());
       ZKPersStateManager.createPersStateDir(client, rootPath, job);
-      ZKEventsManager.createEventsZNode(client, rootPath, job.getJobName());
-      ZKBarrierManager.createBarrierDir(client, rootPath, job.getJobName());
+      ZKEventsManager.createEventsZNode(client, rootPath, job.getJobId());
+      ZKBarrierManager.createBarrierDir(client, rootPath, job.getJobId());
 
       // test job znode content reading
-      JobAPI.Job readJob = ZKPersStateManager.readJobZNode(client, rootPath, job.getJobName());
+      JobAPI.Job readJob = ZKPersStateManager.readJobZNode(client, rootPath, job.getJobId());
       LOG.info("JobZNode content: " + readJob);
 
     } catch (Exception e) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/jobmaster/ZKJobTerminator.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/jobmaster/ZKJobTerminator.java
@@ -27,14 +27,14 @@ public class ZKJobTerminator implements IJobTerminator {
   }
 
   @Override
-  public boolean terminateJob(String jobName) {
+  public boolean terminateJob(String jobID) {
 
     boolean zkCleared = true;
 
     if (ZKContext.isZooKeeperServerUsed(config)) {
       CuratorFramework client = ZKUtils.connectToServer(ZKContext.serverAddresses(config));
       String rootPath = ZKContext.rootNode(config);
-      zkCleared = ZKUtils.deleteJobZNodes(client, rootPath, jobName);
+      zkCleared = ZKUtils.deleteJobZNodes(client, rootPath, jobID);
       ZKUtils.closeClient();
     }
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/rsched/DriverExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/rsched/DriverExample.java
@@ -41,7 +41,7 @@ public class  DriverExample implements IDriver {
 //    scalingExampleCLI(scaler);
     scalingExample(scaler, messenger);
     broadcastExample(messenger);
-    sendCompleteMessage(messenger);
+//    sendCompleteMessage(messenger);
 
     LOG.info("Driver has finished execution.");
   }

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/IJobTerminator.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/IJobTerminator.java
@@ -16,5 +16,5 @@ package edu.iu.dsc.tws.master;
  * It calls this method when all workers in a job sent COMPLETED message
  */
 public interface IJobTerminator {
-  boolean terminateJob(String jobName);
+  boolean terminateJob(String jobID);
 }

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/driver/Scaler.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/driver/Scaler.java
@@ -102,7 +102,7 @@ public class Scaler implements IScaler {
 
     boolean updatedJobInZK = updateJobInZK(0 - instancesToRemove);
     boolean checkZNodesDeleted =
-        zkJobUpdater.removeInitialStateZNodes(job.getJobName(), minID, maxID);
+        zkJobUpdater.removeInitialStateZNodes(job.getJobId(), minID, maxID);
 
     return updatedJobInZK && checkZNodesDeleted;
   }

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/driver/ZKJobUpdater.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/driver/ZKJobUpdater.java
@@ -59,7 +59,7 @@ public class ZKJobUpdater {
    * remove InitialState worker znodes after scaling down
    * @return
    */
-  public boolean removeInitialStateZNodes(String jobName, int minWorkerID, int maxWorkerID) {
+  public boolean removeInitialStateZNodes(String jobID, int minWorkerID, int maxWorkerID) {
 
     // if ZooKeeper server is not used, return. Nothing to be done.
     if (!ZKContext.isZooKeeperServerUsed(config)) {
@@ -70,8 +70,8 @@ public class ZKJobUpdater {
     String rootPath = ZKContext.rootNode(config);
     try {
       ZKPersStateManager.removeScaledDownZNodes(
-          client, rootPath, jobName, minWorkerID, maxWorkerID);
-      ZKBarrierManager.removeScaledDownZNodes(client, rootPath, jobName, minWorkerID, maxWorkerID);
+          client, rootPath, jobID, minWorkerID, maxWorkerID);
+      ZKBarrierManager.removeScaledDownZNodes(client, rootPath, jobID, minWorkerID, maxWorkerID);
 
       return true;
     } catch (Twister2Exception e) {

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/server/JobMaster.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/server/JobMaster.java
@@ -407,7 +407,7 @@ public class JobMaster {
     }
 
     if (jobTerminator != null) {
-      jobTerminator.terminateJob(job.getJobName());
+      jobTerminator.terminateJob(job.getJobId());
     }
 
     if (dashClient != null) {
@@ -481,7 +481,7 @@ public class JobMaster {
    */
   private void initZKMasterController(WorkerMonitor wMonitor) throws Twister2Exception {
     if (ZKContext.isZooKeeperServerUsed(config)) {
-      zkMasterController = new ZKMasterController(config, job.getJobName(),
+      zkMasterController = new ZKMasterController(config, job.getJobId(),
           job.getNumberOfWorkers(), jmAddress, workerMonitor);
 
       try {
@@ -559,7 +559,7 @@ public class JobMaster {
           looper.wakeup();
 
           if (jobTerminator != null) {
-            jobTerminator.terminateJob(job.getJobName());
+            jobTerminator.terminateJob(job.getJobId());
           }
         }
 

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/server/ZKMasterController.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/server/ZKMasterController.java
@@ -45,7 +45,7 @@ public class ZKMasterController {
 
   // number of workers in this job
   protected int numberOfWorkers;
-  protected String jobName;
+  protected String jobID;
 
   // config object
   protected Config config;
@@ -83,20 +83,20 @@ public class ZKMasterController {
   private WorkerMonitor workerMonitor;
 
   public ZKMasterController(Config config,
-                            String jobName,
+                            String jobID,
                             int numberOfWorkers,
                             String jmAddress,
                             WorkerMonitor workerMonitor) {
     this.config = config;
-    this.jobName = jobName;
+    this.jobID = jobID;
     this.numberOfWorkers = numberOfWorkers;
     this.jmAddress = jmAddress;
     this.workerMonitor = workerMonitor;
 
     rootPath = ZKContext.rootNode(config);
-    persDir = ZKUtils.persDir(rootPath, jobName);
-    ephemDir = ZKUtils.ephemDir(rootPath, jobName);
-    barrierDir = ZKUtils.barrierDir(rootPath, jobName);
+    persDir = ZKUtils.persDir(rootPath, jobID);
+    ephemDir = ZKUtils.ephemDir(rootPath, jobID);
+    barrierDir = ZKUtils.barrierDir(rootPath, jobID);
   }
 
   /**
@@ -203,7 +203,7 @@ public class ZKMasterController {
   private boolean allJoinedPublished() throws Exception {
 
     TreeMap<Integer, JobMasterAPI.JobEvent> events =
-        ZKEventsManager.getAllEvents(client, rootPath, jobName);
+        ZKEventsManager.getAllEvents(client, rootPath, jobID);
 
     for (JobMasterAPI.JobEvent event: events.values()) {
       // allJoined event with highest index, must have the same number of workers
@@ -245,7 +245,7 @@ public class ZKMasterController {
    * create ephemeral znode for the job master
    */
   private void createJMEphemZnode(JobMasterState initialState) {
-    String jmPath = ZKUtils.jmEphemPath(rootPath, jobName);
+    String jmPath = ZKUtils.jmEphemPath(rootPath, jobID);
 
     // put masterAddress and its state into znode body
     byte[] jmZnodeBody = ZKUtils.encodeJobMasterZnode(jmAddress, initialState.getNumber());
@@ -406,7 +406,7 @@ public class ZKMasterController {
         .setRestarted(workerRestarted)
         .build();
     try {
-      ZKEventsManager.publishEvent(client, rootPath, jobName, jobEvent);
+      ZKEventsManager.publishEvent(client, rootPath, jobID, jobEvent);
     } catch (Twister2Exception e) {
       LOG.log(Level.SEVERE, e.getMessage(), e);
     }
@@ -422,7 +422,7 @@ public class ZKMasterController {
         .build();
 
     try {
-      ZKEventsManager.publishEvent(client, rootPath, jobName, jobEvent);
+      ZKEventsManager.publishEvent(client, rootPath, jobID, jobEvent);
     } catch (Twister2Exception e) {
       LOG.log(Level.SEVERE, e.getMessage(), e);
     }
@@ -442,7 +442,7 @@ public class ZKMasterController {
         .setAllJoined(allWorkersJoined)
         .build();
     try {
-      ZKEventsManager.publishEvent(client, rootPath, jobName, jobEvent);
+      ZKEventsManager.publishEvent(client, rootPath, jobID, jobEvent);
     } catch (Twister2Exception e) {
       LOG.log(Level.SEVERE, e.getMessage(), e);
     }
@@ -459,7 +459,7 @@ public class ZKMasterController {
         .setJmRestarted(jmRestarted)
         .build();
     try {
-      ZKEventsManager.publishEvent(client, rootPath, jobName, jobEvent);
+      ZKEventsManager.publishEvent(client, rootPath, jobID, jobEvent);
     } catch (Twister2Exception e) {
       LOG.log(Level.SEVERE, e.getMessage(), e);
     }
@@ -493,7 +493,7 @@ public class ZKMasterController {
     WorkerWithState workerWithState;
     try {
       workerWithState =
-          ZKPersStateManager.getWorkerWithState(client, rootPath, jobName, removedWorkerID);
+          ZKPersStateManager.getWorkerWithState(client, rootPath, jobID, removedWorkerID);
       if (workerWithState == null) {
         LOG.severe("worker[" + removedWorkerID + "] removed, but its data can not be retrieved.");
         return;
@@ -532,7 +532,7 @@ public class ZKMasterController {
 
       try {
         ZKPersStateManager.updateWorkerStatus(
-            client, rootPath, jobName, workerWithState.getInfo(), JobMasterAPI.WorkerState.FAILED);
+            client, rootPath, jobID, workerWithState.getInfo(), JobMasterAPI.WorkerState.FAILED);
       } catch (Twister2Exception e) {
         LOG.log(Level.SEVERE, e.getMessage(), e);
       }
@@ -574,7 +574,7 @@ public class ZKMasterController {
           .setAllArrived(allArrived)
           .build();
       try {
-        ZKEventsManager.publishEvent(client, rootPath, jobName, jobEvent);
+        ZKEventsManager.publishEvent(client, rootPath, jobID, jobEvent);
       } catch (Twister2Exception e) {
         LOG.log(Level.SEVERE, e.getMessage(), e);
       }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/ResourceAllocator.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/ResourceAllocator.java
@@ -217,7 +217,7 @@ public class ResourceAllocator {
     updatedJob = JobAPI.Job.newBuilder(job).setJobFormat(format).build();
 
     // add job description file to the archive
-    String jobDescFileName = SchedulerContext.createJobDescriptionFileName(job.getJobName());
+    String jobDescFileName = SchedulerContext.createJobDescriptionFileName(job.getJobId());
     boolean added = packer.addFileToArchive(jobDescFileName, updatedJob.toByteArray());
     if (!added) {
       throw new RuntimeException("Failed to add the job description file to the archive: "
@@ -350,9 +350,9 @@ public class ResourceAllocator {
   /**
    * Terminate a job
    *
-   * @param jobName the name of the job to terminate
+   * @param jobID the name of the job to terminate
    */
-  public void terminateJob(String jobName, Config config) {
+  public void terminateJob(String jobID, Config config) {
 
     String launcherClass = SchedulerContext.launcherClass(config);
     if (launcherClass == null) {
@@ -371,7 +371,7 @@ public class ResourceAllocator {
 
     // initialize the launcher and terminate the job
     launcher.initialize(config);
-    boolean terminated = launcher.terminateJob(jobName);
+    boolean terminated = launcher.terminateJob(jobID);
     if (!terminated) {
       LOG.log(Level.SEVERE, "Could not terminate the job");
     }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/RuntimeManagerMain.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/RuntimeManagerMain.java
@@ -23,6 +23,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
 import edu.iu.dsc.tws.api.config.Config;
+import edu.iu.dsc.tws.api.config.Context;
 import edu.iu.dsc.tws.api.scheduler.SchedulerContext;
 import edu.iu.dsc.tws.common.config.ConfigLoader;
 
@@ -62,7 +63,7 @@ public final class RuntimeManagerMain {
       case "kill":
         // now load the correct class to terminate the job
         ResourceAllocator resourceAllocator = new ResourceAllocator();
-        resourceAllocator.terminateJob(SchedulerContext.jobName(cfg), cfg);
+        resourceAllocator.terminateJob(Context.jobId(cfg), cfg);
     }
   }
 
@@ -70,7 +71,7 @@ public final class RuntimeManagerMain {
     String twister2Home = cmd.getOptionValue("twister2_home");
     String configDir = cmd.getOptionValue("config_path");
     String cluster = cmd.getOptionValue("cluster");
-    String jobName = cmd.getOptionValue("job_name");
+    String jobID = cmd.getOptionValue("job_id");
     String command = cmd.getOptionValue("command");
 
     LOG.log(Level.INFO, String.format("Initializing process with "
@@ -79,11 +80,12 @@ public final class RuntimeManagerMain {
 
     Config config = ConfigLoader.loadConfig(twister2Home, configDir, cluster);
 
-    return Config.newBuilder().putAll(config).
-        put(SchedulerContext.TWISTER2_HOME.getKey(), twister2Home).
-        put(SchedulerContext.CONFIG_DIR, config).
-        put(SchedulerContext.JOB_NAME, jobName).
-        put(SchedulerContext.TWISTER2_CLUSTER_TYPE, cluster).build();
+    return Config.newBuilder()
+        .putAll(config)
+        .put(Context.TWISTER2_HOME.getKey(), twister2Home)
+        .put(SchedulerContext.CONFIG_DIR, configDir)
+        .put(Context.JOB_ID, jobID)
+        .put(Context.TWISTER2_CLUSTER_TYPE, cluster).build();
   }
 
   /**
@@ -126,18 +128,18 @@ public final class RuntimeManagerMain {
         .required()
         .build();
 
-    Option jobName = Option.builder("j")
-        .desc("Job name")
-        .longOpt("job_name")
+    Option jobID = Option.builder("j")
+        .desc("Job id")
+        .longOpt("job_id")
         .hasArgs()
-        .argName("job name")
+        .argName("job id")
         .required()
         .build();
     options.addOption(twister2Home);
     options.addOption(cluster);
     options.addOption(configDirectory);
     options.addOption(command);
-    options.addOption(jobName);
+    options.addOption(jobID);
 
     return options;
   }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/WorkerRuntime.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/WorkerRuntime.java
@@ -77,7 +77,7 @@ public final class WorkerRuntime {
     // get IWorkerController and IWorkerStatusUpdater through ZKWorkerController
     if (ZKContext.isZooKeeperServerUsed(config)) {
       zkWorkerController =
-          new ZKWorkerController(config, job.getJobName(), job.getNumberOfWorkers(), workerInfo);
+          new ZKWorkerController(config, job.getJobId(), job.getNumberOfWorkers(), workerInfo);
       try {
         zkWorkerController.initialize(initialState);
       } catch (Exception e) {

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/job/Twister2Submitter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/job/Twister2Submitter.java
@@ -26,6 +26,7 @@ import edu.iu.dsc.tws.common.config.ConfigSerializer;
 import edu.iu.dsc.tws.proto.system.job.JobAPI;
 import edu.iu.dsc.tws.rsched.core.ResourceAllocator;
 import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesConstants;
+import edu.iu.dsc.tws.rsched.utils.FileUtils;
 import edu.iu.dsc.tws.rsched.utils.JobUtils;
 
 public final class Twister2Submitter {
@@ -77,6 +78,14 @@ public final class Twister2Submitter {
     // update the config object with the values from job
     Config updatedConfig = JobUtils.updateConfigs(job, config);
     String jobId = job.getJobId();
+
+    // write jobID to file
+    String dir = System.getProperty("user.home") + "/.twister2";
+    if (!FileUtils.isDirectoryExists(dir)) {
+      FileUtils.createDirectory(dir);
+    }
+    String filename = dir + "/last-job-id.txt";
+    FileUtils.writeToFile(filename, (jobId + "").getBytes(), true);
 
     //print ascii
     LOG.info("\n\n _____           _     _           ____  \n"

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/job/Twister2Submitter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/job/Twister2Submitter.java
@@ -26,7 +26,6 @@ import edu.iu.dsc.tws.common.config.ConfigSerializer;
 import edu.iu.dsc.tws.proto.system.job.JobAPI;
 import edu.iu.dsc.tws.rsched.core.ResourceAllocator;
 import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesConstants;
-import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesUtils;
 import edu.iu.dsc.tws.rsched.utils.JobUtils;
 
 public final class Twister2Submitter {
@@ -51,7 +50,6 @@ public final class Twister2Submitter {
     if (!startingFromACheckpoint) {
       switch (Context.clusterType(config)) {
         case KubernetesConstants.KUBERNETES_CLUSTER_TYPE:
-          processJobNameForK8s(twister2Job);
           break;
         case "mesos":
         case "nomad":
@@ -64,7 +62,14 @@ public final class Twister2Submitter {
 
     // set jobID if it is set in configuration file,
     // otherwise it will be automatically generated
-    twister2Job.setJobID(config.getStringValue(Context.JOB_ID));
+    twister2Job.setJobID(Context.jobId(config));
+
+    // set username
+    String userName = Context.userName(config);
+    if (userName == null) {
+      userName = System.getProperty("user.name");
+    }
+    twister2Job.setUserName(userName);
 
     JobAPI.Job job = twister2Job.serialize();
     LOG.info("The job to be submitted: \n" + JobUtils.toString(job));
@@ -129,48 +134,10 @@ public final class Twister2Submitter {
   /**
    * terminate a Twister2 job
    */
-  @SuppressWarnings("ParameterAssignment")
-  public static void terminateJob(String jobName, Config config) {
-
-    // if this is a Kubernetes cluster, check the job name,
-    // if it does not conform to Kubernetes rules, change it
-    if (Context.clusterType(config).equals(KubernetesConstants.KUBERNETES_CLUSTER_TYPE)) {
-      if (!KubernetesUtils.jobNameConformsToK8sNamingRules(jobName)) {
-
-        LOG.info("JobName does not conform to Kubernetes naming rules: [" + jobName
-            + "] Only lower case alphanumeric characters and dash(-) are allowed.");
-
-        jobName = KubernetesUtils.convertJobNameToK8sFormat(jobName);
-
-        LOG.info("****************** JobName modified. Following jobname will be used: " + jobName);
-      }
-    }
-
+  public static void terminateJob(String jobID, Config config) {
     // launch the launcher
     ResourceAllocator resourceAllocator = new ResourceAllocator();
-    resourceAllocator.terminateJob(jobName, config);
-  }
-
-  /**
-   * write the values from Job object to config object
-   * only write the values that are initialized
-   */
-  public static void processJobNameForK8s(Twister2Job twister2Job) {
-
-    String jobName = twister2Job.getJobName();
-
-    // if it is a proper job name, return
-    if (KubernetesUtils.jobNameConformsToK8sNamingRules(jobName)) {
-      return;
-    }
-
-    LOG.info("JobName does not conform to Kubernetes naming rules: " + jobName
-        + " Only lower case alphanumeric characters and dashes(-) are allowed");
-
-    jobName = KubernetesUtils.convertJobNameToK8sFormat(jobName);
-    twister2Job.setJobName(jobName);
-
-    LOG.info("******************* JobName modified. Following jobname will be used: " + jobName);
+    resourceAllocator.terminateJob(jobID, config);
   }
 
 }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/aurora/AuroraLauncher.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/aurora/AuroraLauncher.java
@@ -95,14 +95,14 @@ public class AuroraLauncher implements ILauncher {
    * Terminate the Aurora Job
    */
   @Override
-  public boolean terminateJob(String jobName) {
+  public boolean terminateJob(String jobID) {
 
     //construct the controller to submit the job to Aurora Scheduler
     String cluster = AuroraContext.auroraClusterName(config);
     String role = AuroraContext.role(config);
     String env = AuroraContext.environment(config);
     AuroraClientController controller =
-        new AuroraClientController(cluster, role, env, jobName, true);
+        new AuroraClientController(cluster, role, env, jobID, true);
 
     boolean killedAuroraJob = controller.killJob();
     if (killedAuroraJob) {
@@ -112,7 +112,7 @@ public class AuroraLauncher implements ILauncher {
     }
 
     // first clear ZooKeeper data
-    boolean deletedZKNodes = ZKUtil.terminateJob(jobName, config);
+    boolean deletedZKNodes = ZKUtil.terminateJob(jobID, config);
 
     return killedAuroraJob && deletedZKNodes;
   }
@@ -126,7 +126,7 @@ public class AuroraLauncher implements ILauncher {
   public static Map<AuroraField, String> constructEnvVariables(Config config, JobAPI.Job job) {
 
     String jobName = SchedulerContext.jobName(config);
-    String jobDescriptionFile = SchedulerContext.createJobDescriptionFileName(jobName);
+    String jobDescriptionFile = SchedulerContext.createJobDescriptionFileName(job.getJobId());
     JobAPI.ComputeResource computeResource = job.getComputeResource(0);
 
     HashMap<AuroraField, String> envs = new HashMap<AuroraField, String>();

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/K8sEnvVariables.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/K8sEnvVariables.java
@@ -15,7 +15,7 @@ package edu.iu.dsc.tws.rsched.schedulers.k8s;
  * Environment variable names passed to worker pods
  */
 public enum K8sEnvVariables {
-  JOB_NAME,
+  JOB_ID,
   USER_JOB_JAR_FILE,    // java jar file for running user job
   JOB_PACKAGE_FILENAME,
   JOB_PACKAGE_FILE_SIZE, // file size of tar.gz file

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesConstants.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesConstants.java
@@ -19,13 +19,16 @@ public final class KubernetesConstants {
   public static final String POD_VOLATILE_VOLUME_NAME = "twister2-volatile-dir";
   public static final String POD_VOLATILE_VOLUME = "/twister2-volatile";
   public static final String CONTAINER_NAME_PREFIX = "twister2-container-";
-  public static final String TWISTER2_SERVICE_PREFIX = "t2-srv-";
-  public static final String SERVICE_LABEL_PREFIX = "t2-srv-lb-";
+
+  public static final String TWISTER2_SERVICE_PREFIX = "t2s-";
+  public static final String SERVICE_LABEL_PREFIX = "t2s-lb-";
+  public static final String TWISTER2_JOB_PODS_LABEL_PREFIX = "t2pod-lb-";
+  public static final String TWISTER2_STORAGE_CLAIM_PREFIX = "t2strg-";
+
   public static final String SERVICE_LABEL_KEY = "app";
   public static final String TWISTER2_JOB_PODS_KEY = "twister2-job-pods";
   public static final String TWISTER2_PODS_ROLE_KEY = "twister2-role";
-  public static final String TWISTER2_JOB_PODS_PREFIX = "twister2-";
-  public static final String TWISTER2_STORAGE_CLAIM_PREFIX = "twister2-storage-";
+
   public static final String PERSISTENT_VOLUME_NAME = "persistent-volume";
   public static final String PERSISTENT_VOLUME_MOUNT = "/persistent";
   public static final String SECRET_VOLUME_NAME = "kube-openmpi-ssh-key";

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesController.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesController.java
@@ -103,10 +103,10 @@ public class KubernetesController {
 
   /**
    * return the list of StatefulSet names that matches this jobs StatefulSet names for workers
-   * they must be in the form of "jobName-index"
+   * they must be in the form of "jobID-index"
    * otherwise return an empty ArrayList
    */
-  public ArrayList<String> getStatefulSetsForJobWorkers(String jobName) {
+  public ArrayList<String> getStatefulSetsForJobWorkers(String jobID) {
     V1StatefulSetList setList = null;
     try {
       setList = appsApi.listNamespacedStatefulSet(
@@ -120,7 +120,7 @@ public class KubernetesController {
 
     for (V1StatefulSet statefulSet : setList.getItems()) {
       String ssName = statefulSet.getMetadata().getName();
-      if (ssName.matches(jobName + "-" + "[0-9]+")) {
+      if (ssName.matches(jobID + "-" + "[0-9]+")) {
         ssNameList.add(ssName);
       }
     }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesUtils.java
@@ -67,100 +67,100 @@ public final class KubernetesUtils {
 
   /**
    * create service name from job name
-   * @param jobName
+   * @param jobID
    * @return
    */
-  public static String createServiceName(String jobName) {
-    return KubernetesConstants.TWISTER2_SERVICE_PREFIX + jobName;
+  public static String createServiceName(String jobID) {
+    return KubernetesConstants.TWISTER2_SERVICE_PREFIX + jobID;
   }
 
   /**
    * create service name from job name
-   * @param jobName
+   * @param jobID
    * @return
    */
-  public static String createJobMasterServiceName(String jobName) {
-    return KubernetesConstants.TWISTER2_SERVICE_PREFIX + jobName + "-jm";
+  public static String createJobMasterServiceName(String jobID) {
+    return KubernetesConstants.TWISTER2_SERVICE_PREFIX + jobID + "-jm";
   }
 
   /**
    * create persistent volume claim name name from the job name
-   * @param jobName
+   * @param jobID
    * @return
    */
-  public static String createPersistentVolumeClaimName(String jobName) {
-    return KubernetesConstants.TWISTER2_STORAGE_CLAIM_PREFIX + jobName;
+  public static String createPersistentVolumeClaimName(String jobID) {
+    return KubernetesConstants.TWISTER2_STORAGE_CLAIM_PREFIX + jobID;
   }
 
   /**
    * create storage claim name name from job name
-   * @param jobName
+   * @param jobID
    * @return
    */
-  public static String createPersistentVolumeName(String jobName) {
-    return "persistent-volume-" + jobName;
+  public static String createPersistentVolumeName(String jobID) {
+    return "persistent-volume-" + jobID;
   }
 
   /**
    * create service label from job name
    * this label is used when constructing statefulset
-   * @param jobName
+   * @param jobID
    * @return
    */
-  public static String createServiceLabel(String jobName) {
-    return KubernetesConstants.SERVICE_LABEL_PREFIX + jobName;
+  public static String createServiceLabel(String jobID) {
+    return KubernetesConstants.SERVICE_LABEL_PREFIX + jobID;
   }
 
   /**
    * create service label from job name
    * this label is used when constructing statefulset
-   * @param jobName
+   * @param jobID
    * @return
    */
-  public static String createJobMasterServiceLabel(String jobName) {
-    return KubernetesConstants.SERVICE_LABEL_PREFIX + jobName + "-jm";
+  public static String createJobMasterServiceLabel(String jobID) {
+    return KubernetesConstants.SERVICE_LABEL_PREFIX + jobID + "-jm";
   }
 
-  public static String createJobMasterRoleLabel(String jobName) {
-    return jobName + "-jm";
+  public static String createJobMasterRoleLabel(String jobID) {
+    return jobID + "-jm";
   }
 
-  public static String createWorkerRoleLabel(String jobName) {
-    return jobName + "-worker";
+  public static String createWorkerRoleLabel(String jobID) {
+    return jobID + "-worker";
   }
 
-  public static String createJobPodsLabel(String jobName) {
-    return KubernetesConstants.TWISTER2_JOB_PODS_LABEL_PREFIX + jobName;
+  public static String createJobPodsLabel(String jobID) {
+    return KubernetesConstants.TWISTER2_JOB_PODS_LABEL_PREFIX + jobID;
   }
 
   /**
    * this label is used when submitting queries to kubernetes master
-   * @param jobName
+   * @param jobID
    * @return
    */
-  public static String createServiceLabelWithKey(String jobName) {
-    return KubernetesConstants.SERVICE_LABEL_KEY + "=" + createServiceLabel(jobName);
+  public static String createServiceLabelWithKey(String jobID) {
+    return KubernetesConstants.SERVICE_LABEL_KEY + "=" + createServiceLabel(jobID);
   }
 
   /**
    * this label is used when submitting queries to kubernetes master
-   * @param jobName
+   * @param jobID
    * @return
    */
-  public static String createJobMasterServiceLabelWithKey(String jobName) {
-    return KubernetesConstants.SERVICE_LABEL_KEY + "=" + createJobMasterServiceLabel(jobName);
+  public static String createJobMasterServiceLabelWithKey(String jobID) {
+    return KubernetesConstants.SERVICE_LABEL_KEY + "=" + createJobMasterServiceLabel(jobID);
   }
 
-  public static String createJobPodsLabelWithKey(String jobName) {
-    return KubernetesConstants.TWISTER2_JOB_PODS_KEY + "=" + createJobPodsLabel(jobName);
+  public static String createJobPodsLabelWithKey(String jobID) {
+    return KubernetesConstants.TWISTER2_JOB_PODS_KEY + "=" + createJobPodsLabel(jobID);
   }
 
-  public static String createJobMasterRoleLabelWithKey(String jobName) {
-    return KubernetesConstants.TWISTER2_PODS_ROLE_KEY + "=" + createJobMasterRoleLabel(jobName);
+  public static String createJobMasterRoleLabelWithKey(String jobID) {
+    return KubernetesConstants.TWISTER2_PODS_ROLE_KEY + "=" + createJobMasterRoleLabel(jobID);
   }
 
-  public static String createWorkerRoleLabelWithKey(String jobName) {
-    return KubernetesConstants.TWISTER2_PODS_ROLE_KEY + "=" + createWorkerRoleLabel(jobName);
+  public static String createWorkerRoleLabelWithKey(String jobID) {
+    return KubernetesConstants.TWISTER2_PODS_ROLE_KEY + "=" + createWorkerRoleLabel(jobID);
   }
 
   /**
@@ -178,8 +178,8 @@ public final class KubernetesUtils {
    * add the given index a suffix to the job name
    * @return
    */
-  public static String createWorkersStatefulSetName(String jobName, int index) {
-    return jobName + "-" + index;
+  public static String createWorkersStatefulSetName(String jobID, int index) {
+    return jobID + "-" + index;
   }
 
   /**
@@ -187,8 +187,8 @@ public final class KubernetesUtils {
    * add a suffix to job name
    * @return
    */
-  public static String createJobMasterStatefulSetName(String jobName) {
-    return jobName + "-jm";
+  public static String createJobMasterStatefulSetName(String jobID) {
+    return jobID + "-jm";
   }
 
   /**
@@ -197,8 +197,8 @@ public final class KubernetesUtils {
    * we add a suffix to statefulset name
    * @return
    */
-  public static String createJobMasterPodName(String jobName) {
-    return createJobMasterStatefulSetName(jobName) + "-0";
+  public static String createJobMasterPodName(String jobID) {
+    return createJobMasterStatefulSetName(jobID) + "-0";
   }
 
   public static String getLocalAddress() {
@@ -252,7 +252,7 @@ public final class KubernetesUtils {
       int index = computeResource.getIndex();
 
       for (int j = 0; j < podsCount; j++) {
-        String ssName = KubernetesUtils.createWorkersStatefulSetName(job.getJobName(), index);
+        String ssName = KubernetesUtils.createWorkersStatefulSetName(job.getJobId(), index);
         String podName = KubernetesUtils.podNameFromStatefulSetName(ssName, j);
         podNames.add(podName);
       }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesUtils.java
@@ -26,6 +26,12 @@ public final class KubernetesUtils {
   private static final Logger LOG = Logger.getLogger(KubernetesUtils.class.getName());
 
   // max length for the user provided Twister2 job name
+  // statefulset pods has the following label
+  // controller-revision-hash=t2-job-sdf-123456789-123456789-123456789-1234-jm-f56767777
+  // label values can be at most 63 chars in length
+  // This label has the pod name and 10 char suffix as the value
+  // so, the pod name can be at most 52 chars, since jm pod name has a 3 char suffix
+  // jobNames can have at most 49 chars
   private static final int MAX_JOB_NAME_LENGTH = 49;
 
   private KubernetesUtils() {

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesUtils.java
@@ -26,7 +26,7 @@ public final class KubernetesUtils {
   private static final Logger LOG = Logger.getLogger(KubernetesUtils.class.getName());
 
   // max length for the user provided Twister2 job name
-  private static final int MAX_JOB_NAME_LENGTH = 45;
+  private static final int MAX_JOB_NAME_LENGTH = 49;
 
   private KubernetesUtils() {
   }
@@ -134,7 +134,7 @@ public final class KubernetesUtils {
   }
 
   public static String createJobPodsLabel(String jobName) {
-    return KubernetesConstants.TWISTER2_JOB_PODS_PREFIX + jobName;
+    return KubernetesConstants.TWISTER2_JOB_PODS_LABEL_PREFIX + jobName;
   }
 
   /**

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/PodWatchUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/PodWatchUtils.java
@@ -134,7 +134,7 @@ public final class PodWatchUtils {
    * mark each pod that reached to Running state in the given map
    */
   public static boolean watchPodsToRunning(String namespace,
-                                           String jobName,
+                                           String jobID,
                                            HashMap<String, Boolean> pods,
                                            int timeout) {
 
@@ -146,7 +146,7 @@ public final class PodWatchUtils {
     }
 
     String phase = "Running";
-    String serviceLabel = KubernetesUtils.createServiceLabelWithKey(jobName);
+    String serviceLabel = KubernetesUtils.createServiceLabelWithKey(jobID);
     Integer timeoutSeconds = timeout;
     Watch<V1Pod> watch = null;
 
@@ -159,7 +159,7 @@ public final class PodWatchUtils {
           }.getType());
 
     } catch (ApiException e) {
-      String logMessage = "Exception when watching the pods for the job: " + jobName + "\n"
+      String logMessage = "Exception when watching the pods for the job: " + jobID + "\n"
           + "exCode: " + e.getCode() + "\n"
           + "responseBody: " + e.getResponseBody();
       LOG.log(Level.SEVERE, logMessage, e);
@@ -211,7 +211,7 @@ public final class PodWatchUtils {
    * flag the pods with a true value in the given HashMap
    */
   public static boolean watchPodsToStarting(String namespace,
-                                            String jobName,
+                                            String jobID,
                                             HashMap<String, Boolean> pods,
                                             int timeout) {
 
@@ -222,7 +222,7 @@ public final class PodWatchUtils {
       createApiInstances();
     }
 
-    String workerRoleLabel = KubernetesUtils.createWorkerRoleLabelWithKey(jobName);
+    String workerRoleLabel = KubernetesUtils.createWorkerRoleLabelWithKey(jobID);
     String reason = "Started";
     Integer timeoutSeconds = timeout;
     Watch<V1Event> watch = null;
@@ -273,7 +273,7 @@ public final class PodWatchUtils {
    * @param namespace
    * @return
    */
-  public static String getNodeIP(String namespace, String jobName, String podIP) {
+  public static String getNodeIP(String namespace, String jobID, String podIP) {
 
     if (apiClient == null || coreApi == null) {
       createApiInstances();
@@ -281,7 +281,7 @@ public final class PodWatchUtils {
 
     // this is better but it does not work with another installation
 //    String podNameLabel = "statefulset.kubernetes.io/pod-name=" + podName;
-    String workerRoleLabel = KubernetesUtils.createWorkerRoleLabelWithKey(jobName);
+    String workerRoleLabel = KubernetesUtils.createWorkerRoleLabelWithKey(jobID);
 
     V1PodList podList = null;
     try {
@@ -332,14 +332,14 @@ public final class PodWatchUtils {
   /**
    * test watch pods method in the worker pod
    */
-  public static void testWatchPods(String namespace, String jobName, int timeout) {
+  public static void testWatchPods(String namespace, String jobID, int timeout) {
 
     if (apiClient == null || coreApi == null) {
       createApiInstances();
     }
 
-    String jobPodsLabel = KubernetesUtils.createJobPodsLabelWithKey(jobName);
-    LOG.info("Starting the watcher for: " + namespace + ", " + jobName);
+    String jobPodsLabel = KubernetesUtils.createJobPodsLabelWithKey(jobID);
+    LOG.info("Starting the watcher for: " + namespace + ", " + jobID);
     Integer timeoutSeconds = timeout;
     Watch<V1Pod> watch = null;
 
@@ -456,17 +456,17 @@ public final class PodWatchUtils {
    * we assume that the job master has the unique twister2-role label and value pair
    */
   public static String getJobMasterIpByWatchingPodToRunning(String namespace,
-                                                            String jobName,
+                                                            String jobID,
                                                             int timeout) {
 
     if (apiClient == null || coreApi == null) {
       createApiInstances();
     }
 
-    String jobMasterRoleLabel = KubernetesUtils.createJobMasterRoleLabelWithKey(jobName);
+    String jobMasterRoleLabel = KubernetesUtils.createJobMasterRoleLabelWithKey(jobID);
     String podPhase = "Running";
 
-    LOG.finest("Starting the watcher for the job master: " + namespace + ", " + jobName
+    LOG.finest("Starting the watcher for the job master: " + namespace + ", " + jobID
         + ", " + jobMasterRoleLabel);
     Integer timeoutSeconds = timeout;
     Watch<V1Pod> watch = null;
@@ -528,7 +528,7 @@ public final class PodWatchUtils {
    * return null, if it can not get the full list
    */
   public static ArrayList<String> getWorkerIPsByWatchingPodsToRunning(String namespace,
-                                                            String jobName,
+                                                            String jobID,
                                                             int numberOfPods,
                                                             int timeout) {
 
@@ -536,10 +536,10 @@ public final class PodWatchUtils {
       createApiInstances();
     }
 
-    String workerRoleLabel = KubernetesUtils.createWorkerRoleLabelWithKey(jobName);
+    String workerRoleLabel = KubernetesUtils.createWorkerRoleLabelWithKey(jobID);
     String podPhase = "Running";
 
-    LOG.finest("Starting the watcher for the worker pods: " + namespace + ", " + jobName
+    LOG.finest("Starting the watcher for the worker pods: " + namespace + ", " + jobID
         + ", " + workerRoleLabel);
     Integer timeoutSeconds = timeout;
     Watch<V1Pod> watch = null;

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/driver/K8sScaler.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/driver/K8sScaler.java
@@ -44,7 +44,7 @@ public class K8sScaler implements IScalerPerCluster {
     workersPerPod = scalableCompRes.getWorkersPerPod();
     scalable = scalableCompRes.getScalable();
     scalableSSName =
-        KubernetesUtils.createWorkersStatefulSetName(job.getJobName(), computeResourceIndex);
+        KubernetesUtils.createWorkersStatefulSetName(job.getJobId(), computeResourceIndex);
   }
 
   @Override

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/master/JobMasterRequestObject.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/master/JobMasterRequestObject.java
@@ -55,15 +55,15 @@ public final class JobMasterRequestObject {
   private static final Logger LOG = Logger.getLogger(JobMasterRequestObject.class.getName());
 
   private static Config config;
-  private static String jobName;
+  private static String jobID;
   private static String encodedNodeInfoList;
   private static long jobPackageFileSize;
 
   private JobMasterRequestObject() { }
 
-  public static void init(Config cnfg, String jName, long jpFileSize) {
+  public static void init(Config cnfg, String jID, long jpFileSize) {
     config = cnfg;
-    jobName = jName;
+    jobID = jID;
     jobPackageFileSize = jpFileSize;
   }
 
@@ -81,19 +81,19 @@ public final class JobMasterRequestObject {
 
     V1StatefulSet statefulSet = new V1StatefulSet();
 
-    // construct metadata and set for jobName setting
+    // construct metadata and set for jobID setting
     V1ObjectMeta meta = new V1ObjectMeta();
-    meta.setName(KubernetesUtils.createJobMasterStatefulSetName(jobName));
+    meta.setName(KubernetesUtils.createJobMasterStatefulSetName(jobID));
     statefulSet.setMetadata(meta);
 
     // construct JobSpec and set
     V1StatefulSetSpec setSpec = new V1StatefulSetSpec();
-    setSpec.serviceName(KubernetesUtils.createJobMasterServiceName(jobName));
+    setSpec.serviceName(KubernetesUtils.createJobMasterServiceName(jobID));
     setSpec.setReplicas(1);
 
     // add selector for the job
     V1LabelSelector selector = new V1LabelSelector();
-    String jobMasterServiceLabel = KubernetesUtils.createJobMasterServiceLabel(jobName);
+    String jobMasterServiceLabel = KubernetesUtils.createJobMasterServiceLabel(jobID);
     selector.putMatchLabelsItem(KubernetesConstants.SERVICE_LABEL_KEY, jobMasterServiceLabel);
     setSpec.setSelector(selector);
 
@@ -116,12 +116,12 @@ public final class JobMasterRequestObject {
     V1ObjectMeta templateMetaData = new V1ObjectMeta();
     HashMap<String, String> labels = new HashMap<String, String>();
     labels.put(KubernetesConstants.SERVICE_LABEL_KEY,
-        KubernetesUtils.createJobMasterServiceLabel(jobName));
+        KubernetesUtils.createJobMasterServiceLabel(jobID));
 
-    String jobPodsLabel = KubernetesUtils.createJobPodsLabel(jobName);
+    String jobPodsLabel = KubernetesUtils.createJobPodsLabel(jobID);
     labels.put(KubernetesConstants.TWISTER2_JOB_PODS_KEY, jobPodsLabel);
 
-    String jobMasterRoleLabel = KubernetesUtils.createJobMasterRoleLabel(jobName);
+    String jobMasterRoleLabel = KubernetesUtils.createJobMasterRoleLabel(jobID);
     labels.put(KubernetesConstants.TWISTER2_PODS_ROLE_KEY, jobMasterRoleLabel);
 
     templateMetaData.setLabels(labels);
@@ -147,7 +147,7 @@ public final class JobMasterRequestObject {
     }
 
     if (JobMasterContext.persistentVolumeRequested(config)) {
-      String claimName = KubernetesUtils.createPersistentVolumeClaimName(jobName);
+      String claimName = KubernetesUtils.createPersistentVolumeClaimName(jobID);
       V1Volume persistentVolume = RequestObjectBuilder.createPersistentVolume(claimName);
       volumes.add(persistentVolume);
     }
@@ -225,8 +225,8 @@ public final class JobMasterRequestObject {
     ArrayList<V1EnvVar> envVars = new ArrayList<>();
 
     envVars.add(new V1EnvVar()
-        .name(K8sEnvVariables.JOB_NAME + "")
-        .value(jobName));
+        .name(K8sEnvVariables.JOB_ID + "")
+        .value(jobID));
 
     envVars.add(new V1EnvVar()
         .name(K8sEnvVariables.ENCODED_NODE_INFO_LIST + "")
@@ -293,8 +293,8 @@ public final class JobMasterRequestObject {
    */
   public static V1Service createJobMasterServiceObject() {
 
-    String serviceName = KubernetesUtils.createJobMasterServiceName(jobName);
-    String serviceLabel = KubernetesUtils.createJobMasterServiceLabel(jobName);
+    String serviceName = KubernetesUtils.createJobMasterServiceName(jobID);
+    String serviceLabel = KubernetesUtils.createJobMasterServiceLabel(jobID);
 
     V1Service service = new V1Service();
     service.setKind("Service");
@@ -330,8 +330,8 @@ public final class JobMasterRequestObject {
    */
   public static V1Service createJobMasterHeadlessServiceObject() {
 
-    String serviceName = KubernetesUtils.createJobMasterServiceName(jobName);
-    String serviceLabel = KubernetesUtils.createJobMasterServiceLabel(jobName);
+    String serviceName = KubernetesUtils.createJobMasterServiceName(jobID);
+    String serviceLabel = KubernetesUtils.createJobMasterServiceLabel(jobID);
 
     V1Service service = new V1Service();
     service.setKind("Service");

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/master/JobMasterStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/master/JobMasterStarter.java
@@ -52,7 +52,7 @@ public final class JobMasterStarter {
     LoggingHelper.setLoggingFormat(LoggingHelper.DEFAULT_FORMAT);
 
     // get environment variables
-    String jobName = System.getenv(K8sEnvVariables.JOB_NAME + "");
+    String jobID = System.getenv(K8sEnvVariables.JOB_ID + "");
     String encodedNodeInfoList = System.getenv(K8sEnvVariables.ENCODED_NODE_INFO_LIST + "");
     String hostIP = System.getenv(K8sEnvVariables.HOST_IP + "");
 
@@ -62,7 +62,7 @@ public final class JobMasterStarter {
     Config config = K8sWorkerUtils.loadConfig(configDir);
 
     // read job description file
-    String jobDescFileName = SchedulerContext.createJobDescriptionFileName(jobName);
+    String jobDescFileName = SchedulerContext.createJobDescriptionFileName(jobID);
     jobDescFileName = POD_MEMORY_VOLUME + "/" + JOB_ARCHIVE_DIRECTORY + "/" + jobDescFileName;
     job = JobUtils.readJobFile(null, jobDescFileName);
     LOG.info("Job description file is loaded: " + jobDescFileName);
@@ -95,7 +95,7 @@ public final class JobMasterStarter {
 
     LOG.info("NodeInfo for JobMaster: " + nodeInfo);
 
-    JobMasterAPI.JobMasterState initialState = initialStateAndUpdate(config, jobName, podIP);
+    JobMasterAPI.JobMasterState initialState = initialStateAndUpdate(config, jobID, podIP);
 
     JobTerminator jobTerminator = new JobTerminator(config);
     KubernetesController controller = new KubernetesController();
@@ -128,7 +128,7 @@ public final class JobMasterStarter {
    * @return
    */
   public static JobMasterAPI.JobMasterState initialStateAndUpdate(Config config,
-                                                                  String jobName,
+                                                                  String jobID,
                                                                   String jmAddress) {
 
     if (ZKContext.isZooKeeperServerUsed(config)) {
@@ -138,9 +138,9 @@ public final class JobMasterStarter {
       String rootPath = ZKContext.rootNode(config);
 
       try {
-        if (ZKPersStateManager.initJobMasterPersState(client, rootPath, jobName, jmAddress)) {
-          ZKEventsManager.initEventCounter(client, rootPath, jobName);
-          job = ZKPersStateManager.readJobZNode(client, rootPath, jobName);
+        if (ZKPersStateManager.initJobMasterPersState(client, rootPath, jobID, jmAddress)) {
+          ZKEventsManager.initEventCounter(client, rootPath, jobID);
+          job = ZKPersStateManager.readJobZNode(client, rootPath, jobID);
           return JobMasterAPI.JobMasterState.JM_RESTARTED;
         }
 

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/mpi/MPIMasterStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/mpi/MPIMasterStarter.java
@@ -52,7 +52,7 @@ public final class MPIMasterStarter {
 
   private static final String HOSTFILE_NAME = "hostfile";
   private static Config config = null;
-  private static String jobName = null;
+  private static String jobID = null;
 
   private MPIMasterStarter() {
   }
@@ -66,9 +66,9 @@ public final class MPIMasterStarter {
     String encodedNodeInfoList = System.getenv(K8sEnvVariables.ENCODED_NODE_INFO_LIST + "");
     String podName = System.getenv(K8sEnvVariables.POD_NAME + "");
 
-    jobName = System.getenv(K8sEnvVariables.JOB_NAME + "");
-    if (jobName == null) {
-      throw new RuntimeException("JobName is null");
+    jobID = System.getenv(K8sEnvVariables.JOB_ID + "");
+    if (jobID == null) {
+      throw new RuntimeException("JobID is null");
     }
 
     String configDir = POD_MEMORY_VOLUME + "/" + JOB_ARCHIVE_DIRECTORY;
@@ -79,7 +79,7 @@ public final class MPIMasterStarter {
     K8sWorkerUtils.initLogger(config, "mpiMaster");
 
     // read job description file
-    String jobDescFileName = SchedulerContext.createJobDescriptionFileName(jobName);
+    String jobDescFileName = SchedulerContext.createJobDescriptionFileName(jobID);
     jobDescFileName = POD_MEMORY_VOLUME + "/" + JOB_ARCHIVE_DIRECTORY + "/" + jobDescFileName;
     JobAPI.Job job = JobUtils.readJobFile(null, jobDescFileName);
     LOG.info("Job description file is loaded: " + jobDescFileName);
@@ -108,7 +108,7 @@ public final class MPIMasterStarter {
     LOG.info("MPIMaster information summary: \n"
         + "podName: " + podName + "\n"
         + "podIP: " + podIP + "\n"
-        + "jobName: " + jobName + "\n"
+        + "jobID: " + jobID + "\n"
         + "namespace: " + namespace + "\n"
         + "numberOfWorkers: " + job.getNumberOfWorkers() + "\n"
         + "numberOfPods: " + numberOfPods
@@ -119,7 +119,7 @@ public final class MPIMasterStarter {
 
     if (!JobMasterContext.jobMasterRunsInClient(config)) {
       jobMasterIP = PodWatchUtils.getJobMasterIpByWatchingPodToRunning(
-          namespace, jobName, timeoutSeconds);
+          namespace, jobID, timeoutSeconds);
 
       if (jobMasterIP == null) {
         LOG.severe("Could not get job master IP by wathing job master pod to running. Aborting. "
@@ -130,7 +130,7 @@ public final class MPIMasterStarter {
     LOG.info("Job Master IP address: " + jobMasterIP);
 
     ArrayList<String> podIPs = PodWatchUtils.getWorkerIPsByWatchingPodsToRunning(
-        namespace, jobName, numberOfPods, timeoutSeconds);
+        namespace, jobID, numberOfPods, timeoutSeconds);
 
     if (podIPs == null) {
       LOG.severe("Could not get IPs of all pods running. Aborting. "
@@ -232,7 +232,7 @@ public final class MPIMasterStarter {
             "-cp", System.getenv("CLASSPATH"),
             className,
             jobMasterCLArgument,
-            jobName,
+            jobID,
             "'" + encodedNodeInfoList + "'"
         };
   }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/mpi/MPIWorkerStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/mpi/MPIWorkerStarter.java
@@ -26,6 +26,7 @@ import edu.iu.dsc.tws.api.resource.IWorkerStatusUpdater;
 import edu.iu.dsc.tws.api.scheduler.SchedulerContext;
 import edu.iu.dsc.tws.common.logging.LoggingHelper;
 import edu.iu.dsc.tws.common.util.ReflectionUtils;
+import edu.iu.dsc.tws.master.JobMasterContext;
 import edu.iu.dsc.tws.proto.jobmaster.JobMasterAPI;
 import edu.iu.dsc.tws.proto.system.job.JobAPI;
 import edu.iu.dsc.tws.proto.utils.NodeInfoUtils;
@@ -115,6 +116,13 @@ public final class MPIWorkerStarter {
     // job file configurations will override
     config = JobUtils.overrideConfigs(job, config);
     config = JobUtils.updateConfigs(job, config);
+
+    // update jobMasterIP
+    // update config with jobMasterIP
+    config = Config.newBuilder()
+        .putAll(config)
+        .put(JobMasterContext.JOB_MASTER_IP, jobMasterIP)
+        .build();
 
     InetAddress localHost = null;
     String podName = null;

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/uploader/JobPackageTransferThread.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/uploader/JobPackageTransferThread.java
@@ -245,7 +245,7 @@ public class JobPackageTransferThread extends Thread {
 
     ArrayList<String> podNames = KubernetesUtils.generatePodNames(job);
     // add job master pod name
-    podNames.add(KubernetesUtils.createJobMasterPodName(job.getJobName()));
+    podNames.add(KubernetesUtils.createJobMasterPodName(job.getJobId()));
 
     transferThreads = new JobPackageTransferThread[podNames.size()];
 

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/uploader/UploaderForJob.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/uploader/UploaderForJob.java
@@ -63,7 +63,7 @@ public class UploaderForJob extends Thread {
   private Config config;
   private String namespace;
   private JobAPI.Job job;
-  private String jobName;
+  private String jobID;
   private String jobPackageFile;
 
   private ArrayList<String> podNames;
@@ -81,13 +81,13 @@ public class UploaderForJob extends Thread {
     this.config = config;
     this.namespace = KubernetesContext.namespace(config);
     this.job = job;
-    this.jobName = job.getJobName();
+    this.jobID = job.getJobId();
     this.jobPackageFile = jobPackageFile;
 
     podNames = KubernetesUtils.generatePodNames(job);
     // add job master pod name
     if (!JobMasterContext.jobMasterRunsInClient(config)) {
-      podNames.add(KubernetesUtils.createJobMasterPodName(job.getJobName()));
+      podNames.add(KubernetesUtils.createJobMasterPodName(job.getJobId()));
     }
   }
 
@@ -117,7 +117,7 @@ public class UploaderForJob extends Thread {
     /** Pod Phases: Pending, Running, Succeeded, Failed, Unknown
      * ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase */
 
-    String jobPodsLabel = KubernetesUtils.createJobPodsLabelWithKey(jobName);
+    String jobPodsLabel = KubernetesUtils.createJobPodsLabelWithKey(jobID);
 
     Integer timeoutSeconds = Integer.MAX_VALUE;
     String podPhase = "Running";
@@ -150,7 +150,7 @@ public class UploaderForJob extends Thread {
         }
 
         if (item.object != null
-            && item.object.getMetadata().getName().startsWith(jobName)
+            && item.object.getMetadata().getName().startsWith(jobID)
             && podPhase.equals(item.object.getStatus().getPhase())
         ) {
           String podName = item.object.getMetadata().getName();

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sVolatileVolume.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sVolatileVolume.java
@@ -21,8 +21,8 @@ public class K8sVolatileVolume implements IVolatileVolume {
   private String workerDirPath;
   private File workerDir;
 
-  public K8sVolatileVolume(String jobName, int workerID) {
-    workerDirPath = KubernetesConstants.POD_VOLATILE_VOLUME + "/" + jobName + "/worker-" + workerID;
+  public K8sVolatileVolume(String jobID, int workerID) {
+    workerDirPath = KubernetesConstants.POD_VOLATILE_VOLUME + "/" + jobID + "/worker-" + workerID;
     workerDir = new File(workerDirPath);
   }
 

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerUtils.java
@@ -212,8 +212,8 @@ public final class K8sWorkerUtils {
   /**
    * get job master service IP from job master service name
    */
-  public static String getJobMasterServiceIP(String namespace, String jobName) {
-    String jobMasterServiceName = KubernetesUtils.createJobMasterServiceName(jobName);
+  public static String getJobMasterServiceIP(String namespace, String jobID) {
+    String jobMasterServiceName = KubernetesUtils.createJobMasterServiceName(jobID);
     jobMasterServiceName = jobMasterServiceName + "." + namespace + ".svc.cluster.local";
     try {
       return InetAddress.getByName(jobMasterServiceName).getHostAddress();
@@ -268,7 +268,7 @@ public final class K8sWorkerUtils {
    * @return
    */
   public static JobMasterAPI.WorkerState initialStateAndUpdate(Config cnfg,
-                                                               String jbName,
+                                                               String jbID,
                                                                JobMasterAPI.WorkerInfo wInfo) {
 
     if (ZKContext.isZooKeeperServerUsed(cnfg)) {
@@ -278,7 +278,7 @@ public final class K8sWorkerUtils {
       String rootPath = ZKContext.rootNode(cnfg);
 
       try {
-        if (ZKPersStateManager.initWorkerPersState(client, rootPath, jbName, wInfo)) {
+        if (ZKPersStateManager.initWorkerPersState(client, rootPath, jbID, wInfo)) {
           return JobMasterAPI.WorkerState.RESTARTED;
         }
 

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/mesos/MesosDockerWorker.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/mesos/MesosDockerWorker.java
@@ -94,7 +94,7 @@ public class MesosDockerWorker {
       LOG.severe("Error " + e.getMessage());
     }
     //find the jobmaster
-    ZKJobMasterFinder finder = new ZKJobMasterFinder(config);
+    ZKJobMasterFinder finder = new ZKJobMasterFinder(config, job.getJobId());
     finder.initialize();
 
     String jobMasterIPandPort = finder.getJobMasterIPandPort();

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/mesos/MesosJobTerminator.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/mesos/MesosJobTerminator.java
@@ -15,7 +15,7 @@ import edu.iu.dsc.tws.master.IJobTerminator;
 
 public class MesosJobTerminator implements IJobTerminator {
   @Override
-  public boolean terminateJob(String jobName) {
+  public boolean terminateJob(String jobID) {
     return false;
   }
 }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/mesos/MesosLauncher.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/mesos/MesosLauncher.java
@@ -50,7 +50,7 @@ public class MesosLauncher implements ILauncher {
   }
 
   @Override
-  public boolean terminateJob(String jobName) {
+  public boolean terminateJob(String jobID) {
     //Protos.Status status = driver.stop();
     boolean status;
     if (driver == null) {

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/mesos/master/JobTerminator.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/mesos/master/JobTerminator.java
@@ -29,7 +29,7 @@ public class JobTerminator implements IJobTerminator {
   }
   @Override
   //mesos needs frameworkd Id to kill it
-  public boolean terminateJob(String jobName) {
+  public boolean terminateJob(String jobID) {
 
 //    MesosController.schedulerDriver.killTask(Protos.TaskID.newBuilder()
 //        .setValue(Integer.toString(2)).build());

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/mesos/master/MesosJobMasterStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/mesos/master/MesosJobMasterStarter.java
@@ -99,7 +99,7 @@ public final class MesosJobMasterStarter {
     ZKJobMasterRegistrar registrar = null;
     try {
       registrar = new ZKJobMasterRegistrar(config,
-          Inet4Address.getLocalHost().getHostAddress(), 11011);
+          Inet4Address.getLocalHost().getHostAddress(), 11011, job.getJobId());
       LOG.info("JobMaster REGISTERED..:" + Inet4Address.getLocalHost().getHostAddress());
     } catch (UnknownHostException e) {
       LOG.info("JobMaster CAN NOT BE REGISTERED:");

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/nomad/NomadJobMasterStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/nomad/NomadJobMasterStarter.java
@@ -234,7 +234,7 @@ public final class NomadJobMasterStarter {
     }
     try {
       registrar = new ZKJobMasterRegistrar(config,
-          hostAddress, port);
+          hostAddress, port, job.getJobId());
       LOG.info("JobMaster REGISTERED..:" + hostAddress);
     } catch (Exception e) {
       LOG.info("JobMaster CAN NOT BE REGISTERED:");

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/nomad/NomadLauncher.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/nomad/NomadLauncher.java
@@ -41,7 +41,7 @@ public class NomadLauncher implements ILauncher {
   }
 
   @Override
-  public boolean terminateJob(String jobName) {
+  public boolean terminateJob(String jobID) {
     LOG.log(Level.INFO, "Terminating job for cluster: ",
         NomadContext.clusterType(config));
 
@@ -54,8 +54,8 @@ public class NomadLauncher implements ILauncher {
     IController controller = new NomadController(true);
     controller.initialize(newConfig);
 
-    jobWorkingDirectory = Paths.get(jobWorkingDirectory, jobName).toAbsolutePath().toString();
-    String jobDescFile = JobUtils.getJobDescriptionFilePath(jobWorkingDirectory, jobName, config);
+    jobWorkingDirectory = Paths.get(jobWorkingDirectory, jobID).toAbsolutePath().toString();
+    String jobDescFile = JobUtils.getJobDescriptionFilePath(jobWorkingDirectory, jobID, config);
     JobAPI.Job job = JobUtils.readJobFile(null, jobDescFile);
 
     return controller.kill(job);

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/nomad/NomadTerminator.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/nomad/NomadTerminator.java
@@ -15,7 +15,7 @@ import edu.iu.dsc.tws.master.IJobTerminator;
 
 public class NomadTerminator implements IJobTerminator {
   @Override
-  public boolean terminateJob(String jobName) {
+  public boolean terminateJob(String jobID) {
     return false;
   }
 }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/nomad/NomadWorkerStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/nomad/NomadWorkerStarter.java
@@ -264,7 +264,7 @@ public final class NomadWorkerStarter {
 
     //find the jobmaster
     if (!JobMasterContext.jobMasterRunsInClient(config)) {
-      ZKJobMasterFinder finder = new ZKJobMasterFinder(config);
+      ZKJobMasterFinder finder = new ZKJobMasterFinder(config, job.getJobId());
       finder.initialize();
 
       String jobMasterIPandPort = finder.getJobMasterIPandPort();

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPILauncher.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPILauncher.java
@@ -66,7 +66,7 @@ public class MPILauncher implements ILauncher {
   }
 
   @Override
-  public boolean terminateJob(String jobName) {
+  public boolean terminateJob(String jobID) {
     // not implemented yet
     return false;
   }

--- a/twister2/tools/cli/src/python/args.py
+++ b/twister2/tools/cli/src/python/args.py
@@ -80,8 +80,8 @@ def add_job(parser):
     :return:
     '''
     parser.add_argument(
-        'job-name',
-        help='Name of the job')
+        'job-id',
+        help='ID of the job')
     return parser
 
 

--- a/twister2/tools/cli/src/python/cli_helper.py
+++ b/twister2/tools/cli/src/python/cli_helper.py
@@ -33,7 +33,7 @@ def create_parser(subparsers, action, help_arg):
     parser = subparsers.add_parser(
         action,
         help=help_arg,
-        usage="%(prog)s [options] cluster <job-name>",
+        usage="%(prog)s [options] cluster <job-id>",
         add_help=True)
 
     args.add_titles(parser)
@@ -57,13 +57,13 @@ def run(command, cl_args, action, extra_args=[], extra_lib_jars=[]):
     :param action:        description of action taken
     :return:
     '''
-    job_name = cl_args['job-name']
+    job_id = cl_args['job-id']
 
     new_args = [
         "--cluster", cl_args['cluster'],
         "--twister2_home", config.get_twister2_dir(),
         "--config_path", config.get_twister2_conf_dir(),
-        "--job_name", job_name,
+        "--job_id", job_id,
         "--command", command,
     ]
     new_args += extra_args
@@ -87,7 +87,7 @@ def run(command, cl_args, action, extra_args=[], extra_lib_jars=[]):
         java_defines=java_defines
     )
 
-    err_msg = "Failed to %s %s" % (action, job_name)
-    succ_msg = "Successfully %s %s" % (action, job_name)
+    err_msg = "Failed to %s %s" % (action, job_id)
+    succ_msg = "Successfully %s %s" % (action, job_id)
     result.add_context(err_msg, succ_msg)
     return result


### PR DESCRIPTION
jobID is in the form of: $user.name-$jobName-$timestamp
max jobID length is 49 chars. 
first 30 characters of jobName is used, if jobName is longer.
jobID is generated when the job object is serialized after twister2Job.serialize().
jobID is integral part of JobAPI.Job object. 
jobID is written to the file $HOME/.twister2/last-job-id.txt when a job is submitted. When killing jobs, this file can be used. 

When killing jobs, now jobID is used. 
I have modified cli.helper.py and args.py files. @chathurawidanage could you check those? I replaced job-name with job-id in those files. 
I replaced all jobName usage in Kubernetes implementation with jobID. 
@gurhangunduz Could you replace jobName usage in mesos and nomad with jobID?
