### PR TITLE
Removing redundant sort boolean flag from keyed operations

### DIFF
--- a/twister2/comms/src/java/edu/iu/dsc/tws/comms/batch/BKeyedGather.java
+++ b/twister2/comms/src/java/edu/iu/dsc/tws/comms/batch/BKeyedGather.java
@@ -126,9 +126,6 @@ public class BKeyedGather extends BaseOperation {
                       Comparator<Object> comparator,
                       boolean groupByKey, int edgeId, MessageSchema messageSchema) {
     super(comm, false, CommunicationContext.KEYED_GATHER);
-    if (useDisk && comparator == null) {
-      throw new RuntimeException("Key comparator should be specified in disk based mode");
-    }
     this.keyType = kType;
     this.dataType = dType;
 

--- a/twister2/comms/src/java/edu/iu/dsc/tws/comms/batch/BKeyedGather.java
+++ b/twister2/comms/src/java/edu/iu/dsc/tws/comms/batch/BKeyedGather.java
@@ -136,11 +136,11 @@ public class BKeyedGather extends BaseOperation {
     MessageReceiver finalReceiver;
     MessageReceiver partialReceiver = new PartitionPartialReceiver();
     if (!useDisk) {
-      finalReceiver = new KGatherBatchFinalReceiver(rcvr, groupByKey);
+      finalReceiver = new KGatherBatchFinalReceiver(rcvr, groupByKey, comparator);
     } else {
       receiveDataType = MessageTypes.BYTE_ARRAY;
       finalReceiver = new DPartitionBatchFinalReceiver(
-          rcvr, true, comm.getPersistentDirectories(), comparator, groupByKey);
+          rcvr, comm.getPersistentDirectories(), comparator, groupByKey);
     }
 
     if (CommunicationContext.ALLTOALL_ALGO_SIMPLE.equals(

--- a/twister2/comms/src/java/edu/iu/dsc/tws/comms/batch/BPartition.java
+++ b/twister2/comms/src/java/edu/iu/dsc/tws/comms/batch/BPartition.java
@@ -62,7 +62,7 @@ public class BPartition extends BaseOperation {
     MessageReceiver finalRcvr;
     if (shuffle) {
       finalRcvr = new DPartitionBatchFinalReceiver(
-          rcvr, false, shuffleDirs, null, true);
+          rcvr, shuffleDirs, null, true);
     } else {
       finalRcvr = new PartitionBatchFinalReceiver(rcvr);
     }

--- a/twister2/comms/src/java/edu/iu/dsc/tws/comms/dfw/io/gather/keyed/KGatherBatchFinalReceiver.java
+++ b/twister2/comms/src/java/edu/iu/dsc/tws/comms/dfw/io/gather/keyed/KGatherBatchFinalReceiver.java
@@ -12,6 +12,7 @@
 package edu.iu.dsc.tws.comms.dfw.io.gather.keyed;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -28,7 +29,9 @@ import edu.iu.dsc.tws.comms.dfw.io.TargetFinalReceiver;
 
 import edu.iu.dsc.tws.comms.utils.THashMap;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
 
 /**
  * Final receiver for keyed gather
@@ -43,13 +46,33 @@ public class KGatherBatchFinalReceiver extends TargetFinalReceiver {
   /**
    * The reduced values for each target and key
    */
-  protected Int2ObjectOpenHashMap<Map<Object, List<Object>>> gathered =
-      new Int2ObjectOpenHashMap<>();
+  protected Int2ObjectMap<Map<Object, List<Object>>> gathered;
 
+  /**
+   * Create a receiver without sorting
+   * @param receiver  the receiver
+   * @param groupByKey weather to group return values according to key
+   */
   public KGatherBatchFinalReceiver(BulkReceiver receiver,
                                    boolean groupByKey) {
+    this(receiver, groupByKey, null);
+  }
+
+  /**
+   * Create a receiver with sorting
+   * @param receiver  the receiver
+   * @param groupByKey weather to group return values according to key
+   */
+  public KGatherBatchFinalReceiver(BulkReceiver receiver,
+                                   boolean groupByKey,
+                                   Comparator<Object> keyComparator) {
     this.bulkReceiver = receiver;
     this.groupByKey = groupByKey;
+    if (keyComparator != null) {
+      this.gathered = new Int2ObjectRBTreeMap<>(keyComparator);
+    } else {
+      this.gathered = new Int2ObjectOpenHashMap<>();
+    }
   }
 
   @Override

--- a/twister2/comms/src/java/edu/iu/dsc/tws/comms/dfw/io/gather/keyed/KGatherBatchFinalReceiver.java
+++ b/twister2/comms/src/java/edu/iu/dsc/tws/comms/dfw/io/gather/keyed/KGatherBatchFinalReceiver.java
@@ -31,7 +31,6 @@ import edu.iu.dsc.tws.comms.utils.THashMap;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
 
 /**
  * Final receiver for keyed gather
@@ -68,11 +67,7 @@ public class KGatherBatchFinalReceiver extends TargetFinalReceiver {
                                    Comparator<Object> keyComparator) {
     this.bulkReceiver = receiver;
     this.groupByKey = groupByKey;
-    if (keyComparator != null) {
-      this.gathered = new Int2ObjectRBTreeMap<>(keyComparator);
-    } else {
-      this.gathered = new Int2ObjectOpenHashMap<>();
-    }
+    this.gathered = new Int2ObjectOpenHashMap<>();
   }
 
   @Override

--- a/twister2/comms/src/java/edu/iu/dsc/tws/comms/dfw/io/join/DJoinBatchFinalReceiver2.java
+++ b/twister2/comms/src/java/edu/iu/dsc/tws/comms/dfw/io/join/DJoinBatchFinalReceiver2.java
@@ -64,9 +64,9 @@ public class DJoinBatchFinalReceiver2 implements MessageReceiver {
     this.bulkReceiver = bulkReceiver;
     this.joinType = joinType;
     this.leftReceiver = new DPartitionBatchFinalReceiver(new InnerBulkReceiver(0),
-        true, shuffleDirs, com, false);
+        shuffleDirs, com, false);
     this.rightReceiver = new DPartitionBatchFinalReceiver(new InnerBulkReceiver(1),
-        true, shuffleDirs, com, false);
+        shuffleDirs, com, false);
     this.leftValues = new HashMap<>();
     this.rightValues = new HashMap<>();
     this.comparator = new KeyComparatorWrapper(com);

--- a/twister2/comms/src/java/edu/iu/dsc/tws/comms/dfw/io/partition/DPartitionBatchFinalReceiver.java
+++ b/twister2/comms/src/java/edu/iu/dsc/tws/comms/dfw/io/partition/DPartitionBatchFinalReceiver.java
@@ -57,11 +57,6 @@ public class DPartitionBatchFinalReceiver implements MessageReceiver {
   private Int2ObjectOpenHashMap<Shuffle> sortedMergers = new Int2ObjectOpenHashMap<>();
 
   /**
-   * weather we need to sort the records according to key
-   */
-  private boolean sorted;
-
-  /**
    * Comparator for sorting records
    */
   private Comparator<Object> comparator;
@@ -134,12 +129,11 @@ public class DPartitionBatchFinalReceiver implements MessageReceiver {
    */
   private boolean complete = false;
 
-  public DPartitionBatchFinalReceiver(BulkReceiver receiver, boolean srt,
+  public DPartitionBatchFinalReceiver(BulkReceiver receiver,
                                       List<String> shuffleDirs,
                                       Comparator<Object> com,
                                       boolean groupByKey) {
     this.bulkReceiver = receiver;
-    this.sorted = srt;
     this.comparator = com;
     this.shuffleDirectories = shuffleDirs;
     this.groupByKey = groupByKey;
@@ -181,7 +175,7 @@ public class DPartitionBatchFinalReceiver implements MessageReceiver {
         sortedMerger = new FSMerger(maxBytesInMemory, maxRecordsInMemory, shuffleDirectory,
             DFWIOUtils.getOperationName(target, partition, refresh), partition.getDataType());
       } else {
-        if (sorted) {
+        if (comparator != null) {
           sortedMerger = new FSKeyedSortedMerger2(maxBytesInMemory, maxFileSize,
               shuffleDirectory, DFWIOUtils.getOperationName(target, partition, refresh),
               partition.getKeyType(), partition.getDataType(), comparator, target,

--- a/twister2/comms/src/java/edu/iu/dsc/tws/comms/shuffle/FSKeyedMerger.java
+++ b/twister2/comms/src/java/edu/iu/dsc/tws/comms/shuffle/FSKeyedMerger.java
@@ -30,10 +30,9 @@ import edu.iu.dsc.tws.api.util.KryoSerializer;
 /**
  * Un sorted merger
  *
- * @deprecated This merger can't output data in the expected format Iterator<Tuple<Key,Iterator>>
+ * This merger can't output data in the expected format Iterator<Tuple<Key,Iterator>>
  */
 @SuppressWarnings({"unchecked", "rawtypes"})
-@Deprecated
 public class FSKeyedMerger implements Shuffle {
   private static final Logger LOG = Logger.getLogger(FSKeyedMerger.class.getName());
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/batch/terasort/TeraSort.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/batch/terasort/TeraSort.java
@@ -197,7 +197,7 @@ public class TeraSort implements IWorker {
         .withKeyType(MessageTypes.BYTE_ARRAY)
         .withTaskPartitioner(taskPartitioner)
         .useDisk(true)
-        .sortBatchByKey(true, ByteArrayComparator.getInstance())
+        .sortBatchByKey(ByteArrayComparator.getInstance())
         .groupBatchByKey(false);
 
     if (config.getBooleanValue(ARG_FIXED_SCHEMA, false)) {

--- a/twister2/task/src/main/java/edu/iu/dsc/tws/task/impl/ops/KeyedGatherConfig.java
+++ b/twister2/task/src/main/java/edu/iu/dsc/tws/task/impl/ops/KeyedGatherConfig.java
@@ -22,26 +22,22 @@ public class KeyedGatherConfig extends AbstractKeyedOpsConfig<KeyedGatherConfig>
 
   private Comparator keyCompartor;
   private boolean grpByKey = true;
-  private boolean srtByKey;
 
   public KeyedGatherConfig(String parent,
                            ComputeConnection computeConnection) {
     super(parent, OperationNames.KEYED_GATHER, computeConnection);
   }
 
-  public <T> KeyedGatherConfig sortBatchByKey(boolean sortByKey,
-                                              Comparator<T> keyComparator) {
-    this.srtByKey = sortByKey;
+  public <T> KeyedGatherConfig sortBatchByKey(Comparator<T> keyComparator) {
     this.keyCompartor = keyComparator;
-    return this.withProperty(CommunicationContext.SORT_BY_KEY, sortByKey)
+    return this.withProperty(CommunicationContext.SORT_BY_KEY, keyComparator != null)
         .withProperty(CommunicationContext.KEY_COMPARATOR, keyComparator);
   }
 
-  public <T> KeyedGatherConfig sortBatchByKey(boolean sortByKey, Class<T> tClass,
+  public <T> KeyedGatherConfig sortBatchByKey(Class<T> tClass,
                                               Comparator<T> keyComparator) {
-    this.srtByKey = sortByKey;
     this.keyCompartor = keyComparator;
-    return this.withProperty(CommunicationContext.SORT_BY_KEY, sortByKey)
+    return this.withProperty(CommunicationContext.SORT_BY_KEY, keyComparator != null)
         .withProperty(CommunicationContext.KEY_COMPARATOR, keyComparator);
   }
 
@@ -52,10 +48,6 @@ public class KeyedGatherConfig extends AbstractKeyedOpsConfig<KeyedGatherConfig>
 
   @Override
   void validate() {
-    if (this.srtByKey && this.keyCompartor == null) {
-      failValidation("KeyedGather operation configured to sort by key. "
-          + "But Key Comparator is not specified.");
-    }
   }
 
   @Override
@@ -64,7 +56,7 @@ public class KeyedGatherConfig extends AbstractKeyedOpsConfig<KeyedGatherConfig>
       newEdge.addProperty(CommunicationContext.KEY_COMPARATOR, this.keyCompartor);
     }
 
-    newEdge.addProperty(CommunicationContext.SORT_BY_KEY, this.srtByKey);
+    newEdge.addProperty(CommunicationContext.SORT_BY_KEY, keyCompartor != null);
     newEdge.addProperty(CommunicationContext.GROUP_BY_KEY, this.grpByKey);
 
     return newEdge;

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/HashingPartitioner.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/HashingPartitioner.java
@@ -32,7 +32,7 @@ public class HashingPartitioner<T> implements PartitionFunc<T> {
   @Override
   public int partition(int sourceIndex, T val) {
     List<Integer> destinations = destination.get(sourceIndex);
-    int next = val.hashCode() % destinations.size();
+    int next = Math.abs(val.hashCode()) % destinations.size();
     return destinations.get(next);
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedGatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedGatherTLink.java
@@ -26,17 +26,17 @@ public class KeyedGatherTLink<K, V> extends KeyedGatherUngroupedTLink<K, Iterato
   }
 
   public KeyedGatherTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism) {
-    this(tSetEnv, null, sourceParallelism, false, null);
+    this(tSetEnv, null, sourceParallelism, null);
   }
 
   public KeyedGatherTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<K> partitionFn,
                           int sourceParallelism) {
-    this(tSetEnv, partitionFn, sourceParallelism, false, null);
+    this(tSetEnv, partitionFn, sourceParallelism, null);
   }
 
   public KeyedGatherTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<K> partitionFn,
-                          int sourceParallelism, boolean sortByKey, Comparator<K> keyCompartor) {
-    super(tSetEnv, partitionFn, sourceParallelism, sortByKey, keyCompartor);
+                          int sourceParallelism, Comparator<K> keyCompartor) {
+    super(tSetEnv, partitionFn, sourceParallelism, keyCompartor);
     this.enableGroupByKey();
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedGatherUngroupedTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedGatherUngroupedTLink.java
@@ -27,30 +27,24 @@ public class KeyedGatherUngroupedTLink<K, V> extends KeyedBatchIteratorLinkWrapp
   private PartitionFunc<K> partitionFunction;
   private Comparator<K> keyCompartor;
 
-  private boolean sortByKey;
   private boolean groupByKey = false;
 
   private boolean useDisk = false;
 
   public KeyedGatherUngroupedTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism) {
-    this(tSetEnv, null, sourceParallelism, false, null);
+    this(tSetEnv, null, sourceParallelism, null);
   }
 
   public KeyedGatherUngroupedTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<K> partitionFn,
                                    int sourceParallelism) {
-    this(tSetEnv, partitionFn, sourceParallelism, false, null);
+    this(tSetEnv, partitionFn, sourceParallelism, null);
   }
 
   public KeyedGatherUngroupedTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<K> partitionFn,
-                                   int sourceParallelism, boolean sortByKey,
-                                   Comparator<K> keyCompartor) {
+                                   int sourceParallelism, Comparator<K> keyCompartor) {
     super(tSetEnv, "kgather", sourceParallelism);
     this.partitionFunction = partitionFn;
-    this.sortByKey = sortByKey;
     this.keyCompartor = keyCompartor;
-    if (sortByKey && keyCompartor == null) {
-      LOG.warning("Key comparator cannot be null when sorting is true");
-    }
   }
 
   public KeyedGatherUngroupedTLink() {
@@ -63,7 +57,7 @@ public class KeyedGatherUngroupedTLink<K, V> extends KeyedBatchIteratorLinkWrapp
     Edge e = new Edge(getId(), OperationNames.KEYED_GATHER, getMessageType());
     e.setKeyed(true);
     e.setPartitioner(partitionFunction);
-    e.addProperty(CommunicationContext.SORT_BY_KEY, this.sortByKey);
+    e.addProperty(CommunicationContext.SORT_BY_KEY, this.keyCompartor != null);
     e.addProperty(CommunicationContext.GROUP_BY_KEY, this.groupByKey);
 
     if (this.keyCompartor != null) {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/BatchTupleTSetImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/BatchTupleTSetImpl.java
@@ -93,7 +93,7 @@ public abstract class BatchTupleTSetImpl<K, V> extends BaseTSet<V> implements Ba
   public KeyedGatherTLink<K, V> keyedGather(PartitionFunc<K> partitionFn,
                                             Comparator<K> comparator) {
     KeyedGatherTLink<K, V> gather = new KeyedGatherTLink<>(getTSetEnv(),
-        partitionFn, getParallelism(), true, comparator);
+        partitionFn, getParallelism(), comparator);
     addChildToGraph(gather);
     return gather;
   }
@@ -118,7 +118,7 @@ public abstract class BatchTupleTSetImpl<K, V> extends BaseTSet<V> implements Ba
   public KeyedGatherUngroupedTLink<K, V> keyedGatherUngrouped(PartitionFunc<K> partitionFn,
                                                               Comparator<K> comparator) {
     KeyedGatherUngroupedTLink<K, V> gather = new KeyedGatherUngroupedTLink<>(getTSetEnv(),
-        partitionFn, getParallelism(), true, comparator);
+        partitionFn, getParallelism(), comparator);
     addChildToGraph(gather);
     return gather;
   }


### PR DESCRIPTION
We can only use the comparator as an indicator for sorting. All the java APIs follow the same.