### PR TITLE
moved zk initialization and cleanup from KubernetesLauncher to JobMaster

### DIFF
--- a/twister2/common/src/java/edu/iu/dsc/tws/common/zk/ZKEventsManager.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/zk/ZKEventsManager.java
@@ -94,8 +94,12 @@ public final class ZKEventsManager {
           .withMode(CreateMode.PERSISTENT)
           .forPath(eventPath, jobEvent.toByteArray());
 
-      LOG.info("JobEvent published: " + jobEvent);
-
+      if (jobEvent.hasAllJoined()) {
+        LOG.info("AllJoined JobEvent published. Number of workers: "
+            + jobEvent.getAllJoined().getNumberOfWorkers());
+      } else {
+        LOG.info("JobEvent published: " + jobEvent);
+      }
     } catch (Exception e) {
       throw new Twister2Exception("JobEvent can not be created for the path: "
           + eventPath, e);

--- a/twister2/config/src/yaml/conf/kubernetes/core.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/core.yaml
@@ -50,9 +50,6 @@ twister2.job.master.cpu: 0.2
 # default value is 1024 MB
 twister2.job.master.ram: 1024
 
-# the number of http connections from job master to Twister2 Dashboard
-twister2.job.master.to.dashboard.connections: 3
-
 ###################################################################################
 # WorkerController related config parameters
 ###################################################################################
@@ -68,6 +65,11 @@ twister2.worker.controller.max.wait.time.on.barrier: 100000
 ###################################################################
 # Dashboard related settings
 ###################################################################
+
+# the number of http connections from job master to Twister2 Dashboard
+# default value is 3
+# for jobs with large number of workers, this can be set to higher number
+# twister2.job.master.to.dashboard.connections: 3
 
 # Dashboard server host address and port
 # if this parameter is not specified, then job master will not try to connect to Dashboard

--- a/twister2/config/src/yaml/conf/kubernetes/resource.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/resource.yaml
@@ -101,6 +101,9 @@ twister2.zookeeper.based.group.management: false
 
 # ZooKeeper server addresses: comma separated host:port pairs
 # example: "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002"
+# when conf/kubernetes/deployment/zookeeper-wo-persistence.yaml is used
+# following service name can be used as zk address
+# twister2.resource.zookeeper.server.addresses: "twister2-zookeeper.default.svc.cluster.local:2181"
 twister2.resource.zookeeper.server.addresses: "ip:port"
 
 # the root node path of this job on ZooKeeper

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/JobSubmissionStatus.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/JobSubmissionStatus.java
@@ -18,7 +18,6 @@ public class JobSubmissionStatus {
   private boolean serviceForJobMasterCreated;
   private boolean pvcCreated;
   private ArrayList<String> createdStatefulSetNames = new ArrayList<>();
-  private boolean jobZNodesCreated;
 
   public JobSubmissionStatus() { }
 
@@ -32,10 +31,6 @@ public class JobSubmissionStatus {
 
   public boolean isPvcCreated() {
     return pvcCreated;
-  }
-
-  public boolean isJobZNodesCreated() {
-    return jobZNodesCreated;
   }
 
   public ArrayList<String> getCreatedStatefulSetNames() {
@@ -56,10 +51,6 @@ public class JobSubmissionStatus {
 
   public void setPvcCreated(boolean pvcCreated) {
     this.pvcCreated = pvcCreated;
-  }
-
-  public void setJobZNodesCreated(boolean jobZNodesCreated) {
-    this.jobZNodesCreated = jobZNodesCreated;
   }
 
 }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesController.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesController.java
@@ -269,10 +269,10 @@ public class KubernetesController {
   }
 
   /**
-   * return true if one of the services exist in Kubernetes master,
-   * otherwise return false
+   * return existing service name if one of the services exist in Kubernetes master,
+   * otherwise return null
    */
-  public boolean existServices(List<String> serviceNames) {
+  public String existServices(List<String> serviceNames) {
 // sending the request with label does not work for list services call
 //    String label = "app=" + serviceLabel;
     V1ServiceList serviceList = null;
@@ -286,12 +286,11 @@ public class KubernetesController {
 
     for (V1Service service : serviceList.getItems()) {
       if (serviceNames.contains(service.getMetadata().getName())) {
-        LOG.severe("There is already a service with the name: " + service.getMetadata().getName());
-        return true;
+        return service.getMetadata().getName();
       }
     }
 
-    return false;
+    return null;
   }
 
   /**
@@ -435,7 +434,7 @@ public class KubernetesController {
       } else {
 
         if (response.code() == 404 && response.message().equals("Not Found")) {
-          LOG.log(Level.WARNING, "There is no PersistentVolumeClaim [" + pvcName
+          LOG.log(Level.FINE, "There is no PersistentVolumeClaim [" + pvcName
               + "] to delete on Kubernetes master. It may have already been deleted.");
           return true;
         }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/master/JobTerminator.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/master/JobTerminator.java
@@ -13,11 +13,7 @@ package edu.iu.dsc.tws.rsched.schedulers.k8s.master;
 
 import java.util.ArrayList;
 
-import org.apache.curator.framework.CuratorFramework;
-
 import edu.iu.dsc.tws.api.config.Config;
-import edu.iu.dsc.tws.common.zk.ZKContext;
-import edu.iu.dsc.tws.common.zk.ZKUtils;
 import edu.iu.dsc.tws.master.IJobTerminator;
 import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesContext;
 import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesController;
@@ -54,14 +50,6 @@ public class JobTerminator implements IJobTerminator {
     String pvcName = KubernetesUtils.createPersistentVolumeClaimName(jobID);
     boolean pvcDeleted = controller.deletePersistentVolumeClaim(pvcName);
 
-    boolean zkCleared = true;
-    if (ZKContext.isZooKeeperServerUsed(config)) {
-      CuratorFramework client = ZKUtils.connectToServer(ZKContext.serverAddresses(config));
-      String rootPath = ZKContext.rootNode(config);
-      zkCleared = ZKUtils.deleteJobZNodes(client, rootPath, jobID);
-      ZKUtils.closeClient();
-    }
-
     // delete the job master StatefulSet
     String jobMasterStatefulSetName = KubernetesUtils.createJobMasterStatefulSetName(jobID);
     boolean ssForJobMasterDeleted =
@@ -75,7 +63,6 @@ public class JobTerminator implements IJobTerminator {
         && serviceForWorkersDeleted
         && serviceForJobMasterDeleted
         && pvcDeleted
-        && ssForJobMasterDeleted
-        && zkCleared;
+        && ssForJobMasterDeleted;
   }
 }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerStarter.java
@@ -194,8 +194,8 @@ public final class K8sWorkerStarter {
 
       // get job master service ip from job master service name and use it as Job master IP
     } else {
-      jobMasterIP = K8sWorkerUtils.getJobMasterServiceIPByPolling(
-          KubernetesContext.namespace(config), jobID, 50);
+      jobMasterIP = K8sWorkerUtils.getJobMasterServiceIP(
+          KubernetesContext.namespace(config), jobID);
 
       // if it can not get jm ip by using service name
       // get it by watching jm pod

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerUtils.java
@@ -248,7 +248,7 @@ public final class K8sWorkerUtils {
         InetAddress jmAddress = InetAddress.getByName(jmServiceName);
         return jmAddress.getHostAddress();
       } catch (UnknownHostException e) {
-        LOG.info("Cannot get Job master IP from service name.");
+        LOG.fine("Cannot get Job master IP from service name.");
       }
 
       try {

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/worker/K8sWorkerUtils.java
@@ -42,7 +42,6 @@ import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesConstants;
 import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesContext;
 import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesUtils;
 import edu.iu.dsc.tws.rsched.utils.JobUtils;
-
 import static edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesConstants.KUBERNETES_CLUSTER_TYPE;
 
 public final class K8sWorkerUtils {
@@ -328,8 +327,12 @@ public final class K8sWorkerUtils {
       String rootPath = ZKContext.rootNode(cnfg);
 
       try {
-        if (ZKPersStateManager.initWorkerPersState(client, rootPath, jbID, wInfo)) {
+        if (ZKPersStateManager.isWorkerRestarting(client, rootPath, jbID, wInfo)) {
           return JobMasterAPI.WorkerState.RESTARTED;
+        }
+
+        if (ZKPersStateManager.checkPersDirWaitIfNeeded(client, rootPath, jbID)) {
+          ZKPersStateManager.createWorkerPersState(client, rootPath, jbID, wInfo);
         }
 
         return JobMasterAPI.WorkerState.STARTED;


### PR DESCRIPTION
Twister2 client may not be able to access ZK server when it runs in the cluster. So, it is more robust if JobMaster performs initialization and cleanup in ZK server. 