### PR TITLE
fixed a bug in Job Master for publishing allWorkersJoined event to Driver

### DIFF
--- a/twister2/common/src/java/edu/iu/dsc/tws/common/net/tcp/request/RRServer.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/net/tcp/request/RRServer.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -153,6 +154,10 @@ public class RRServer {
 
     // after sometime we need to stop
     stop();
+  }
+
+  public Set<Integer> getConnectedWorkers() {
+    return workerChannels.values();
   }
 
   /**

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/server/JobMaster.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/server/JobMaster.java
@@ -457,6 +457,8 @@ public class JobMaster {
 
     // if all workers already joined, publish that event to the driver
     // this usually happens when jm restarted
+    // since now we require all workers to be both joined and connected,
+    // this should not be an issue, but i am not %100 sure. so keeping it.
     // TODO: make sure driver thread started before publishing this event
     //       as a temporary solution, wait 50 ms before starting new thread
     if (workerMonitor.isAllJoined()) {

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/server/WorkerMonitor.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/server/WorkerMonitor.java
@@ -76,6 +76,13 @@ public class WorkerMonitor implements MessageHandler {
   // a flag to show whether all expected workers has already joined
   private boolean allJoined = false;
 
+  // a flag to show whether AllJoined event published to the driver
+  // it is published when the driver exists, all workers joined and all workers connected
+  // it is initially false and becomes true after it is published
+  // it also becomes false after scaling up and becomes true
+  // when AllJoined event published to the driver again
+  private boolean publishedAllJoinedToDriver = false;
+
   /**
    * numberOfWorkers in the job is tracked by this variable
    * all other classes in job master should get the upto-date numberOfWorkers from this variable
@@ -204,7 +211,7 @@ public class WorkerMonitor implements MessageHandler {
       return failMessage;
     }
 
-      // if it is a regular join event
+    // if it is a regular join event
     // add the worker to worker list
     workers.put(workerWithState.getWorkerID(), workerWithState);
     LOG.info("Worker: " + workerWithState.getWorkerID() + " joined the job.");
@@ -242,7 +249,7 @@ public class WorkerMonitor implements MessageHandler {
     }
 
     // if this is not a fault tolerant job, we terminate the job with failure
-    // because, this worker has failed previously failed and it is coming from failure
+    // because, this worker has failed previously and it is coming from failure
     if (!faultTolerant) {
       jobState = JobState.FAILED;
       String failMessage =
@@ -269,15 +276,16 @@ public class WorkerMonitor implements MessageHandler {
     return null;
   }
 
+  /**
+   * handle allJoined after started and restarted events
+   */
   private void handleAllJoined() {
 
     if (!allJoined && allWorkersJoined()) {
       allJoined = true;
 
-      // inform Driver if exist
-      if (driver != null) {
-        driver.allWorkersJoined(getWorkerInfoList());
-      }
+      // inform Driver if exist and allConnected
+      informDriverForAllJoined();
 
       // if the job is becoming all joined for the first time, inform dashboard
       if (jobState == JobState.STARTING) {
@@ -287,7 +295,6 @@ public class WorkerMonitor implements MessageHandler {
           dashClient.jobStateChange(JobState.STARTED);
         }
       }
-
     }
   }
 
@@ -378,12 +385,14 @@ public class WorkerMonitor implements MessageHandler {
   public void workersScaledUp(int instancesAdded) {
 
     allJoined = false;
+    publishedAllJoinedToDriver = false;
 
     // keep previous numberOfWorkers and update numberOfWorkers with new value
     numberOfWorkers += instancesAdded;
     if (jobMaster.getZkMasterController() != null) {
       jobMaster.getZkMasterController().jobScaledUp(numberOfWorkers);
-    } else if (jobMaster.getWorkerHandler() != null) {
+    }
+    if (jobMaster.getWorkerHandler() != null) {
       jobMaster.getWorkerHandler().workersScaledUp(instancesAdded);
     }
 
@@ -399,9 +408,7 @@ public class WorkerMonitor implements MessageHandler {
         jobMaster.getWorkerHandler().sendWorkersJoinedMessage();
       }
 
-      if (driver != null) {
-        driver.allWorkersJoined(getWorkerInfoList());
-      }
+      informDriverForAllJoined();
     }
 
     // send Scaled message to the dashboard
@@ -415,7 +422,7 @@ public class WorkerMonitor implements MessageHandler {
    * returns true if allJoined becomes true
    */
   public boolean addJoinedWorkers(List<WorkerWithState> joinedWorkers) {
-    for (WorkerWithState wws: joinedWorkers) {
+    for (WorkerWithState wws : joinedWorkers) {
       workers.put(wws.getWorkerID(), wws);
     }
 
@@ -434,10 +441,12 @@ public class WorkerMonitor implements MessageHandler {
    * inform the driver on restarts if all workers already joined
    */
   public void informDriverForAllJoined() {
-    if (allJoined) {
-      if (driver != null) {
-        driver.allWorkersJoined(getWorkerInfoList());
-      }
+    if (allJoined
+        && driver != null
+        && !publishedAllJoinedToDriver
+        && jobMaster.getWorkerHandler().isAllConnected()) {
+      driver.allWorkersJoined(getWorkerInfoList());
+      publishedAllJoinedToDriver = true;
     }
   }
 


### PR DESCRIPTION
published allWorkersJoined event to Driver after all workers joined and connected to JobMaster.
Before it was publishing allWorkersJoined event when all workers joined the job through zookeeper without waiting all workers to be connected to JobMaster. Now, it waits for all workers to connect to JobMaster before publishing allWorkersJoined event to Driver. 