### PR TITLE
performance improvement for k8s

### DIFF
--- a/twister2/proto/jobmaster.proto
+++ b/twister2/proto/jobmaster.proto
@@ -175,10 +175,7 @@ message ListWorkersRequest {
 
 // Job master returns the list of workers in a job to a worker
 message ListWorkersResponse {
-
-    oneof required {
-        int32 workerID = 1;
-    }
+    int32 numberOfWorkers = 1;
     repeated WorkerInfo worker = 2;
 }
 

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerStarter.java
@@ -33,7 +33,7 @@ import edu.iu.dsc.tws.rsched.core.WorkerRuntime;
 import edu.iu.dsc.tws.rsched.schedulers.k8s.K8sEnvVariables;
 import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesConstants;
 import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesContext;
-import edu.iu.dsc.tws.rsched.schedulers.k8s.PodWatchUtils;
+import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesUtils;
 import edu.iu.dsc.tws.rsched.utils.JobUtils;
 import edu.iu.dsc.tws.rsched.worker.WorkerManager;
 import static edu.iu.dsc.tws.api.config.Context.JOB_ARCHIVE_DIRECTORY;
@@ -194,8 +194,9 @@ public final class K8sWorkerStarter {
 
       // get job master service ip from job master service name and use it as Job master IP
     } else {
-      jobMasterIP = PodWatchUtils.getJobMasterIpByWatchingPodToRunning(
-          KubernetesContext.namespace(config), jobID, 100);
+      jobMasterIP = KubernetesUtils.createJobMasterServiceName(jobID);
+//      jobMasterIP = PodWatchUtils.getJobMasterIpByWatchingPodToRunning(
+//          KubernetesContext.namespace(config), jobID, 100);
       if (jobMasterIP == null) {
         throw new RuntimeException("Job master is running in a separate pod, but "
             + "this worker can not get the job master IP address from Kubernetes master.\n"

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerStarter.java
@@ -194,8 +194,8 @@ public final class K8sWorkerStarter {
 
       // get job master service ip from job master service name and use it as Job master IP
     } else {
-      jobMasterIP = K8sWorkerUtils.getJobMasterServiceIP(
-          KubernetesContext.namespace(config), jobID);
+      jobMasterIP = K8sWorkerUtils.getJobMasterServiceIPByPolling(
+          KubernetesContext.namespace(config), jobID, 500);
 
       // if it can not get jm ip by using service name
       // get it by watching jm pod

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerStarter.java
@@ -195,7 +195,7 @@ public final class K8sWorkerStarter {
       // get job master service ip from job master service name and use it as Job master IP
     } else {
       jobMasterIP = K8sWorkerUtils.getJobMasterServiceIPByPolling(
-          KubernetesContext.namespace(config), jobID, 500);
+          KubernetesContext.namespace(config), jobID, 50);
 
       // if it can not get jm ip by using service name
       // get it by watching jm pod

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerUtils.java
@@ -227,11 +227,12 @@ public final class K8sWorkerUtils {
    * get job master service IP from job master service name
    * poll repeatedly until getting it or times out
    */
-  public static String getJobMasterServiceIPByPolling(String namespace, String jobID) {
+  public static String getJobMasterServiceIPByPolling(String namespace,
+                                                      String jobID,
+                                                      long timeLimitMS) {
     String jmServiceName = KubernetesUtils.createJobMasterServiceName(jobID);
     jmServiceName = jmServiceName + "." + namespace + ".svc.cluster.local";
 
-    long timeLimit = 100000; // 100sec
     long sleepInterval = 100;
 
     long startTime = System.currentTimeMillis();
@@ -241,14 +242,14 @@ public final class K8sWorkerUtils {
     long logInterval = 1000;
     long nextLogTime = logInterval;
 
-    while (duration < timeLimit) {
+    while (duration < timeLimitMS) {
 
       // try getting job master IP address
       try {
         InetAddress jmAddress = InetAddress.getByName(jmServiceName);
         return jmAddress.getHostAddress();
       } catch (UnknownHostException e) {
-        LOG.warning("Cannot get Job master IP from service name.");
+        LOG.fine("Cannot get Job master IP from service name.");
       }
 
       try {

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerUtils.java
@@ -218,8 +218,57 @@ public final class K8sWorkerUtils {
     try {
       return InetAddress.getByName(jobMasterServiceName).getHostAddress();
     } catch (UnknownHostException e) {
-      throw new RuntimeException("Cannot get Job master IP from service name.", e);
+      LOG.info("Cannot get Job master IP from service name: " + jobMasterServiceName);
+      return null;
     }
+  }
+
+  /**
+   * get job master service IP from job master service name
+   * poll repeatedly until getting it or times out
+   */
+  public static String getJobMasterServiceIPByPolling(String namespace, String jobID) {
+    String jmServiceName = KubernetesUtils.createJobMasterServiceName(jobID);
+    jmServiceName = jmServiceName + "." + namespace + ".svc.cluster.local";
+
+    long timeLimit = 100000; // 100sec
+    long sleepInterval = 100;
+
+    long startTime = System.currentTimeMillis();
+    long duration = 0;
+
+    // log interval in milliseconds
+    long logInterval = 1000;
+    long nextLogTime = logInterval;
+
+    while (duration < timeLimit) {
+
+      // try getting job master IP address
+      try {
+        InetAddress jmAddress = InetAddress.getByName(jmServiceName);
+        return jmAddress.getHostAddress();
+      } catch (UnknownHostException e) {
+        LOG.warning("Cannot get Job master IP from service name.");
+      }
+
+      try {
+        Thread.sleep(sleepInterval);
+      } catch (InterruptedException e) {
+        LOG.warning("Sleep interrupted.");
+      }
+
+      // increase sleep interval by 10 in every iteration
+      sleepInterval += 10;
+
+      duration = System.currentTimeMillis() - startTime;
+
+      if (duration > nextLogTime) {
+        LOG.info("Still trying to get Job Master IP address for the service:  " + jmServiceName);
+        nextLogTime += logInterval;
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerUtils.java
@@ -249,7 +249,7 @@ public final class K8sWorkerUtils {
         InetAddress jmAddress = InetAddress.getByName(jmServiceName);
         return jmAddress.getHostAddress();
       } catch (UnknownHostException e) {
-        LOG.fine("Cannot get Job master IP from service name.");
+        LOG.info("Cannot get Job master IP from service name.");
       }
 
       try {

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/worker/WorkerManager.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/worker/WorkerManager.java
@@ -118,7 +118,7 @@ public class WorkerManager implements IManagedFailureListener, IAllJoinedListene
     this.maxRetries = SchedulerContext.failureRetries(config, 3);
 
     WorkerRuntime.addWorkerFailureListener(this);
-    WorkerRuntime.addAllJoinedListener(this);
+//    WorkerRuntime.addAllJoinedListener(this);
     this.workerStatus = WorkerStatus.RUNNING;
   }
 


### PR DESCRIPTION
Job Master IP discovery improved. 
First, a dns based query is used, if it is unsuccessful, pod watching is used. 
Performance of listWorkers message improved when all workers joined. 
The same list is sent to all waitList. 