### PR TITLE
Adding data types to tsets and links - v2 

### DIFF
--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/TSetConstants.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/TSetConstants.java
@@ -1,0 +1,21 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package edu.iu.dsc.tws.api.tset;
+
+public final class TSetConstants {
+  private TSetConstants() {
+  }
+
+  public static final String INPUT_SCHEMA_KEY = "__input_schema";
+  public static final String OUTPUT_SCHEMA_KEY = "__output_schema";
+}

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/TSetContext.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/TSetContext.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import edu.iu.dsc.tws.api.compute.TaskContext;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.dataset.DataPartition;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 
 /**
  * This is the runtime context for a {@link edu.iu.dsc.tws.api.tset.sets.TSet}. This
@@ -70,6 +71,10 @@ public class TSetContext implements Serializable {
    * Configuration
    */
   private Config config;
+
+  private transient Schema inSchema;
+
+  private transient Schema outSchema;
 
   /**
    * Creates and empty TSet Context
@@ -192,6 +197,24 @@ public class TSetContext implements Serializable {
   }
 
   /**
+   * Returns the input schema of the {@link edu.iu.dsc.tws.api.tset.sets.TSet}
+   *
+   * @return input schema
+   */
+  public Schema getInputSchema() {
+    return inSchema;
+  }
+
+  /**
+   * Returns the output schema of the {@link edu.iu.dsc.tws.api.tset.sets.TSet}
+   *
+   * @return output schema
+   */
+  public Schema getOutputSchema() {
+    return outSchema;
+  }
+
+  /**
    * Adds a input object into the map
    *
    * @param key  the key to be associated with the input object
@@ -256,6 +279,8 @@ public class TSetContext implements Serializable {
     setConfig(conf);
     settSetIndex(taskCtx.taskIndex());
     setWorkerId(taskCtx.getWorkerId());
+    setInSchema((Schema) taskCtx.getConfig(TSetConstants.INPUT_SCHEMA_KEY));
+    setOutputSchema((Schema) taskCtx.getConfig(TSetConstants.OUTPUT_SCHEMA_KEY));
   }
 
   private void setWorkerId(int workerId) {
@@ -268,5 +293,13 @@ public class TSetContext implements Serializable {
 
   private void settSetIndex(int tSetIndex) {
     this.tSetIndex = tSetIndex;
+  }
+
+  private void setInSchema(Schema inputSchema) {
+    this.inSchema = inputSchema;
+  }
+
+  private void setOutputSchema(Schema ouputSchema) {
+    this.outSchema = ouputSchema;
   }
 }

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/link/TLink.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/link/TLink.java
@@ -11,6 +11,7 @@
 //  limitations under the License.
 package edu.iu.dsc.tws.api.tset.link;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.TBase;
 import edu.iu.dsc.tws.api.tset.fn.ApplyFunc;
@@ -108,4 +109,12 @@ public interface TLink<T1, T0> extends TBase {
    * @return Sink tset. This would would be a terminal TSet with no transformation capabilities.
    */
   TBase sink(SinkFunc<T1> sinkFunction);
+
+  /**
+   * Sets the data type of the TLink. This will be used in the packers for efficient SER-DE operations
+   *
+   * @param dataType data type as a {@link MessageType}
+   * @return this {@link TLink}
+   */
+  TLink<T1, T0> withDataType(MessageType dataType);
 }

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/link/TLink.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/link/TLink.java
@@ -11,7 +11,6 @@
 //  limitations under the License.
 package edu.iu.dsc.tws.api.tset.link;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.TBase;
 import edu.iu.dsc.tws.api.tset.fn.ApplyFunc;
@@ -109,12 +108,4 @@ public interface TLink<T1, T0> extends TBase {
    * @return Sink tset. This would would be a terminal TSet with no transformation capabilities.
    */
   TBase sink(SinkFunc<T1> sinkFunction);
-
-  /**
-   * Sets the data type of the TLink. This will be used in the packers for efficient SER-DE operations
-   *
-   * @param dataType data type as a {@link MessageType}
-   * @return this {@link TLink}
-   */
-  TLink<T1, T0> withDataType(MessageType dataType);
 }

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/schema/JoinSchema.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/schema/JoinSchema.java
@@ -1,0 +1,38 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package edu.iu.dsc.tws.api.tset.schema;
+
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
+
+
+public class JoinSchema extends KeyedSchema {
+  private MessageType dTypeR;
+
+  public JoinSchema(MessageType keyType, MessageType leftDataType,
+                    MessageType rightDataType) {
+    super(keyType, leftDataType);
+    this.dTypeR = rightDataType;
+  }
+
+  public JoinSchema(TupleSchema leftSchema, TupleSchema rightSchema) {
+    this(leftSchema.getKeyType(), leftSchema.getDataType(),
+        rightSchema.getDataType());
+    if (leftSchema.getClass() != rightSchema.getClass()) {
+      throw new RuntimeException("Left and right schemas have different key "
+          + "types");
+    }
+  }
+
+  public MessageType getDataTypeRight() {
+    return dTypeR;
+  }
+}

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/schema/KeyedSchema.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/schema/KeyedSchema.java
@@ -1,0 +1,33 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package edu.iu.dsc.tws.api.tset.schema;
+
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
+
+public class KeyedSchema implements TupleSchema {
+  private final MessageType dType;
+  private final MessageType kType;
+
+  public KeyedSchema(MessageType keyType, MessageType dataType) {
+    this.dType = dataType;
+    this.kType = keyType;
+  }
+
+  @Override
+  public MessageType getDataType() {
+    return dType;
+  }
+
+  public MessageType getKeyType() {
+    return kType;
+  }
+}

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/schema/PrimitiveSchemas.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/schema/PrimitiveSchemas.java
@@ -1,0 +1,37 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package edu.iu.dsc.tws.api.tset.schema;
+
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
+
+public final class PrimitiveSchemas {
+  private PrimitiveSchemas() {
+  }
+
+  public static final Schema INTEGER = () -> MessageTypes.INTEGER;
+
+  public static final Schema STRING = () -> MessageTypes.STRING;
+
+  public static final Schema OBJECT = () -> MessageTypes.OBJECT;
+
+  public static final Schema EMPTY = () -> MessageTypes.EMPTY;
+
+  public static final Schema NULL = () -> null;
+
+  public static final KeyedSchema OBJECT_TUPLE2 = new KeyedSchema(MessageTypes.OBJECT,
+      MessageTypes.OBJECT);
+
+  public static final JoinSchema OBJECT_TUPLE3 = new JoinSchema(MessageTypes.OBJECT,
+      MessageTypes.OBJECT, MessageTypes.OBJECT);
+
+  public static final KeyedSchema NULL_TUPLE2 = new KeyedSchema(null, null);
+}

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/schema/Schema.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/schema/Schema.java
@@ -1,0 +1,20 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package edu.iu.dsc.tws.api.tset.schema;
+
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
+
+public interface Schema {
+
+  MessageType getDataType();
+}
+

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/schema/TupleSchema.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/schema/TupleSchema.java
@@ -1,0 +1,19 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package edu.iu.dsc.tws.api.tset.schema;
+
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
+
+public interface TupleSchema extends Schema {
+
+  MessageType getKeyType();
+}

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/sets/TSet.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/sets/TSet.java
@@ -37,6 +37,7 @@ package edu.iu.dsc.tws.api.tset.sets;
 
 import java.util.Collection;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.TBase;
 import edu.iu.dsc.tws.api.tset.fn.MapFunc;
@@ -162,4 +163,13 @@ public interface TSet<T> extends TBase {
    * @return Union TSet
    */
   TSet<T> union(Collection<TSet<T>> tSets);
+
+  /**
+   * Sets the data type of the {@link TSet} output. This will be used in the packers for efficient
+   * SER-DE operations in the following {@link TLink}s
+   *
+   * @param dataType data type as a {@link MessageType}
+   * @return this {@link TSet}
+   */
+  TSet<T> withDataType(MessageType dataType);
 }

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/sets/TSet.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/sets/TSet.java
@@ -44,6 +44,7 @@ import edu.iu.dsc.tws.api.tset.fn.MapFunc;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
 import edu.iu.dsc.tws.api.tset.link.TLink;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 
 /**
  * Twister data set. A {@link TSet} would abstract a Task level computation (Source/ Compute or
@@ -171,5 +172,5 @@ public interface TSet<T> extends TBase {
    * @param dataType data type as a {@link MessageType}
    * @return this {@link TSet}
    */
-  TSet<T> withDataType(MessageType dataType);
+  TSet<T> withSchema(Schema dataType);
 }

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/sets/TupleTSet.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/sets/TupleTSet.java
@@ -11,6 +11,7 @@
 //  limitations under the License.
 package edu.iu.dsc.tws.api.tset.sets;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.tset.TBase;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
 import edu.iu.dsc.tws.api.tset.link.TLink;
@@ -54,4 +55,22 @@ public interface TupleTSet<K, V> extends TBase {
    * @return Keyed Direct TLink
    */
   TLink<?, ?> keyedDirect();
+
+  /**
+   * Sets the data type of the {@link TupleTSet} output. This will be used in the packers for efficient
+   * SER-DE operations in the following {@link TLink}s
+   *
+   * @param dataType data type as a {@link MessageType}
+   * @return this {@link TupleTSet}
+   */
+  TupleTSet<K, V> withDataType(MessageType dataType);
+
+  /**
+   * Sets the data type of the {@link TupleTSet} output. This will be used in the packers for efficient
+   * SER-DE operations in the following {@link TLink}s
+   *
+   * @param keyType data type as a {@link MessageType}
+   * @return this {@link TupleTSet}
+   */
+  TupleTSet<K, V> withKeyType(MessageType keyType);
 }

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/sets/TupleTSet.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/sets/TupleTSet.java
@@ -15,6 +15,7 @@ import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.tset.TBase;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
 import edu.iu.dsc.tws.api.tset.link.TLink;
+import edu.iu.dsc.tws.api.tset.schema.TupleSchema;
 
 /**
  * Twister data set for keyed data. This would abstract the Task level keyed computations in a
@@ -60,17 +61,8 @@ public interface TupleTSet<K, V> extends TBase {
    * Sets the data type of the {@link TupleTSet} output. This will be used in the packers for efficient
    * SER-DE operations in the following {@link TLink}s
    *
-   * @param dataType data type as a {@link MessageType}
+   * @param schema data type as a {@link MessageType}
    * @return this {@link TupleTSet}
    */
-  TupleTSet<K, V> withDataType(MessageType dataType);
-
-  /**
-   * Sets the data type of the {@link TupleTSet} output. This will be used in the packers for efficient
-   * SER-DE operations in the following {@link TLink}s
-   *
-   * @param keyType data type as a {@link MessageType}
-   * @return this {@link TupleTSet}
-   */
-  TupleTSet<K, V> withKeyType(MessageType keyType);
+  TupleTSet<K, V> withSchema(TupleSchema schema);
 }

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/BatchTsetExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/BatchTsetExample.java
@@ -22,6 +22,8 @@ import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.scheduler.Twister2JobState;
 import edu.iu.dsc.tws.api.tset.fn.SourceFunc;
+import edu.iu.dsc.tws.api.tset.schema.KeyedSchema;
+import edu.iu.dsc.tws.api.tset.schema.PrimitiveSchemas;
 import edu.iu.dsc.tws.rsched.job.Twister2Submitter;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.sets.batch.KeyedSourceTSet;
@@ -64,7 +66,7 @@ public abstract class BatchTsetExample implements BatchTSetIWorker, Serializable
       public String next() {
         return dataList[c++ % dataList.length];
       }
-    }, parallel).withDataType(MessageTypes.STRING);
+    }, parallel).withSchema(PrimitiveSchemas.STRING);
   }
 
   KeyedSourceTSet<String, Integer> dummyKeyedSource(BatchTSetEnvironment env, int count,
@@ -82,7 +84,7 @@ public abstract class BatchTsetExample implements BatchTSetIWorker, Serializable
         c++;
         return new Tuple<>(Integer.toString(c), c);
       }
-    }, parallel).withKeyType(MessageTypes.STRING).withDataType(MessageTypes.INTEGER);
+    }, parallel).withSchema(new KeyedSchema(MessageTypes.STRING, MessageTypes.INTEGER));
   }
 
   SourceTSet<Integer> dummyReplayableSource(BatchTSetEnvironment env, int count, int parallel) {
@@ -119,7 +121,7 @@ public abstract class BatchTsetExample implements BatchTSetIWorker, Serializable
       public Integer next() {
         return c++;
       }
-    }, parallel).withDataType(MessageTypes.INTEGER);
+    }, parallel).withSchema(PrimitiveSchemas.INTEGER);
   }
 
   KeyedSourceTSet<String, Integer> dummyKeyedSourceOther(BatchTSetEnvironment env, int count,
@@ -137,7 +139,7 @@ public abstract class BatchTsetExample implements BatchTSetIWorker, Serializable
         c++;
         return new Tuple<>(Integer.toString(c), c + 25);
       }
-    }, parallel).withKeyType(MessageTypes.STRING).withDataType(MessageTypes.INTEGER);
+    }, parallel).withSchema(new KeyedSchema(MessageTypes.STRING, MessageTypes.INTEGER));
   }
 
   public static void submitJob(Config config, int containers, JobConfig jobConfig, String clazz) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/BatchTsetExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/BatchTsetExample.java
@@ -17,6 +17,7 @@ import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
 import edu.iu.dsc.tws.api.Twister2Job;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.scheduler.Twister2JobState;
@@ -63,7 +64,7 @@ public abstract class BatchTsetExample implements BatchTSetIWorker, Serializable
       public String next() {
         return dataList[c++ % dataList.length];
       }
-    }, parallel);
+    }, parallel).withDataType(MessageTypes.STRING);
   }
 
   KeyedSourceTSet<String, Integer> dummyKeyedSource(BatchTSetEnvironment env, int count,
@@ -81,7 +82,7 @@ public abstract class BatchTsetExample implements BatchTSetIWorker, Serializable
         c++;
         return new Tuple<>(Integer.toString(c), c);
       }
-    }, parallel);
+    }, parallel).withKeyType(MessageTypes.STRING).withDataType(MessageTypes.INTEGER);
   }
 
   SourceTSet<Integer> dummyReplayableSource(BatchTSetEnvironment env, int count, int parallel) {
@@ -118,7 +119,7 @@ public abstract class BatchTsetExample implements BatchTSetIWorker, Serializable
       public Integer next() {
         return c++;
       }
-    }, parallel);
+    }, parallel).withDataType(MessageTypes.INTEGER);
   }
 
   KeyedSourceTSet<String, Integer> dummyKeyedSourceOther(BatchTSetEnvironment env, int count,
@@ -136,7 +137,7 @@ public abstract class BatchTsetExample implements BatchTSetIWorker, Serializable
         c++;
         return new Tuple<>(Integer.toString(c), c + 25);
       }
-    }, parallel);
+    }, parallel).withKeyType(MessageTypes.STRING).withDataType(MessageTypes.INTEGER);
   }
 
   public static void submitJob(Config config, int containers, JobConfig jobConfig, String clazz) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ComputeExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ComputeExample.java
@@ -53,10 +53,12 @@ public class ComputeExample extends BatchTsetExample {
             s += input.next();
           }
           return s;
-        }).withSchema(PrimitiveSchemas.STRING).setName("sum");
+        }).withSchema(PrimitiveSchemas.INTEGER).setName("sum");
 
 
     sum.direct().forEach(data -> System.out.println("val: " + data));
+
+    sum.reduce(Integer::sum).forEach(i -> System.out.println("red: " + i));
   }
 
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ComputeExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ComputeExample.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 
 import edu.iu.dsc.tws.api.JobConfig;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 import edu.iu.dsc.tws.rsched.core.ResourceAllocator;
@@ -42,7 +43,8 @@ public class ComputeExample extends BatchTsetExample {
 
   @Override
   public void execute(BatchTSetEnvironment env) {
-    SourceTSet<Integer> src = dummySource(env, COUNT, PARALLELISM).setName("src");
+    SourceTSet<Integer> src = dummySource(env, COUNT, PARALLELISM).setName("src")
+        .withDataType(MessageTypes.INTEGER);
 
     ComputeTSet<Integer, Iterator<Integer>> sum = src.direct().compute(
         (ComputeFunc<Integer, Iterator<Integer>>) input -> {
@@ -51,7 +53,7 @@ public class ComputeExample extends BatchTsetExample {
             s += input.next();
           }
           return s;
-        }).setName("sum");
+        }).withDataType(MessageTypes.INTEGER).setName("sum");
 
 
     sum.direct().forEach(data -> System.out.println("val: " + data));

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ComputeExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ComputeExample.java
@@ -29,9 +29,9 @@ import java.util.HashMap;
 import java.util.Iterator;
 
 import edu.iu.dsc.tws.api.JobConfig;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
+import edu.iu.dsc.tws.api.tset.schema.PrimitiveSchemas;
 import edu.iu.dsc.tws.rsched.core.ResourceAllocator;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.sets.batch.ComputeTSet;
@@ -44,7 +44,7 @@ public class ComputeExample extends BatchTsetExample {
   @Override
   public void execute(BatchTSetEnvironment env) {
     SourceTSet<Integer> src = dummySource(env, COUNT, PARALLELISM).setName("src")
-        .withDataType(MessageTypes.INTEGER);
+        .withSchema(PrimitiveSchemas.INTEGER);
 
     ComputeTSet<Integer, Iterator<Integer>> sum = src.direct().compute(
         (ComputeFunc<Integer, Iterator<Integer>>) input -> {
@@ -53,7 +53,7 @@ public class ComputeExample extends BatchTsetExample {
             s += input.next();
           }
           return s;
-        }).withDataType(MessageTypes.INTEGER).setName("sum");
+        }).withSchema(PrimitiveSchemas.STRING).setName("sum");
 
 
     sum.direct().forEach(data -> System.out.println("val: " + data));

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/DirectExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/DirectExample.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
@@ -49,7 +50,7 @@ public class DirectExample extends BatchTsetExample {
   public void execute(BatchTSetEnvironment env) {
     SourceTSet<Integer> src = dummySource(env, COUNT, PARALLELISM).setName("src");
 
-    DirectTLink<Integer> direct = src.direct().setName("direct");
+    DirectTLink<Integer> direct = src.direct().setName("direct").withDataType(MessageTypes.INTEGER);
 
     LOG.info("test foreach");
     direct.forEach(i -> LOG.info("foreach: " + i));

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/DirectExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/DirectExample.java
@@ -30,11 +30,11 @@ import java.util.Iterator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
+import edu.iu.dsc.tws.api.tset.schema.PrimitiveSchemas;
 import edu.iu.dsc.tws.rsched.core.ResourceAllocator;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.links.batch.DirectTLink;
@@ -56,13 +56,13 @@ public class DirectExample extends BatchTsetExample {
     direct.forEach(i -> LOG.info("foreach: " + i));
 
     LOG.info("test map");
-    direct.map(i -> i.toString() + "$$").setName("map").withDataType(MessageTypes.STRING)
+    direct.map(i -> i.toString() + "$$").setName("map").withSchema(PrimitiveSchemas.STRING)
         .direct()
         .forEach(s -> LOG.info("map: " + s));
 
     LOG.info("test flat map");
     direct.flatmap((i, c) -> c.collect(i.toString() + "##")).setName("flatmap")
-        .withDataType(MessageTypes.STRING)
+        .withSchema(PrimitiveSchemas.STRING)
         .direct()
         .forEach(s -> LOG.info("flat:" + s));
 
@@ -73,7 +73,7 @@ public class DirectExample extends BatchTsetExample {
         sum += input.next();
       }
       return "sum" + sum;
-    }).setName("compute").withDataType(MessageTypes.STRING)
+    }).setName("compute").withSchema(PrimitiveSchemas.STRING)
         .direct()
         .forEach(i -> LOG.info("comp: " + i));
 
@@ -86,7 +86,7 @@ public class DirectExample extends BatchTsetExample {
           }
           output.collect("sum" + sum);
         }).setName("ccompute")
-        .withDataType(MessageTypes.STRING)
+        .withSchema(PrimitiveSchemas.STRING)
         .direct()
         .forEach(s -> LOG.info("computec: " + s));
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/DirectExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/DirectExample.java
@@ -30,7 +30,6 @@ import java.util.Iterator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
@@ -50,7 +49,7 @@ public class DirectExample extends BatchTsetExample {
   public void execute(BatchTSetEnvironment env) {
     SourceTSet<Integer> src = dummySource(env, COUNT, PARALLELISM).setName("src");
 
-    DirectTLink<Integer> direct = src.direct().setName("direct").withDataType(MessageTypes.INTEGER);
+    DirectTLink<Integer> direct = src.direct().setName("direct");
 
     LOG.info("test foreach");
     direct.forEach(i -> LOG.info("foreach: " + i));

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/DirectExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/DirectExample.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
@@ -55,12 +56,13 @@ public class DirectExample extends BatchTsetExample {
     direct.forEach(i -> LOG.info("foreach: " + i));
 
     LOG.info("test map");
-    direct.map(i -> i.toString() + "$$").setName("map")
+    direct.map(i -> i.toString() + "$$").setName("map").withDataType(MessageTypes.STRING)
         .direct()
         .forEach(s -> LOG.info("map: " + s));
 
     LOG.info("test flat map");
     direct.flatmap((i, c) -> c.collect(i.toString() + "##")).setName("flatmap")
+        .withDataType(MessageTypes.STRING)
         .direct()
         .forEach(s -> LOG.info("flat:" + s));
 
@@ -71,7 +73,7 @@ public class DirectExample extends BatchTsetExample {
         sum += input.next();
       }
       return "sum" + sum;
-    }).setName("compute")
+    }).setName("compute").withDataType(MessageTypes.STRING)
         .direct()
         .forEach(i -> LOG.info("comp: " + i));
 
@@ -84,6 +86,7 @@ public class DirectExample extends BatchTsetExample {
           }
           output.collect("sum" + sum);
         }).setName("ccompute")
+        .withDataType(MessageTypes.STRING)
         .direct()
         .forEach(s -> LOG.info("computec: " + s));
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/GatherExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/GatherExample.java
@@ -30,11 +30,11 @@ import java.util.Iterator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
+import edu.iu.dsc.tws.api.tset.schema.PrimitiveSchemas;
 import edu.iu.dsc.tws.rsched.core.ResourceAllocator;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.links.batch.GatherTLink;
@@ -54,7 +54,7 @@ public class GatherExample extends BatchTsetExample {
     gather.forEach(i -> LOG.info("foreach: " + i));
 
     LOG.info("test map");
-    gather.map(i -> i.toString() + "$$").withDataType(MessageTypes.STRING)
+    gather.map(i -> i.toString() + "$$").withSchema(PrimitiveSchemas.STRING)
         .direct()
         .forEach(s -> LOG.info("map: " + s));
 
@@ -66,7 +66,7 @@ public class GatherExample extends BatchTsetExample {
       }
       return "sum=" + sum;
     })
-        .withDataType(MessageTypes.STRING)
+        .withSchema(PrimitiveSchemas.STRING)
         .direct()
         .forEach(s -> LOG.info("compute: " + s));
 
@@ -79,7 +79,7 @@ public class GatherExample extends BatchTsetExample {
           }
           output.collect("sum=" + sum);
         })
-        .withDataType(MessageTypes.STRING)
+        .withSchema(PrimitiveSchemas.STRING)
         .direct()
         .forEach(s -> LOG.info("computec: " + s));
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/GatherExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/GatherExample.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
@@ -53,7 +54,7 @@ public class GatherExample extends BatchTsetExample {
     gather.forEach(i -> LOG.info("foreach: " + i));
 
     LOG.info("test map");
-    gather.map(i -> i.toString() + "$$")
+    gather.map(i -> i.toString() + "$$").withDataType(MessageTypes.STRING)
         .direct()
         .forEach(s -> LOG.info("map: " + s));
 
@@ -65,6 +66,7 @@ public class GatherExample extends BatchTsetExample {
       }
       return "sum=" + sum;
     })
+        .withDataType(MessageTypes.STRING)
         .direct()
         .forEach(s -> LOG.info("compute: " + s));
 
@@ -77,6 +79,7 @@ public class GatherExample extends BatchTsetExample {
           }
           output.collect("sum=" + sum);
         })
+        .withDataType(MessageTypes.STRING)
         .direct()
         .forEach(s -> LOG.info("computec: " + s));
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/GatherExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/GatherExample.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
@@ -47,7 +48,7 @@ public class GatherExample extends BatchTsetExample {
   public void execute(BatchTSetEnvironment env) {
     SourceTSet<Integer> src = dummySource(env, COUNT, PARALLELISM);
 
-    GatherTLink<Integer> gather = src.gather();
+    GatherTLink<Integer> gather = src.gather().withDataType(MessageTypes.INTEGER);
 
     LOG.info("test foreach");
     gather.forEach(i -> LOG.info("foreach: " + i));

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/GatherExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/GatherExample.java
@@ -30,7 +30,6 @@ import java.util.Iterator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
@@ -48,7 +47,7 @@ public class GatherExample extends BatchTsetExample {
   public void execute(BatchTSetEnvironment env) {
     SourceTSet<Integer> src = dummySource(env, COUNT, PARALLELISM);
 
-    GatherTLink<Integer> gather = src.gather().withDataType(MessageTypes.INTEGER);
+    GatherTLink<Integer> gather = src.gather();
 
     LOG.info("test foreach");
     gather.forEach(i -> LOG.info("foreach: " + i));

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ReduceExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ReduceExample.java
@@ -28,11 +28,11 @@ import java.util.HashMap;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
+import edu.iu.dsc.tws.api.tset.schema.PrimitiveSchemas;
 import edu.iu.dsc.tws.rsched.core.ResourceAllocator;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.links.batch.ReduceTLink;
@@ -56,13 +56,13 @@ public class ReduceExample extends BatchTsetExample {
 
     LOG.info("test map");
     reduce
-        .map(i -> i.toString() + "$$").withDataType(MessageTypes.STRING)
+        .map(i -> i.toString() + "$$").withSchema(PrimitiveSchemas.STRING)
         .direct()
         .forEach(s -> LOG.info("map: " + s));
 
     LOG.info("test flat map");
     reduce
-        .flatmap((i, c) -> c.collect(i.toString() + "##")).withDataType(MessageTypes.STRING)
+        .flatmap((i, c) -> c.collect(i.toString() + "##")).withSchema(PrimitiveSchemas.STRING)
         .direct()
         .forEach(s -> LOG.info("flat:" + s));
 
@@ -70,7 +70,7 @@ public class ReduceExample extends BatchTsetExample {
     reduce
         .compute((ComputeFunc<String, Integer>)
             input -> "sum=" + input)
-        .withDataType(MessageTypes.STRING)
+        .withSchema(PrimitiveSchemas.STRING)
         .direct()
         .forEach(s -> LOG.info("compute: " + s));
 
@@ -78,7 +78,7 @@ public class ReduceExample extends BatchTsetExample {
     reduce
         .compute((ComputeCollectorFunc<String, Integer>)
             (input, output) -> output.collect("sum=" + input))
-        .withDataType(MessageTypes.STRING)
+        .withSchema(PrimitiveSchemas.STRING)
         .direct()
         .forEach(s -> LOG.info("computec: " + s));
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ReduceExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ReduceExample.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
@@ -49,7 +48,7 @@ public class ReduceExample extends BatchTsetExample {
   public void execute(BatchTSetEnvironment env) {
     SourceTSet<Integer> src = dummySource(env, COUNT, PARALLELISM);
 
-    ReduceTLink<Integer> reduce = src.reduce(Integer::sum).withDataType(MessageTypes.INTEGER);
+    ReduceTLink<Integer> reduce = src.reduce(Integer::sum);
 
     LOG.info("test foreach");
     reduce.forEach(i -> LOG.info("foreach: " + i));

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ReduceExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ReduceExample.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
@@ -48,7 +49,7 @@ public class ReduceExample extends BatchTsetExample {
   public void execute(BatchTSetEnvironment env) {
     SourceTSet<Integer> src = dummySource(env, COUNT, PARALLELISM);
 
-    ReduceTLink<Integer> reduce = src.reduce(Integer::sum);
+    ReduceTLink<Integer> reduce = src.reduce(Integer::sum).withDataType(MessageTypes.INTEGER);
 
     LOG.info("test foreach");
     reduce.forEach(i -> LOG.info("foreach: " + i));

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ReduceExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ReduceExample.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
@@ -55,13 +56,13 @@ public class ReduceExample extends BatchTsetExample {
 
     LOG.info("test map");
     reduce
-        .map(i -> i.toString() + "$$")
+        .map(i -> i.toString() + "$$").withDataType(MessageTypes.STRING)
         .direct()
         .forEach(s -> LOG.info("map: " + s));
 
     LOG.info("test flat map");
     reduce
-        .flatmap((i, c) -> c.collect(i.toString() + "##"))
+        .flatmap((i, c) -> c.collect(i.toString() + "##")).withDataType(MessageTypes.STRING)
         .direct()
         .forEach(s -> LOG.info("flat:" + s));
 
@@ -69,6 +70,7 @@ public class ReduceExample extends BatchTsetExample {
     reduce
         .compute((ComputeFunc<String, Integer>)
             input -> "sum=" + input)
+        .withDataType(MessageTypes.STRING)
         .direct()
         .forEach(s -> LOG.info("compute: " + s));
 
@@ -76,6 +78,7 @@ public class ReduceExample extends BatchTsetExample {
     reduce
         .compute((ComputeCollectorFunc<String, Integer>)
             (input, output) -> output.collect("sum=" + input))
+        .withDataType(MessageTypes.STRING)
         .direct()
         .forEach(s -> LOG.info("computec: " + s));
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/SetSchemaExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/SetSchemaExample.java
@@ -20,6 +20,7 @@ import edu.iu.dsc.tws.api.JobConfig;
 import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.config.Config;
+import edu.iu.dsc.tws.api.tset.TSetContext;
 import edu.iu.dsc.tws.api.tset.fn.BaseMapFunc;
 import edu.iu.dsc.tws.api.tset.fn.BaseSourceFunc;
 import edu.iu.dsc.tws.api.tset.schema.KeyedSchema;
@@ -42,6 +43,12 @@ public class SetSchemaExample implements BatchTSetIWorker, Serializable {
       private int i = 0;
 
       @Override
+      public void prepare(TSetContext ctx) {
+        super.prepare(ctx);
+        LOG.info("schemas0: " + ctx.getInputSchema() + " -> " + ctx.getOutputSchema());
+      }
+
+      @Override
       public boolean hasNext() {
         return i == 0;
       }
@@ -59,6 +66,12 @@ public class SetSchemaExample implements BatchTSetIWorker, Serializable {
     ComputeTSet<String, Integer> map = src.allReduce(Integer::sum).map(
         new BaseMapFunc<String, Integer>() {
           @Override
+          public void prepare(TSetContext ctx) {
+            super.prepare(ctx);
+            LOG.info("schemas1: " + ctx.getInputSchema() + " -> " + ctx.getOutputSchema());
+          }
+
+          @Override
           public String map(Integer input) {
             return input.toString();
           }
@@ -71,6 +84,12 @@ public class SetSchemaExample implements BatchTSetIWorker, Serializable {
 
     KeyedTSet<String, Integer> keyed = map.mapToTuple(
         new BaseMapFunc<Tuple<String, Integer>, String>() {
+          @Override
+          public void prepare(TSetContext ctx) {
+            super.prepare(ctx);
+            LOG.info("schemas2: " + ctx.getInputSchema() + " -> " + ctx.getOutputSchema());
+          }
+
           @Override
           public Tuple<String, Integer> map(String input) {
             return new Tuple<>(input, Integer.parseInt(input));

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/SetSchemaExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/SetSchemaExample.java
@@ -1,0 +1,92 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package edu.iu.dsc.tws.examples.tset.batch;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.logging.Logger;
+
+import edu.iu.dsc.tws.api.JobConfig;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
+import edu.iu.dsc.tws.api.comms.structs.Tuple;
+import edu.iu.dsc.tws.api.config.Config;
+import edu.iu.dsc.tws.api.tset.fn.BaseMapFunc;
+import edu.iu.dsc.tws.api.tset.fn.BaseSourceFunc;
+import edu.iu.dsc.tws.api.tset.schema.KeyedSchema;
+import edu.iu.dsc.tws.api.tset.schema.PrimitiveSchemas;
+import edu.iu.dsc.tws.rsched.core.ResourceAllocator;
+import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
+import edu.iu.dsc.tws.tset.sets.batch.ComputeTSet;
+import edu.iu.dsc.tws.tset.sets.batch.KeyedTSet;
+import edu.iu.dsc.tws.tset.sets.batch.SourceTSet;
+import edu.iu.dsc.tws.tset.worker.BatchTSetIWorker;
+
+
+public class SetSchemaExample implements BatchTSetIWorker, Serializable {
+  private static final long serialVersionUID = -2753072757838198105L;
+  private static final Logger LOG = Logger.getLogger(SetSchemaExample.class.getName());
+
+  @Override
+  public void execute(BatchTSetEnvironment env) {
+    SourceTSet<Integer> src = env.createSource(new BaseSourceFunc<Integer>() {
+      private int i = 0;
+
+      @Override
+      public boolean hasNext() {
+        return i == 0;
+      }
+
+      @Override
+      public Integer next() {
+        return ++i;
+      }
+    }, 2).setName("src");
+
+    src.direct().forEach(ii -> LOG.info("out0: " + ii));
+
+    src.withSchema(PrimitiveSchemas.INTEGER).direct().forEach(ii -> LOG.info("out1: " + ii));
+
+    ComputeTSet<String, Integer> map = src.allReduce(Integer::sum).map(
+        new BaseMapFunc<String, Integer>() {
+          @Override
+          public String map(Integer input) {
+            return input.toString();
+          }
+        });
+
+
+    map.direct().forEach(ii -> LOG.info("out2: " + ii));
+
+    map.withSchema(PrimitiveSchemas.STRING).direct().forEach(ii -> LOG.info("out3: " + ii));
+
+    KeyedTSet<String, Integer> keyed = map.mapToTuple(
+        new BaseMapFunc<Tuple<String, Integer>, String>() {
+          @Override
+          public Tuple<String, Integer> map(String input) {
+            return new Tuple<>(input, Integer.parseInt(input));
+          }
+        });
+
+    keyed.keyedDirect().forEach(ii -> LOG.info("out4: " + ii));
+
+    keyed.withSchema(new KeyedSchema(MessageTypes.STRING, MessageTypes.INTEGER)).keyedDirect()
+        .forEach(ii -> LOG.info("out5: " + ii));
+  }
+
+  public static void main(String[] args) {
+    Config config = ResourceAllocator.loadConfig(new HashMap<>());
+
+    JobConfig jobConfig = new JobConfig();
+    BatchTsetExample.submitJob(config, 2, jobConfig, SetSchemaExample.class.getName());
+  }
+}

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/TSetUtils.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/TSetUtils.java
@@ -15,6 +15,8 @@ package edu.iu.dsc.tws.tset;
 import java.util.Set;
 import java.util.StringJoiner;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.tset.TBase;
 
 public final class TSetUtils {
@@ -32,5 +34,41 @@ public final class TSetUtils {
 
   public static String generateBuildId(TBase root) {
     return "build_" + root.getId();
+  }
+
+  public static MessageType getDataType(Class type) {
+    if (type == int[].class) {
+      return MessageTypes.INTEGER_ARRAY;
+    } else if (type == double[].class) {
+      return MessageTypes.DOUBLE_ARRAY;
+    } else if (type == short[].class) {
+      return MessageTypes.SHORT_ARRAY;
+    } else if (type == byte[].class) {
+      return MessageTypes.BYTE_ARRAY;
+    } else if (type == long[].class) {
+      return MessageTypes.LONG_ARRAY;
+    } else if (type == char[].class) {
+      return MessageTypes.CHAR_ARRAY;
+    } else {
+      return MessageTypes.OBJECT;
+    }
+  }
+
+  public static MessageType getKeyType(Class type) {
+    if (type == Integer.class) {
+      return MessageTypes.INTEGER_ARRAY;
+    } else if (type == Double.class) {
+      return MessageTypes.DOUBLE_ARRAY;
+    } else if (type == Short.class) {
+      return MessageTypes.SHORT_ARRAY;
+    } else if (type == Byte.class) {
+      return MessageTypes.BYTE_ARRAY;
+    } else if (type == Long.class) {
+      return MessageTypes.LONG_ARRAY;
+    } else if (type == Character.class) {
+      return MessageTypes.CHAR_ARRAY;
+    } else {
+      return MessageTypes.OBJECT;
+    }
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/TSetUtils.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/TSetUtils.java
@@ -15,8 +15,6 @@ package edu.iu.dsc.tws.tset;
 import java.util.Set;
 import java.util.StringJoiner;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.tset.TBase;
 
 public final class TSetUtils {
@@ -34,41 +32,5 @@ public final class TSetUtils {
 
   public static String generateBuildId(TBase root) {
     return "build_" + root.getId();
-  }
-
-  public static MessageType getDataType(Class type) {
-    if (type == int[].class) {
-      return MessageTypes.INTEGER_ARRAY;
-    } else if (type == double[].class) {
-      return MessageTypes.DOUBLE_ARRAY;
-    } else if (type == short[].class) {
-      return MessageTypes.SHORT_ARRAY;
-    } else if (type == byte[].class) {
-      return MessageTypes.BYTE_ARRAY;
-    } else if (type == long[].class) {
-      return MessageTypes.LONG_ARRAY;
-    } else if (type == char[].class) {
-      return MessageTypes.CHAR_ARRAY;
-    } else {
-      return MessageTypes.OBJECT;
-    }
-  }
-
-  public static MessageType getKeyType(Class type) {
-    if (type == Integer.class) {
-      return MessageTypes.INTEGER_ARRAY;
-    } else if (type == Double.class) {
-      return MessageTypes.DOUBLE_ARRAY;
-    } else if (type == Short.class) {
-      return MessageTypes.SHORT_ARRAY;
-    } else if (type == Byte.class) {
-      return MessageTypes.BYTE_ARRAY;
-    } else if (type == Long.class) {
-      return MessageTypes.LONG_ARRAY;
-    } else if (type == Character.class) {
-      return MessageTypes.CHAR_ARRAY;
-    } else {
-      return MessageTypes.OBJECT;
-    }
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/BaseTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/BaseTLink.java
@@ -14,11 +14,7 @@ package edu.iu.dsc.tws.tset.links;
 
 import java.util.Objects;
 
-import com.google.common.reflect.TypeToken;
-
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.tset.TBase;
-import edu.iu.dsc.tws.tset.TSetUtils;
 import edu.iu.dsc.tws.tset.env.TSetEnvironment;
 
 /**
@@ -80,17 +76,6 @@ public abstract class BaseTLink<T1, T0> implements BuildableTLink {
 
   protected void rename(String n) {
     this.name = n;
-  }
-
-  protected Class getType() {
-    TypeToken<T1> typeToken = new TypeToken<T1>(getClass()) {
-    };
-    return typeToken.getRawType();
-  }
-
-  //todo: this always return Object type!!!
-  protected MessageType getMessageType() {
-    return TSetUtils.getDataType(getType());
   }
 
   protected void addChildToGraph(TBase child) {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/BaseTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/BaseTLink.java
@@ -14,7 +14,11 @@ package edu.iu.dsc.tws.tset.links;
 
 import java.util.Objects;
 
+import com.google.common.reflect.TypeToken;
+
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.tset.TBase;
+import edu.iu.dsc.tws.tset.TSetUtils;
 import edu.iu.dsc.tws.tset.env.TSetEnvironment;
 
 /**
@@ -76,6 +80,17 @@ public abstract class BaseTLink<T1, T0> implements BuildableTLink {
 
   protected void rename(String n) {
     this.name = n;
+  }
+
+  protected Class getType() {
+    TypeToken<T1> typeToken = new TypeToken<T1>(getClass()) {
+    };
+    return typeToken.getRawType();
+  }
+
+  //todo: this always return Object type!!!
+  protected MessageType getMessageType() {
+    return TSetUtils.getDataType(getType());
   }
 
   protected void addChildToGraph(TBase child) {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/BaseTLinkWithSchema.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/BaseTLinkWithSchema.java
@@ -1,0 +1,43 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package edu.iu.dsc.tws.tset.links;
+
+import edu.iu.dsc.tws.api.tset.schema.Schema;
+import edu.iu.dsc.tws.tset.env.TSetEnvironment;
+
+public abstract class BaseTLinkWithSchema<T1, T0> extends BaseTLink<T1, T0> {
+  private Schema linkSchema;
+
+  public BaseTLinkWithSchema(TSetEnvironment env, String id, Schema schema) {
+    super(env, id);
+    this.linkSchema = schema;
+  }
+
+  public BaseTLinkWithSchema(TSetEnvironment env, String id, int sourceP, Schema schema) {
+    super(env, id, sourceP);
+    this.linkSchema = schema;
+  }
+
+  public BaseTLinkWithSchema(TSetEnvironment env, String id, int sourceP, int targetP,
+                             Schema schema) {
+    super(env, id, sourceP, targetP);
+    this.linkSchema = schema;
+  }
+
+  public BaseTLinkWithSchema() {
+  }
+
+  protected Schema getSchema() {
+    return linkSchema;
+  }
+}
+

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/AllGatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/AllGatherTLink.java
@@ -26,9 +26,9 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 
 /**
@@ -43,13 +43,13 @@ public class AllGatherTLink<T> extends BatchGatherLink<T> {
     //non arg constructor for kryo
   }
 
-  public AllGatherTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism, MessageType dataType) {
-    super(tSetEnv, "allgather", sourceParallelism, dataType);
+  public AllGatherTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism, Schema schema) {
+    super(tSetEnv, "allgather", sourceParallelism, schema);
   }
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.ALLGATHER, this.getDataType());
+    Edge e = new Edge(getId(), OperationNames.ALLGATHER, this.getSchema().getDataType());
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/AllGatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/AllGatherTLink.java
@@ -10,22 +10,10 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
-//
-//  http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
-
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -48,7 +36,7 @@ public class AllGatherTLink<T> extends BatchGatherLink<T> {
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.ALLGATHER, getMessageType());
+    Edge e = new Edge(getId(), OperationNames.ALLGATHER, getDataType());
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;
   }
@@ -57,6 +45,11 @@ public class AllGatherTLink<T> extends BatchGatherLink<T> {
   public AllGatherTLink<T> setName(String n) {
     rename(n);
     return this;
+  }
+
+  @Override
+  public AllGatherTLink<T> withDataType(MessageType dataType) {
+    return (AllGatherTLink<T>) super.withDataType(dataType);
   }
 
   public AllGatherTLink<T> useDisk() {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/AllGatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/AllGatherTLink.java
@@ -26,6 +26,7 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -42,13 +43,13 @@ public class AllGatherTLink<T> extends BatchGatherLink<T> {
     //non arg constructor for kryo
   }
 
-  public AllGatherTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism) {
-    super(tSetEnv, "allgather", sourceParallelism);
+  public AllGatherTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism, MessageType dataType) {
+    super(tSetEnv, "allgather", sourceParallelism, dataType);
   }
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.ALLGATHER, getMessageType());
+    Edge e = new Edge(getId(), OperationNames.ALLGATHER, this.getDataType());
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/AllGatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/AllGatherTLink.java
@@ -10,10 +10,22 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -36,7 +48,7 @@ public class AllGatherTLink<T> extends BatchGatherLink<T> {
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.ALLGATHER, getDataType());
+    Edge e = new Edge(getId(), OperationNames.ALLGATHER, getMessageType());
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;
   }
@@ -45,11 +57,6 @@ public class AllGatherTLink<T> extends BatchGatherLink<T> {
   public AllGatherTLink<T> setName(String n) {
     rename(n);
     return this;
-  }
-
-  @Override
-  public AllGatherTLink<T> withDataType(MessageType dataType) {
-    return (AllGatherTLink<T>) super.withDataType(dataType);
   }
 
   public AllGatherTLink<T> useDisk() {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/AllReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/AllReduceTLink.java
@@ -10,9 +10,21 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package edu.iu.dsc.tws.tset.links.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
@@ -33,17 +45,12 @@ public class AllReduceTLink<T> extends BatchSingleLink<T> {
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.ALLREDUCE, getDataType(), reduceFn);
+    return new Edge(getId(), OperationNames.ALLREDUCE, getMessageType(), reduceFn);
   }
 
   @Override
   public AllReduceTLink<T> setName(String n) {
     rename(n);
     return this;
-  }
-
-  @Override
-  public AllReduceTLink<T> withDataType(MessageType dataType) {
-    return (AllReduceTLink<T>) super.withDataType(dataType);
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/AllReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/AllReduceTLink.java
@@ -25,10 +25,10 @@
 
 package edu.iu.dsc.tws.tset.links.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 
 /**
@@ -40,14 +40,14 @@ public class AllReduceTLink<T> extends BatchSingleLink<T> {
   private ReduceFunc<T> reduceFn;
 
   public AllReduceTLink(BatchTSetEnvironment tSetEnv, ReduceFunc<T> rFn, int sourceParallelism,
-                        MessageType dataType) {
-    super(tSetEnv, "allreduce", sourceParallelism, dataType);
+                        Schema schema) {
+    super(tSetEnv, "allreduce", sourceParallelism, schema);
     this.reduceFn = rFn;
   }
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.ALLREDUCE, this.getDataType(), reduceFn);
+    return new Edge(getId(), OperationNames.ALLREDUCE, this.getSchema().getDataType(), reduceFn);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/AllReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/AllReduceTLink.java
@@ -25,6 +25,7 @@
 
 package edu.iu.dsc.tws.tset.links.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
@@ -38,14 +39,15 @@ import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 public class AllReduceTLink<T> extends BatchSingleLink<T> {
   private ReduceFunc<T> reduceFn;
 
-  public AllReduceTLink(BatchTSetEnvironment tSetEnv, ReduceFunc<T> rFn, int sourceParallelism) {
-    super(tSetEnv, "allreduce", sourceParallelism);
+  public AllReduceTLink(BatchTSetEnvironment tSetEnv, ReduceFunc<T> rFn, int sourceParallelism,
+                        MessageType dataType) {
+    super(tSetEnv, "allreduce", sourceParallelism, dataType);
     this.reduceFn = rFn;
   }
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.ALLREDUCE, getMessageType(), reduceFn);
+    return new Edge(getId(), OperationNames.ALLREDUCE, this.getDataType(), reduceFn);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/AllReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/AllReduceTLink.java
@@ -10,21 +10,9 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
-//
-//  http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
-
 package edu.iu.dsc.tws.tset.links.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
@@ -45,12 +33,17 @@ public class AllReduceTLink<T> extends BatchSingleLink<T> {
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.ALLREDUCE, getMessageType(), reduceFn);
+    return new Edge(getId(), OperationNames.ALLREDUCE, getDataType(), reduceFn);
   }
 
   @Override
   public AllReduceTLink<T> setName(String n) {
     rename(n);
     return this;
+  }
+
+  @Override
+  public AllReduceTLink<T> withDataType(MessageType dataType) {
+    return (AllReduceTLink<T>) super.withDataType(dataType);
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchGatherLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchGatherLink.java
@@ -15,6 +15,7 @@ package edu.iu.dsc.tws.tset.links.batch;
 
 import java.util.Iterator;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.ApplyFunc;
 import edu.iu.dsc.tws.api.tset.fn.FlatMapFunc;
@@ -40,12 +41,13 @@ import edu.iu.dsc.tws.tset.sinks.DiskPersistGatherSink;
  */
 public abstract class BatchGatherLink<T> extends BatchTLinkImpl<Iterator<Tuple<Integer, T>>, T> {
 
-  BatchGatherLink(BatchTSetEnvironment env, String n, int sourceP) {
-    this(env, n, sourceP, sourceP);
+  BatchGatherLink(BatchTSetEnvironment env, String n, int sourceP, MessageType dataType) {
+    this(env, n, sourceP, sourceP, dataType);
   }
 
-  BatchGatherLink(BatchTSetEnvironment env, String n, int sourceP, int targetP) {
-    super(env, n, sourceP, targetP);
+  BatchGatherLink(BatchTSetEnvironment env, String n, int sourceP, int targetP,
+                  MessageType dataType) {
+    super(env, n, sourceP, targetP, dataType);
   }
 
   protected BatchGatherLink() {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchGatherLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchGatherLink.java
@@ -15,11 +15,11 @@ package edu.iu.dsc.tws.tset.links.batch;
 
 import java.util.Iterator;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.ApplyFunc;
 import edu.iu.dsc.tws.api.tset.fn.FlatMapFunc;
 import edu.iu.dsc.tws.api.tset.fn.MapFunc;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.fn.GatherFlatMapCompute;
 import edu.iu.dsc.tws.tset.fn.GatherForEachCompute;
@@ -41,13 +41,13 @@ import edu.iu.dsc.tws.tset.sinks.DiskPersistGatherSink;
  */
 public abstract class BatchGatherLink<T> extends BatchTLinkImpl<Iterator<Tuple<Integer, T>>, T> {
 
-  BatchGatherLink(BatchTSetEnvironment env, String n, int sourceP, MessageType dataType) {
-    this(env, n, sourceP, sourceP, dataType);
+  BatchGatherLink(BatchTSetEnvironment env, String n, int sourceP, Schema schema) {
+    this(env, n, sourceP, sourceP, schema);
   }
 
   BatchGatherLink(BatchTSetEnvironment env, String n, int sourceP, int targetP,
-                  MessageType dataType) {
-    super(env, n, sourceP, targetP, dataType);
+                  Schema schema) {
+    super(env, n, sourceP, targetP, schema);
   }
 
   protected BatchGatherLink() {
@@ -68,7 +68,7 @@ public abstract class BatchGatherLink<T> extends BatchTLinkImpl<Iterator<Tuple<I
   @Override
   public <K, V> KeyedTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T> genTupleFn) {
     KeyedTSet<K, V> set = new KeyedTSet<>(getTSetEnv(), new GatherMapCompute<>(genTupleFn),
-        getTargetParallelism());
+        getTargetParallelism(), getSchema());
 
     addChildToGraph(set);
 
@@ -90,7 +90,7 @@ public abstract class BatchGatherLink<T> extends BatchTLinkImpl<Iterator<Tuple<I
   @Override
   public CachedTSet<T> lazyCache() {
     CachedTSet<T> cacheTSet = new CachedTSet<>(getTSetEnv(), new CacheGatherSink<T>(),
-        getTargetParallelism());
+        getTargetParallelism(), getSchema());
     addChildToGraph(cacheTSet);
     return cacheTSet;
   }
@@ -105,7 +105,7 @@ public abstract class BatchGatherLink<T> extends BatchTLinkImpl<Iterator<Tuple<I
   @Override
   public PersistedTSet<T> lazyPersist() {
     PersistedTSet<T> persistedTSet = new PersistedTSet<>(getTSetEnv(),
-        new DiskPersistGatherSink<>(), getTargetParallelism());
+        new DiskPersistGatherSink<>(), getTargetParallelism(), getSchema());
     addChildToGraph(persistedTSet);
     return persistedTSet;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchIteratorLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchIteratorLink.java
@@ -15,11 +15,11 @@ package edu.iu.dsc.tws.tset.links.batch;
 
 import java.util.Iterator;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.ApplyFunc;
 import edu.iu.dsc.tws.api.tset.fn.FlatMapFunc;
 import edu.iu.dsc.tws.api.tset.fn.MapFunc;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.fn.FlatMapIterCompute;
 import edu.iu.dsc.tws.tset.fn.ForEachIterCompute;
@@ -29,13 +29,13 @@ import edu.iu.dsc.tws.tset.sets.batch.KeyedTSet;
 
 public abstract class BatchIteratorLink<T> extends BatchTLinkImpl<Iterator<T>, T> {
 
-  BatchIteratorLink(BatchTSetEnvironment env, String n, int sourceP, MessageType dataType) {
-    this(env, n, sourceP, sourceP, dataType);
+  BatchIteratorLink(BatchTSetEnvironment env, String n, int sourceP, Schema schema) {
+    this(env, n, sourceP, sourceP, schema);
   }
 
   BatchIteratorLink(BatchTSetEnvironment env, String n, int sourceP, int targetP,
-                    MessageType dataType) {
-    super(env, n, sourceP, targetP, dataType);
+                    Schema schema) {
+    super(env, n, sourceP, targetP, schema);
   }
 
   protected BatchIteratorLink() {
@@ -54,7 +54,7 @@ public abstract class BatchIteratorLink<T> extends BatchTLinkImpl<Iterator<T>, T
   @Override
   public <K, V> KeyedTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T> mapToTupFn) {
     KeyedTSet<K, V> set = new KeyedTSet<>(getTSetEnv(), new MapIterCompute<>(mapToTupFn),
-        getTargetParallelism());
+        getTargetParallelism(), getSchema());
 
     addChildToGraph(set);
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchIteratorLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchIteratorLink.java
@@ -15,6 +15,7 @@ package edu.iu.dsc.tws.tset.links.batch;
 
 import java.util.Iterator;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.ApplyFunc;
 import edu.iu.dsc.tws.api.tset.fn.FlatMapFunc;
@@ -28,12 +29,13 @@ import edu.iu.dsc.tws.tset.sets.batch.KeyedTSet;
 
 public abstract class BatchIteratorLink<T> extends BatchTLinkImpl<Iterator<T>, T> {
 
-  BatchIteratorLink(BatchTSetEnvironment env, String n, int sourceP) {
-    this(env, n, sourceP, sourceP);
+  BatchIteratorLink(BatchTSetEnvironment env, String n, int sourceP, MessageType dataType) {
+    this(env, n, sourceP, sourceP, dataType);
   }
 
-  BatchIteratorLink(BatchTSetEnvironment env, String n, int sourceP, int targetP) {
-    super(env, n, sourceP, targetP);
+  BatchIteratorLink(BatchTSetEnvironment env, String n, int sourceP, int targetP,
+                    MessageType dataType) {
+    super(env, n, sourceP, targetP, dataType);
   }
 
   protected BatchIteratorLink() {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchIteratorLinkWrapper.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchIteratorLinkWrapper.java
@@ -11,6 +11,7 @@
 //  limitations under the License.
 package edu.iu.dsc.tws.tset.links.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.sets.batch.CachedTSet;
@@ -26,12 +27,13 @@ import edu.iu.dsc.tws.tset.sinks.DiskPersistIterSink;
  * @param <T> type
  */
 public abstract class BatchIteratorLinkWrapper<T> extends BatchIteratorLink<T> {
-  BatchIteratorLinkWrapper(BatchTSetEnvironment env, String n, int sourceP) {
-    super(env, n, sourceP);
+  BatchIteratorLinkWrapper(BatchTSetEnvironment env, String n, int sourceP, MessageType dataType) {
+    super(env, n, sourceP, dataType);
   }
 
-  BatchIteratorLinkWrapper(BatchTSetEnvironment env, String n, int sourceP, int targetP) {
-    super(env, n, sourceP, targetP);
+  BatchIteratorLinkWrapper(BatchTSetEnvironment env, String n, int sourceP, int targetP,
+                           MessageType dataType) {
+    super(env, n, sourceP, targetP, dataType);
   }
 
   protected BatchIteratorLinkWrapper() {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchIteratorLinkWrapper.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchIteratorLinkWrapper.java
@@ -11,7 +11,7 @@
 //  limitations under the License.
 package edu.iu.dsc.tws.tset.links.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.sets.batch.CachedTSet;
@@ -27,13 +27,13 @@ import edu.iu.dsc.tws.tset.sinks.DiskPersistIterSink;
  * @param <T> type
  */
 public abstract class BatchIteratorLinkWrapper<T> extends BatchIteratorLink<T> {
-  BatchIteratorLinkWrapper(BatchTSetEnvironment env, String n, int sourceP, MessageType dataType) {
-    super(env, n, sourceP, dataType);
+  BatchIteratorLinkWrapper(BatchTSetEnvironment env, String n, int sourceP, Schema schema) {
+    super(env, n, sourceP, schema);
   }
 
   BatchIteratorLinkWrapper(BatchTSetEnvironment env, String n, int sourceP, int targetP,
-                           MessageType dataType) {
-    super(env, n, sourceP, targetP, dataType);
+                           Schema schema) {
+    super(env, n, sourceP, targetP, schema);
   }
 
   protected BatchIteratorLinkWrapper() {
@@ -42,7 +42,7 @@ public abstract class BatchIteratorLinkWrapper<T> extends BatchIteratorLink<T> {
   @Override
   public CachedTSet<T> lazyCache() {
     CachedTSet<T> cacheTSet = new CachedTSet<>(getTSetEnv(), new CacheIterSink<T>(),
-        getTargetParallelism());
+        getTargetParallelism(), getSchema());
     addChildToGraph(cacheTSet);
 
     return cacheTSet;
@@ -56,7 +56,7 @@ public abstract class BatchIteratorLinkWrapper<T> extends BatchIteratorLink<T> {
   @Override
   public PersistedTSet<T> lazyPersist() {
     PersistedTSet<T> persistedTSet = new PersistedTSet<>(getTSetEnv(),
-        new DiskPersistIterSink<>(this.getId()), getTargetParallelism());
+        new DiskPersistIterSink<>(this.getId()), getTargetParallelism(), getSchema());
     addChildToGraph(persistedTSet);
 
     return persistedTSet;

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchSingleLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchSingleLink.java
@@ -26,6 +26,7 @@
 
 package edu.iu.dsc.tws.tset.links.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.ApplyFunc;
 import edu.iu.dsc.tws.api.tset.fn.FlatMapFunc;
@@ -43,12 +44,13 @@ import edu.iu.dsc.tws.tset.sinks.DiskPersistSingleSink;
 
 public abstract class BatchSingleLink<T> extends BatchTLinkImpl<T, T> {
 
-  BatchSingleLink(BatchTSetEnvironment env, String n, int sourceP) {
-    super(env, n, sourceP, sourceP);
+  BatchSingleLink(BatchTSetEnvironment env, String n, int sourceP, MessageType dataType) {
+    super(env, n, sourceP, sourceP, dataType);
   }
 
-  BatchSingleLink(BatchTSetEnvironment env, String n, int sourceP, int targetP) {
-    super(env, n, sourceP, targetP);
+  BatchSingleLink(BatchTSetEnvironment env, String n, int sourceP, int targetP,
+                  MessageType dataType) {
+    super(env, n, sourceP, targetP, dataType);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchSingleLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchSingleLink.java
@@ -26,11 +26,11 @@
 
 package edu.iu.dsc.tws.tset.links.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.ApplyFunc;
 import edu.iu.dsc.tws.api.tset.fn.FlatMapFunc;
 import edu.iu.dsc.tws.api.tset.fn.MapFunc;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.fn.FlatMapCompute;
 import edu.iu.dsc.tws.tset.fn.ForEachCompute;
@@ -44,13 +44,13 @@ import edu.iu.dsc.tws.tset.sinks.DiskPersistSingleSink;
 
 public abstract class BatchSingleLink<T> extends BatchTLinkImpl<T, T> {
 
-  BatchSingleLink(BatchTSetEnvironment env, String n, int sourceP, MessageType dataType) {
-    super(env, n, sourceP, sourceP, dataType);
+  BatchSingleLink(BatchTSetEnvironment env, String n, int sourceP, Schema schema) {
+    super(env, n, sourceP, sourceP, schema);
   }
 
   BatchSingleLink(BatchTSetEnvironment env, String n, int sourceP, int targetP,
-                  MessageType dataType) {
-    super(env, n, sourceP, targetP, dataType);
+                  Schema schema) {
+    super(env, n, sourceP, targetP, schema);
   }
 
   @Override
@@ -78,7 +78,7 @@ public abstract class BatchSingleLink<T> extends BatchTLinkImpl<T, T> {
   @Override
   public <K, O> KeyedTSet<K, O> mapToTuple(MapFunc<Tuple<K, O>, T> genTupleFn) {
     KeyedTSet<K, O> set = new KeyedTSet<>(getTSetEnv(), new MapCompute<>(genTupleFn),
-        getTargetParallelism());
+        getTargetParallelism(), getSchema());
 
     addChildToGraph(set);
 
@@ -88,7 +88,7 @@ public abstract class BatchSingleLink<T> extends BatchTLinkImpl<T, T> {
   @Override
   public CachedTSet<T> lazyCache() {
     CachedTSet<T> cacheTSet = new CachedTSet<>(getTSetEnv(), new CacheSingleSink<T>(),
-        getTargetParallelism());
+        getTargetParallelism(), getSchema());
     addChildToGraph(cacheTSet);
     return cacheTSet;
   }
@@ -104,7 +104,7 @@ public abstract class BatchSingleLink<T> extends BatchTLinkImpl<T, T> {
         this.getId()
     );
     PersistedTSet<T> persistedTSet = new PersistedTSet<>(getTSetEnv(),
-        diskPersistSingleSink, getTargetParallelism());
+        diskPersistSingleSink, getTargetParallelism(), getSchema());
     addChildToGraph(persistedTSet);
     return persistedTSet;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchTLinkImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchTLinkImpl.java
@@ -12,9 +12,12 @@
 
 package edu.iu.dsc.tws.tset.links.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
+import edu.iu.dsc.tws.api.tset.link.TLink;
 import edu.iu.dsc.tws.api.tset.link.batch.BatchTLink;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -28,6 +31,8 @@ import edu.iu.dsc.tws.tset.sources.DiskPartitionBackedSource;
 
 public abstract class BatchTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
     implements BatchTLink<T1, T0> {
+
+  private MessageType dType = MessageTypes.OBJECT;
 
   BatchTLinkImpl(BatchTSetEnvironment env, String n, int sourceP, int targetP) {
     super(env, n, sourceP, targetP);
@@ -129,6 +134,16 @@ public abstract class BatchTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
       }
     }
     return doPersist();
+  }
+
+  @Override
+  public TLink<T1, T0> withDataType(MessageType dataType) {
+    this.dType = dataType;
+    return this;
+  }
+
+  protected MessageType getDataType() {
+    return this.dType;
   }
 
   private StorableTBase<T0> doPersist() {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchTLinkImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchTLinkImpl.java
@@ -12,12 +12,9 @@
 
 package edu.iu.dsc.tws.tset.links.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
-import edu.iu.dsc.tws.api.tset.link.TLink;
 import edu.iu.dsc.tws.api.tset.link.batch.BatchTLink;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -31,8 +28,6 @@ import edu.iu.dsc.tws.tset.sources.DiskPartitionBackedSource;
 
 public abstract class BatchTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
     implements BatchTLink<T1, T0> {
-
-  private MessageType dType = MessageTypes.OBJECT;
 
   BatchTLinkImpl(BatchTSetEnvironment env, String n, int sourceP, int targetP) {
     super(env, n, sourceP, targetP);
@@ -134,16 +129,6 @@ public abstract class BatchTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
       }
     }
     return doPersist();
-  }
-
-  @Override
-  public TLink<T1, T0> withDataType(MessageType dataType) {
-    this.dType = dataType;
-    return this;
-  }
-
-  protected MessageType getDataType() {
-    return this.dType;
   }
 
   private StorableTBase<T0> doPersist() {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchTLinkImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchTLinkImpl.java
@@ -12,6 +12,7 @@
 
 package edu.iu.dsc.tws.tset.links.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
@@ -28,9 +29,12 @@ import edu.iu.dsc.tws.tset.sources.DiskPartitionBackedSource;
 
 public abstract class BatchTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
     implements BatchTLink<T1, T0> {
+  private MessageType dType;
 
-  BatchTLinkImpl(BatchTSetEnvironment env, String n, int sourceP, int targetP) {
+  BatchTLinkImpl(BatchTSetEnvironment env, String n, int sourceP, int targetP,
+                 MessageType dataType) {
     super(env, n, sourceP, targetP);
+    this.dType = dataType;
   }
 
   protected BatchTLinkImpl() {
@@ -135,5 +139,9 @@ public abstract class BatchTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
     StorableTBase<T0> lazyPersist = lazyPersist();
     getTSetEnv().run((BaseTSet) lazyPersist);
     return lazyPersist;
+  }
+
+  protected MessageType getDataType() {
+    return dType;
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchTLinkImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchTLinkImpl.java
@@ -12,29 +12,26 @@
 
 package edu.iu.dsc.tws.tset.links.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
 import edu.iu.dsc.tws.api.tset.link.batch.BatchTLink;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.env.CheckpointingTSetEnv;
-import edu.iu.dsc.tws.tset.links.BaseTLink;
+import edu.iu.dsc.tws.tset.links.BaseTLinkWithSchema;
 import edu.iu.dsc.tws.tset.sets.BaseTSet;
 import edu.iu.dsc.tws.tset.sets.batch.CheckpointedTSet;
 import edu.iu.dsc.tws.tset.sets.batch.ComputeTSet;
 import edu.iu.dsc.tws.tset.sets.batch.SinkTSet;
 import edu.iu.dsc.tws.tset.sources.DiskPartitionBackedSource;
 
-public abstract class BatchTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
+public abstract class BatchTLinkImpl<T1, T0> extends BaseTLinkWithSchema<T1, T0>
     implements BatchTLink<T1, T0> {
-  private MessageType dType;
 
-  BatchTLinkImpl(BatchTSetEnvironment env, String n, int sourceP, int targetP,
-                 MessageType dataType) {
-    super(env, n, sourceP, targetP);
-    this.dType = dataType;
+  BatchTLinkImpl(BatchTSetEnvironment env, String n, int sourceP, int targetP, Schema schema) {
+    super(env, n, sourceP, targetP, schema);
   }
 
   protected BatchTLinkImpl() {
@@ -48,9 +45,10 @@ public abstract class BatchTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
   public <P> ComputeTSet<P, T1> compute(String n, ComputeFunc<P, T1> computeFunction) {
     ComputeTSet<P, T1> set;
     if (n != null && !n.isEmpty()) {
-      set = new ComputeTSet<>(getTSetEnv(), n, computeFunction, getTargetParallelism());
+      set = new ComputeTSet<>(getTSetEnv(), n, computeFunction, getTargetParallelism(),
+          getSchema());
     } else {
-      set = new ComputeTSet<>(getTSetEnv(), computeFunction, getTargetParallelism());
+      set = new ComputeTSet<>(getTSetEnv(), computeFunction, getTargetParallelism(), getSchema());
     }
     addChildToGraph(set);
 
@@ -60,9 +58,10 @@ public abstract class BatchTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
   public <P> ComputeTSet<P, T1> compute(String n, ComputeCollectorFunc<P, T1> computeFunction) {
     ComputeTSet<P, T1> set;
     if (n != null && !n.isEmpty()) {
-      set = new ComputeTSet<>(getTSetEnv(), n, computeFunction, getTargetParallelism());
+      set = new ComputeTSet<>(getTSetEnv(), n, computeFunction, getTargetParallelism(),
+          getSchema());
     } else {
-      set = new ComputeTSet<>(getTSetEnv(), computeFunction, getTargetParallelism());
+      set = new ComputeTSet<>(getTSetEnv(), computeFunction, getTargetParallelism(), getSchema());
     }
     addChildToGraph(set);
 
@@ -81,7 +80,8 @@ public abstract class BatchTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
 
   @Override
   public SinkTSet<T1> sink(SinkFunc<T1> sinkFunction) {
-    SinkTSet<T1> sinkTSet = new SinkTSet<>(getTSetEnv(), sinkFunction, getTargetParallelism());
+    SinkTSet<T1> sinkTSet = new SinkTSet<>(getTSetEnv(), sinkFunction, getTargetParallelism(),
+        getSchema());
     addChildToGraph(sinkTSet);
 
     return sinkTSet;
@@ -116,7 +116,7 @@ public abstract class BatchTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
         // source function, the same way as a persisted tset. This preserves the order of tsets
         // that are being created in the checkpointed env)
         CheckpointedTSet<T0> checkTSet = new CheckpointedTSet<>(getTSetEnv(), sourceFn,
-            this.getTargetParallelism());
+            this.getTargetParallelism(), getSchema());
 
         // adding checkpointed tset to the graph, so that the IDs would not change
         addChildToGraph(checkTSet);
@@ -139,9 +139,5 @@ public abstract class BatchTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
     StorableTBase<T0> lazyPersist = lazyPersist();
     getTSetEnv().run((BaseTSet) lazyPersist);
     return lazyPersist;
-  }
-
-  protected MessageType getDataType() {
-    return dType;
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/DirectTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/DirectTLink.java
@@ -14,6 +14,7 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -25,12 +26,13 @@ public class DirectTLink<T> extends BatchIteratorLinkWrapper<T> {
     //non arg constructor for kryp
   }
 
-  public DirectTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism) {
-    super(tSetEnv, "direct", sourceParallelism);
+  public DirectTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism, MessageType dataType) {
+    super(tSetEnv, "direct", sourceParallelism, dataType);
   }
 
-  public DirectTLink(BatchTSetEnvironment tSetEnv, String name, int sourceParallelism) {
-    super(tSetEnv, name, sourceParallelism);
+  public DirectTLink(BatchTSetEnvironment tSetEnv, String name, int sourceParallelism,
+                     MessageType dataType) {
+    super(tSetEnv, name, sourceParallelism, dataType);
   }
 
   @Override
@@ -41,7 +43,7 @@ public class DirectTLink<T> extends BatchIteratorLinkWrapper<T> {
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.DIRECT, getMessageType());
+    Edge e = new Edge(getId(), OperationNames.DIRECT, this.getDataType());
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/DirectTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/DirectTLink.java
@@ -14,7 +14,6 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -41,13 +40,8 @@ public class DirectTLink<T> extends BatchIteratorLinkWrapper<T> {
   }
 
   @Override
-  public DirectTLink<T> withDataType(MessageType dataType) {
-    return (DirectTLink<T>) super.withDataType(dataType);
-  }
-
-  @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.DIRECT, getDataType());
+    Edge e = new Edge(getId(), OperationNames.DIRECT, getMessageType());
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/DirectTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/DirectTLink.java
@@ -14,6 +14,7 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -40,8 +41,13 @@ public class DirectTLink<T> extends BatchIteratorLinkWrapper<T> {
   }
 
   @Override
+  public DirectTLink<T> withDataType(MessageType dataType) {
+    return (DirectTLink<T>) super.withDataType(dataType);
+  }
+
+  @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.DIRECT, getMessageType());
+    Edge e = new Edge(getId(), OperationNames.DIRECT, getDataType());
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/DirectTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/DirectTLink.java
@@ -14,9 +14,9 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 
 public class DirectTLink<T> extends BatchIteratorLinkWrapper<T> {
@@ -26,13 +26,13 @@ public class DirectTLink<T> extends BatchIteratorLinkWrapper<T> {
     //non arg constructor for kryp
   }
 
-  public DirectTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism, MessageType dataType) {
-    super(tSetEnv, "direct", sourceParallelism, dataType);
+  public DirectTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism, Schema schema) {
+    super(tSetEnv, "direct", sourceParallelism, schema);
   }
 
   public DirectTLink(BatchTSetEnvironment tSetEnv, String name, int sourceParallelism,
-                     MessageType dataType) {
-    super(tSetEnv, name, sourceParallelism, dataType);
+                     Schema schema) {
+    super(tSetEnv, name, sourceParallelism, schema);
   }
 
   @Override
@@ -43,7 +43,7 @@ public class DirectTLink<T> extends BatchIteratorLinkWrapper<T> {
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.DIRECT, this.getDataType());
+    Edge e = new Edge(getId(), OperationNames.DIRECT, this.getSchema().getDataType());
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/GatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/GatherTLink.java
@@ -13,6 +13,7 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -42,7 +43,7 @@ public class GatherTLink<T> extends BatchGatherLink<T> {
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.DIRECT, getMessageType());
+    Edge e = new Edge(getId(), OperationNames.DIRECT, getDataType());
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;
   }
@@ -51,6 +52,11 @@ public class GatherTLink<T> extends BatchGatherLink<T> {
   public GatherTLink<T> setName(String n) {
     rename(n);
     return this;
+  }
+
+  @Override
+  public GatherTLink<T> withDataType(MessageType dataType) {
+    return (GatherTLink<T>) super.withDataType(dataType);
   }
 
   public GatherTLink<T> useDisk() {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/GatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/GatherTLink.java
@@ -13,9 +13,9 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 
 /**
@@ -37,13 +37,13 @@ import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 public class GatherTLink<T> extends BatchGatherLink<T> {
   private boolean useDisk = false;
 
-  public GatherTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism, MessageType dataType) {
-    super(tSetEnv, "gather", sourceParallelism, 1, dataType);
+  public GatherTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism, Schema schema) {
+    super(tSetEnv, "gather", sourceParallelism, 1, schema);
   }
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.GATHER, getDataType());
+    Edge e = new Edge(getId(), OperationNames.GATHER, getSchema().getDataType());
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/GatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/GatherTLink.java
@@ -43,7 +43,7 @@ public class GatherTLink<T> extends BatchGatherLink<T> {
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.DIRECT, getDataType());
+    Edge e = new Edge(getId(), OperationNames.GATHER, getDataType());
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/GatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/GatherTLink.java
@@ -13,7 +13,6 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -52,11 +51,6 @@ public class GatherTLink<T> extends BatchGatherLink<T> {
   public GatherTLink<T> setName(String n) {
     rename(n);
     return this;
-  }
-
-  @Override
-  public GatherTLink<T> withDataType(MessageType dataType) {
-    return (GatherTLink<T>) super.withDataType(dataType);
   }
 
   public GatherTLink<T> useDisk() {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/GatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/GatherTLink.java
@@ -13,6 +13,7 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -36,8 +37,8 @@ import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 public class GatherTLink<T> extends BatchGatherLink<T> {
   private boolean useDisk = false;
 
-  public GatherTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism) {
-    super(tSetEnv, "gather", sourceParallelism, 1);
+  public GatherTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism, MessageType dataType) {
+    super(tSetEnv, "gather", sourceParallelism, 1, dataType);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/JoinTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/JoinTLink.java
@@ -69,13 +69,8 @@ public class JoinTLink<K, VL, VR> extends BatchIteratorLinkWrapper<JoinedTuple<K
   }
 
   @Override
-  public JoinTLink<K, VL, VR> withDataType(MessageType dataType) {
-    return (JoinTLink<K, VL, VR>) super.withDataType(dataType);
-  }
-
-  @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.JOIN, getDataType());
+    return new Edge(getId(), OperationNames.JOIN, getMessageType());
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/JoinTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/JoinTLink.java
@@ -69,8 +69,13 @@ public class JoinTLink<K, VL, VR> extends BatchIteratorLinkWrapper<JoinedTuple<K
   }
 
   @Override
+  public JoinTLink<K, VL, VR> withDataType(MessageType dataType) {
+    return (JoinTLink<K, VL, VR>) super.withDataType(dataType);
+  }
+
+  @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.JOIN, getMessageType());
+    return new Edge(getId(), OperationNames.JOIN, getDataType());
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedBatchIteratorLinkWrapper.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedBatchIteratorLinkWrapper.java
@@ -11,6 +11,7 @@
 //  limitations under the License.
 package edu.iu.dsc.tws.tset.links.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.env.CheckpointingTSetEnv;
@@ -23,12 +24,19 @@ import edu.iu.dsc.tws.tset.sources.DiskPartitionBackedSource;
 
 public abstract class KeyedBatchIteratorLinkWrapper<K, V> extends BatchIteratorLink<Tuple<K, V>> {
 
-  KeyedBatchIteratorLinkWrapper(BatchTSetEnvironment env, String n, int sourceP) {
-    super(env, n, sourceP);
+  // keyed links have an additional type for keys
+  private MessageType kType;
+
+  KeyedBatchIteratorLinkWrapper(BatchTSetEnvironment env, String n, int sourceP,
+                                MessageType keyType, MessageType dataType) {
+    super(env, n, sourceP, dataType);
+    this.kType = keyType;
   }
 
-  KeyedBatchIteratorLinkWrapper(BatchTSetEnvironment env, String n, int sourceP, int targetP) {
-    super(env, n, sourceP, targetP);
+  KeyedBatchIteratorLinkWrapper(BatchTSetEnvironment env, String n, int sourceP, int targetP,
+                                MessageType keyType, MessageType dataType) {
+    super(env, n, sourceP, targetP, dataType);
+    this.kType = keyType;
   }
 
   protected KeyedBatchIteratorLinkWrapper() {
@@ -91,6 +99,10 @@ public abstract class KeyedBatchIteratorLinkWrapper<K, V> extends BatchIteratorL
       }
     }
     return doPersist();
+  }
+
+  protected MessageType getKeyType() {
+    return kType;
   }
 
   private KeyedPersistedTSet<K, V> doPersist() {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedDirectTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedDirectTLink.java
@@ -12,6 +12,8 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
@@ -22,8 +24,9 @@ import edu.iu.dsc.tws.tset.sets.batch.KeyedTSet;
 public class KeyedDirectTLink<K, V> extends KeyedBatchIteratorLinkWrapper<K, V> {
   private boolean useDisk = false;
 
-  public KeyedDirectTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism) {
-    super(tSetEnv, "kdirect", sourceParallelism);
+  public KeyedDirectTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism,
+                          MessageType keyType, MessageType dataType) {
+    super(tSetEnv, "kdirect", sourceParallelism, keyType, dataType);
   }
 
   public KeyedTSet<K, V> mapToTuple() {
@@ -38,7 +41,11 @@ public class KeyedDirectTLink<K, V> extends KeyedBatchIteratorLinkWrapper<K, V> 
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.DIRECT, getMessageType());
+    // NOTE: There is no keyed direct in the communication layer!!! Hence this is an keyed direct
+    // emulation. Therefore, we can not use user provided data types here because we will be using
+    // Tuple<K, V> object through a DirectLink here.
+    // todo fix this ambiguity!
+    Edge e = new Edge(getId(), OperationNames.DIRECT, MessageTypes.OBJECT);
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedDirectTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedDirectTLink.java
@@ -12,6 +12,7 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
@@ -37,8 +38,13 @@ public class KeyedDirectTLink<K, V> extends KeyedBatchIteratorLinkWrapper<K, V> 
   }
 
   @Override
+  public KeyedDirectTLink<K, V> withDataType(MessageType dataType) {
+    return (KeyedDirectTLink<K, V>) super.withDataType(dataType);
+  }
+
+  @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.DIRECT, getMessageType());
+    Edge e = new Edge(getId(), OperationNames.DIRECT, getDataType());
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedDirectTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedDirectTLink.java
@@ -12,7 +12,6 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
@@ -38,13 +37,8 @@ public class KeyedDirectTLink<K, V> extends KeyedBatchIteratorLinkWrapper<K, V> 
   }
 
   @Override
-  public KeyedDirectTLink<K, V> withDataType(MessageType dataType) {
-    return (KeyedDirectTLink<K, V>) super.withDataType(dataType);
-  }
-
-  @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.DIRECT, getDataType());
+    Edge e = new Edge(getId(), OperationNames.DIRECT, getMessageType());
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedDirectTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedDirectTLink.java
@@ -12,12 +12,12 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.MapFunc;
+import edu.iu.dsc.tws.api.tset.schema.KeyedSchema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.sets.batch.KeyedTSet;
 
@@ -25,8 +25,8 @@ public class KeyedDirectTLink<K, V> extends KeyedBatchIteratorLinkWrapper<K, V> 
   private boolean useDisk = false;
 
   public KeyedDirectTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism,
-                          MessageType keyType, MessageType dataType) {
-    super(tSetEnv, "kdirect", sourceParallelism, keyType, dataType);
+                          KeyedSchema schema) {
+    super(tSetEnv, "kdirect", sourceParallelism, schema);
   }
 
   public KeyedTSet<K, V> mapToTuple() {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedGatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedGatherTLink.java
@@ -15,6 +15,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.logging.Logger;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 
@@ -25,18 +26,20 @@ public class KeyedGatherTLink<K, V> extends KeyedGatherUngroupedTLink<K, Iterato
     //non arg constructor for kryo
   }
 
-  public KeyedGatherTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism) {
-    this(tSetEnv, null, sourceParallelism, null);
+  public KeyedGatherTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism, MessageType keyType,
+                          MessageType dataType) {
+    this(tSetEnv, null, sourceParallelism, null, keyType, dataType);
   }
 
   public KeyedGatherTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<K> partitionFn,
-                          int sourceParallelism) {
-    this(tSetEnv, partitionFn, sourceParallelism, null);
+                          int sourceParallelism, MessageType keyType, MessageType dataType) {
+    this(tSetEnv, partitionFn, sourceParallelism, null, keyType, dataType);
   }
 
   public KeyedGatherTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<K> partitionFn,
-                          int sourceParallelism, Comparator<K> keyCompartor) {
-    super(tSetEnv, partitionFn, sourceParallelism, keyCompartor);
+                          int sourceParallelism, Comparator<K> keyCompartor, MessageType keyType,
+                          MessageType dataType) {
+    super(tSetEnv, partitionFn, sourceParallelism, keyCompartor, keyType, dataType);
     this.enableGroupByKey();
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedGatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedGatherTLink.java
@@ -15,8 +15,8 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.logging.Logger;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
+import edu.iu.dsc.tws.api.tset.schema.KeyedSchema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 
 public class KeyedGatherTLink<K, V> extends KeyedGatherUngroupedTLink<K, Iterator<V>> {
@@ -26,20 +26,18 @@ public class KeyedGatherTLink<K, V> extends KeyedGatherUngroupedTLink<K, Iterato
     //non arg constructor for kryo
   }
 
-  public KeyedGatherTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism, MessageType keyType,
-                          MessageType dataType) {
-    this(tSetEnv, null, sourceParallelism, null, keyType, dataType);
+  public KeyedGatherTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism, KeyedSchema schema) {
+    this(tSetEnv, null, sourceParallelism, null, schema);
   }
 
   public KeyedGatherTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<K> partitionFn,
-                          int sourceParallelism, MessageType keyType, MessageType dataType) {
-    this(tSetEnv, partitionFn, sourceParallelism, null, keyType, dataType);
+                          int sourceParallelism, KeyedSchema schema) {
+    this(tSetEnv, partitionFn, sourceParallelism, null, schema);
   }
 
   public KeyedGatherTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<K> partitionFn,
-                          int sourceParallelism, Comparator<K> keyCompartor, MessageType keyType,
-                          MessageType dataType) {
-    super(tSetEnv, partitionFn, sourceParallelism, keyCompartor, keyType, dataType);
+                          int sourceParallelism, Comparator<K> keyCompartor, KeyedSchema schema) {
+    super(tSetEnv, partitionFn, sourceParallelism, keyCompartor, schema);
     this.enableGroupByKey();
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedGatherUngroupedTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedGatherUngroupedTLink.java
@@ -16,7 +16,6 @@ import java.util.Comparator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
@@ -54,13 +53,8 @@ public class KeyedGatherUngroupedTLink<K, V> extends KeyedBatchIteratorLinkWrapp
   }
 
   @Override
-  public KeyedGatherUngroupedTLink<K, V> withDataType(MessageType dataType) {
-    return (KeyedGatherUngroupedTLink<K, V>) super.withDataType(dataType);
-  }
-
-  @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.KEYED_GATHER, getDataType());
+    Edge e = new Edge(getId(), OperationNames.KEYED_GATHER, getMessageType());
     e.setKeyed(true);
     e.setPartitioner(partitionFunction);
     e.addProperty(CommunicationContext.SORT_BY_KEY, this.keyCompartor != null);

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedGatherUngroupedTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedGatherUngroupedTLink.java
@@ -16,10 +16,10 @@ import java.util.Comparator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
+import edu.iu.dsc.tws.api.tset.schema.KeyedSchema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 
 public class KeyedGatherUngroupedTLink<K, V> extends KeyedBatchIteratorLinkWrapper<K, V> {
@@ -33,20 +33,19 @@ public class KeyedGatherUngroupedTLink<K, V> extends KeyedBatchIteratorLinkWrapp
   private boolean useDisk = false;
 
   public KeyedGatherUngroupedTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism,
-                                   MessageType keyType, MessageType dataType) {
-    this(tSetEnv, null, sourceParallelism, null, keyType, dataType);
+                                   KeyedSchema schema) {
+    this(tSetEnv, null, sourceParallelism, null, schema);
   }
 
   public KeyedGatherUngroupedTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<K> partitionFn,
-                                   int sourceParallelism, MessageType keyType,
-                                   MessageType dataType) {
-    this(tSetEnv, partitionFn, sourceParallelism, null, keyType, dataType);
+                                   int sourceParallelism, KeyedSchema schema) {
+    this(tSetEnv, partitionFn, sourceParallelism, null, schema);
   }
 
   public KeyedGatherUngroupedTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<K> partitionFn,
                                    int sourceParallelism, Comparator<K> keyCompartor,
-                                   MessageType keyType, MessageType dataType) {
-    super(tSetEnv, "kgather", sourceParallelism, keyType, dataType);
+                                   KeyedSchema schema) {
+    super(tSetEnv, "kgather", sourceParallelism, schema);
     this.partitionFunction = partitionFn;
     this.keyCompartor = keyCompartor;
   }
@@ -58,9 +57,9 @@ public class KeyedGatherUngroupedTLink<K, V> extends KeyedBatchIteratorLinkWrapp
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.KEYED_GATHER, this.getDataType());
+    Edge e = new Edge(getId(), OperationNames.KEYED_GATHER, this.getSchema().getDataType());
     e.setKeyed(true);
-    e.setKeyType(this.getKeyType());
+    e.setKeyType(this.getSchema().getKeyType());
     e.setPartitioner(partitionFunction);
     e.addProperty(CommunicationContext.SORT_BY_KEY, this.keyCompartor != null);
     e.addProperty(CommunicationContext.GROUP_BY_KEY, this.groupByKey);

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedGatherUngroupedTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedGatherUngroupedTLink.java
@@ -16,6 +16,7 @@ import java.util.Comparator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
@@ -31,18 +32,21 @@ public class KeyedGatherUngroupedTLink<K, V> extends KeyedBatchIteratorLinkWrapp
 
   private boolean useDisk = false;
 
-  public KeyedGatherUngroupedTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism) {
-    this(tSetEnv, null, sourceParallelism, null);
+  public KeyedGatherUngroupedTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism,
+                                   MessageType keyType, MessageType dataType) {
+    this(tSetEnv, null, sourceParallelism, null, keyType, dataType);
   }
 
   public KeyedGatherUngroupedTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<K> partitionFn,
-                                   int sourceParallelism) {
-    this(tSetEnv, partitionFn, sourceParallelism, null);
+                                   int sourceParallelism, MessageType keyType,
+                                   MessageType dataType) {
+    this(tSetEnv, partitionFn, sourceParallelism, null, keyType, dataType);
   }
 
   public KeyedGatherUngroupedTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<K> partitionFn,
-                                   int sourceParallelism, Comparator<K> keyCompartor) {
-    super(tSetEnv, "kgather", sourceParallelism);
+                                   int sourceParallelism, Comparator<K> keyCompartor,
+                                   MessageType keyType, MessageType dataType) {
+    super(tSetEnv, "kgather", sourceParallelism, keyType, dataType);
     this.partitionFunction = partitionFn;
     this.keyCompartor = keyCompartor;
   }
@@ -54,8 +58,9 @@ public class KeyedGatherUngroupedTLink<K, V> extends KeyedBatchIteratorLinkWrapp
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.KEYED_GATHER, getMessageType());
+    Edge e = new Edge(getId(), OperationNames.KEYED_GATHER, this.getDataType());
     e.setKeyed(true);
+    e.setKeyType(this.getKeyType());
     e.setPartitioner(partitionFunction);
     e.addProperty(CommunicationContext.SORT_BY_KEY, this.keyCompartor != null);
     e.addProperty(CommunicationContext.GROUP_BY_KEY, this.groupByKey);

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedGatherUngroupedTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedGatherUngroupedTLink.java
@@ -16,6 +16,7 @@ import java.util.Comparator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
@@ -53,8 +54,13 @@ public class KeyedGatherUngroupedTLink<K, V> extends KeyedBatchIteratorLinkWrapp
   }
 
   @Override
+  public KeyedGatherUngroupedTLink<K, V> withDataType(MessageType dataType) {
+    return (KeyedGatherUngroupedTLink<K, V>) super.withDataType(dataType);
+  }
+
+  @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.KEYED_GATHER, getMessageType());
+    Edge e = new Edge(getId(), OperationNames.KEYED_GATHER, getDataType());
     e.setKeyed(true);
     e.setPartitioner(partitionFunction);
     e.addProperty(CommunicationContext.SORT_BY_KEY, this.keyCompartor != null);

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedPartitionTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedPartitionTLink.java
@@ -26,10 +26,10 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
+import edu.iu.dsc.tws.api.tset.schema.KeyedSchema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 
 public class KeyedPartitionTLink<K, V> extends KeyedBatchIteratorLinkWrapper<K, V> {
@@ -38,16 +38,16 @@ public class KeyedPartitionTLink<K, V> extends KeyedBatchIteratorLinkWrapper<K, 
   private boolean useDisk = false;
 
   public KeyedPartitionTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<K> parFn,
-                             int sourceParallelism, MessageType keyType, MessageType dataType) {
-    super(tSetEnv, "kpartition", sourceParallelism, keyType, dataType);
+                             int sourceParallelism, KeyedSchema schema) {
+    super(tSetEnv, "kpartition", sourceParallelism, schema);
     this.partitionFunction = parFn;
   }
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.KEYED_PARTITION, this.getDataType());
+    Edge e = new Edge(getId(), OperationNames.KEYED_PARTITION, this.getSchema().getDataType());
     e.setKeyed(true);
-    e.setKeyType(this.getKeyType());
+    e.setKeyType(this.getSchema().getKeyType());
     e.setPartitioner(partitionFunction);
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedPartitionTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedPartitionTLink.java
@@ -10,22 +10,10 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
-//
-//  http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
-
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
@@ -43,8 +31,13 @@ public class KeyedPartitionTLink<K, V> extends KeyedBatchIteratorLinkWrapper<K, 
   }
 
   @Override
+  public KeyedPartitionTLink<K, V> withDataType(MessageType dataType) {
+    return (KeyedPartitionTLink<K, V>) super.withDataType(dataType);
+  }
+
+  @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.KEYED_PARTITION, getMessageType());
+    Edge e = new Edge(getId(), OperationNames.KEYED_PARTITION, getDataType());
     e.setKeyed(true);
     e.setPartitioner(partitionFunction);
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedPartitionTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedPartitionTLink.java
@@ -26,6 +26,7 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
@@ -37,15 +38,16 @@ public class KeyedPartitionTLink<K, V> extends KeyedBatchIteratorLinkWrapper<K, 
   private boolean useDisk = false;
 
   public KeyedPartitionTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<K> parFn,
-                             int sourceParallelism) {
-    super(tSetEnv, "kpartition", sourceParallelism);
+                             int sourceParallelism, MessageType keyType, MessageType dataType) {
+    super(tSetEnv, "kpartition", sourceParallelism, keyType, dataType);
     this.partitionFunction = parFn;
   }
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.KEYED_PARTITION, getMessageType());
+    Edge e = new Edge(getId(), OperationNames.KEYED_PARTITION, this.getDataType());
     e.setKeyed(true);
+    e.setKeyType(this.getKeyType());
     e.setPartitioner(partitionFunction);
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedPartitionTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedPartitionTLink.java
@@ -10,10 +10,22 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
@@ -31,13 +43,8 @@ public class KeyedPartitionTLink<K, V> extends KeyedBatchIteratorLinkWrapper<K, 
   }
 
   @Override
-  public KeyedPartitionTLink<K, V> withDataType(MessageType dataType) {
-    return (KeyedPartitionTLink<K, V>) super.withDataType(dataType);
-  }
-
-  @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.KEYED_PARTITION, getDataType());
+    Edge e = new Edge(getId(), OperationNames.KEYED_PARTITION, getMessageType());
     e.setKeyed(true);
     e.setPartitioner(partitionFunction);
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedReduceTLink.java
@@ -10,9 +10,21 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package edu.iu.dsc.tws.tset.links.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
@@ -27,13 +39,8 @@ public class KeyedReduceTLink<K, V> extends KeyedBatchIteratorLinkWrapper<K, V> 
   }
 
   @Override
-  public KeyedReduceTLink<K, V> withDataType(MessageType dataType) {
-    return (KeyedReduceTLink<K, V>) super.withDataType(dataType);
-  }
-
-  @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.KEYED_REDUCE, getDataType(), reduceFn);
+    Edge e = new Edge(getId(), OperationNames.KEYED_REDUCE, getMessageType(), reduceFn);
     e.setKeyed(true);
     return e;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedReduceTLink.java
@@ -25,6 +25,7 @@
 
 package edu.iu.dsc.tws.tset.links.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
@@ -33,15 +34,17 @@ import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 public class KeyedReduceTLink<K, V> extends KeyedBatchIteratorLinkWrapper<K, V> {
   private ReduceFunc<V> reduceFn;
 
-  public KeyedReduceTLink(BatchTSetEnvironment tSetEnv, ReduceFunc<V> rFn, int sourceParallelism) {
-    super(tSetEnv, "kreduce", sourceParallelism);
+  public KeyedReduceTLink(BatchTSetEnvironment tSetEnv, ReduceFunc<V> rFn, int sourceParallelism,
+                          MessageType keyType, MessageType dataType) {
+    super(tSetEnv, "kreduce", sourceParallelism, keyType, dataType);
     this.reduceFn = rFn;
   }
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.KEYED_REDUCE, getMessageType(), reduceFn);
+    Edge e = new Edge(getId(), OperationNames.KEYED_REDUCE, this.getDataType(), reduceFn);
     e.setKeyed(true);
+    e.setKeyType(this.getKeyType());
     return e;
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedReduceTLink.java
@@ -10,21 +10,9 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
-//
-//  http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
-
 package edu.iu.dsc.tws.tset.links.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
@@ -39,8 +27,13 @@ public class KeyedReduceTLink<K, V> extends KeyedBatchIteratorLinkWrapper<K, V> 
   }
 
   @Override
+  public KeyedReduceTLink<K, V> withDataType(MessageType dataType) {
+    return (KeyedReduceTLink<K, V>) super.withDataType(dataType);
+  }
+
+  @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.KEYED_REDUCE, getMessageType(), reduceFn);
+    Edge e = new Edge(getId(), OperationNames.KEYED_REDUCE, getDataType(), reduceFn);
     e.setKeyed(true);
     return e;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/KeyedReduceTLink.java
@@ -25,26 +25,27 @@
 
 package edu.iu.dsc.tws.tset.links.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
+import edu.iu.dsc.tws.api.tset.schema.KeyedSchema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 
 public class KeyedReduceTLink<K, V> extends KeyedBatchIteratorLinkWrapper<K, V> {
   private ReduceFunc<V> reduceFn;
 
   public KeyedReduceTLink(BatchTSetEnvironment tSetEnv, ReduceFunc<V> rFn, int sourceParallelism,
-                          MessageType keyType, MessageType dataType) {
-    super(tSetEnv, "kreduce", sourceParallelism, keyType, dataType);
+                          KeyedSchema schema) {
+    super(tSetEnv, "kreduce", sourceParallelism, schema);
     this.reduceFn = rFn;
   }
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.KEYED_REDUCE, this.getDataType(), reduceFn);
+    Edge e = new Edge(getId(), OperationNames.KEYED_REDUCE, this.getSchema().getDataType(),
+        reduceFn);
     e.setKeyed(true);
-    e.setKeyType(this.getKeyType());
+    e.setKeyType(this.getSchema().getKeyType());
     return e;
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/PartitionTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/PartitionTLink.java
@@ -10,10 +10,10 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
@@ -40,14 +40,10 @@ public class PartitionTLink<T> extends BatchIteratorLinkWrapper<T> {
     this.partitionFunction = parFn;
   }
 
-  @Override
-  public PartitionTLink<T> withDataType(MessageType dataType) {
-    return (PartitionTLink<T>) super.withDataType(dataType);
-  }
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.PARTITION, getDataType());
+    Edge e = new Edge(getId(), OperationNames.PARTITION, getMessageType());
     if (partitionFunction != null) {
       e.setPartitioner(partitionFunction);
     }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/PartitionTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/PartitionTLink.java
@@ -14,10 +14,10 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 
 public class PartitionTLink<T> extends BatchIteratorLinkWrapper<T> {
@@ -26,25 +26,25 @@ public class PartitionTLink<T> extends BatchIteratorLinkWrapper<T> {
 
   private PartitionFunc<T> partitionFunction;
 
-  public PartitionTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism, MessageType dataType) {
-    this(tSetEnv, null, sourceParallelism, dataType);
+  public PartitionTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism, Schema schema) {
+    this(tSetEnv, null, sourceParallelism, schema);
   }
 
   public PartitionTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<T> parFn,
-                        int sourceParallelism, MessageType dataType) {
-    this(tSetEnv, parFn, sourceParallelism, sourceParallelism, dataType);
+                        int sourceParallelism, Schema schema) {
+    this(tSetEnv, parFn, sourceParallelism, sourceParallelism, schema);
   }
 
   public PartitionTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<T> parFn,
-                        int sourceParallelism, int targetParallelism, MessageType dataType) {
-    super(tSetEnv, "partition", sourceParallelism, targetParallelism, dataType);
+                        int sourceParallelism, int targetParallelism, Schema schema) {
+    super(tSetEnv, "partition", sourceParallelism, targetParallelism, schema);
     this.partitionFunction = parFn;
   }
 
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.PARTITION, this.getDataType());
+    Edge e = new Edge(getId(), OperationNames.PARTITION, this.getSchema().getDataType());
     if (partitionFunction != null) {
       e.setPartitioner(partitionFunction);
     }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/PartitionTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/PartitionTLink.java
@@ -10,10 +10,10 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
@@ -40,10 +40,14 @@ public class PartitionTLink<T> extends BatchIteratorLinkWrapper<T> {
     this.partitionFunction = parFn;
   }
 
+  @Override
+  public PartitionTLink<T> withDataType(MessageType dataType) {
+    return (PartitionTLink<T>) super.withDataType(dataType);
+  }
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.PARTITION, getMessageType());
+    Edge e = new Edge(getId(), OperationNames.PARTITION, getDataType());
     if (partitionFunction != null) {
       e.setPartitioner(partitionFunction);
     }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/PartitionTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/PartitionTLink.java
@@ -14,6 +14,7 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
@@ -25,25 +26,25 @@ public class PartitionTLink<T> extends BatchIteratorLinkWrapper<T> {
 
   private PartitionFunc<T> partitionFunction;
 
-  public PartitionTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism) {
-    this(tSetEnv, null, sourceParallelism);
+  public PartitionTLink(BatchTSetEnvironment tSetEnv, int sourceParallelism, MessageType dataType) {
+    this(tSetEnv, null, sourceParallelism, dataType);
   }
 
   public PartitionTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<T> parFn,
-                        int sourceParallelism) {
-    this(tSetEnv, parFn, sourceParallelism, sourceParallelism);
+                        int sourceParallelism, MessageType dataType) {
+    this(tSetEnv, parFn, sourceParallelism, sourceParallelism, dataType);
   }
 
   public PartitionTLink(BatchTSetEnvironment tSetEnv, PartitionFunc<T> parFn,
-                        int sourceParallelism, int targetParallelism) {
-    super(tSetEnv, "partition", sourceParallelism, targetParallelism);
+                        int sourceParallelism, int targetParallelism, MessageType dataType) {
+    super(tSetEnv, "partition", sourceParallelism, targetParallelism, dataType);
     this.partitionFunction = parFn;
   }
 
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.PARTITION, getMessageType());
+    Edge e = new Edge(getId(), OperationNames.PARTITION, this.getDataType());
     if (partitionFunction != null) {
       e.setPartitioner(partitionFunction);
     }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/ReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/ReduceTLink.java
@@ -10,21 +10,9 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
-//
-//  http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
-
 package edu.iu.dsc.tws.tset.links.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
@@ -45,8 +33,13 @@ public class ReduceTLink<T> extends BatchSingleLink<T> {
   }
 
   @Override
+  public ReduceTLink<T> withDataType(MessageType dataType) {
+    return (ReduceTLink<T>) super.withDataType(dataType);
+  }
+
+  @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.REDUCE, getMessageType(), reduceFn);
+    return new Edge(getId(), OperationNames.REDUCE, getDataType(), reduceFn);
   }
 
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/ReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/ReduceTLink.java
@@ -10,9 +10,21 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package edu.iu.dsc.tws.tset.links.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
@@ -33,13 +45,8 @@ public class ReduceTLink<T> extends BatchSingleLink<T> {
   }
 
   @Override
-  public ReduceTLink<T> withDataType(MessageType dataType) {
-    return (ReduceTLink<T>) super.withDataType(dataType);
-  }
-
-  @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.REDUCE, getDataType(), reduceFn);
+    return new Edge(getId(), OperationNames.REDUCE, getMessageType(), reduceFn);
   }
 
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/ReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/ReduceTLink.java
@@ -25,18 +25,18 @@
 
 package edu.iu.dsc.tws.tset.links.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 
 public class ReduceTLink<T> extends BatchSingleLink<T> {
   private ReduceFunc<T> reduceFn;
 
   public ReduceTLink(BatchTSetEnvironment tSetEnv, ReduceFunc<T> rFn, int sourceParallelism,
-                     MessageType dataType) {
-    super(tSetEnv, "reduce", sourceParallelism, 1, dataType);
+                     Schema schema) {
+    super(tSetEnv, "reduce", sourceParallelism, 1, schema);
     this.reduceFn = rFn;
   }
 
@@ -48,7 +48,7 @@ public class ReduceTLink<T> extends BatchSingleLink<T> {
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.REDUCE, this.getDataType(), reduceFn);
+    return new Edge(getId(), OperationNames.REDUCE, this.getSchema().getDataType(), reduceFn);
   }
 
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/ReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/ReduceTLink.java
@@ -25,6 +25,7 @@
 
 package edu.iu.dsc.tws.tset.links.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
@@ -33,8 +34,9 @@ import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 public class ReduceTLink<T> extends BatchSingleLink<T> {
   private ReduceFunc<T> reduceFn;
 
-  public ReduceTLink(BatchTSetEnvironment tSetEnv, ReduceFunc<T> rFn, int sourceParallelism) {
-    super(tSetEnv, "reduce", sourceParallelism, 1);
+  public ReduceTLink(BatchTSetEnvironment tSetEnv, ReduceFunc<T> rFn, int sourceParallelism,
+                     MessageType dataType) {
+    super(tSetEnv, "reduce", sourceParallelism, 1, dataType);
     this.reduceFn = rFn;
   }
 
@@ -46,7 +48,7 @@ public class ReduceTLink<T> extends BatchSingleLink<T> {
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.REDUCE, getMessageType(), reduceFn);
+    return new Edge(getId(), OperationNames.REDUCE, this.getDataType(), reduceFn);
   }
 
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/ReplicateTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/ReplicateTLink.java
@@ -14,6 +14,7 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -26,16 +27,21 @@ public class ReplicateTLink<T> extends BatchIteratorLinkWrapper<T> {
   }
 
   @Override
-  public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.BROADCAST, getMessageType());
-    e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
-    return e;
-  }
-
-  @Override
   public ReplicateTLink<T> setName(String n) {
     rename(n);
     return this;
+  }
+
+  @Override
+  public ReplicateTLink<T> withDataType(MessageType dataType) {
+    return (ReplicateTLink<T>) super.withDataType(dataType);
+  }
+
+  @Override
+  public Edge getEdge() {
+    Edge e = new Edge(getId(), OperationNames.BROADCAST, getDataType());
+    e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
+    return e;
   }
 
   public ReplicateTLink<T> useDisk() {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/ReplicateTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/ReplicateTLink.java
@@ -14,7 +14,6 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -27,21 +26,16 @@ public class ReplicateTLink<T> extends BatchIteratorLinkWrapper<T> {
   }
 
   @Override
+  public Edge getEdge() {
+    Edge e = new Edge(getId(), OperationNames.BROADCAST, getMessageType());
+    e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
+    return e;
+  }
+
+  @Override
   public ReplicateTLink<T> setName(String n) {
     rename(n);
     return this;
-  }
-
-  @Override
-  public ReplicateTLink<T> withDataType(MessageType dataType) {
-    return (ReplicateTLink<T>) super.withDataType(dataType);
-  }
-
-  @Override
-  public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.BROADCAST, getDataType());
-    e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
-    return e;
   }
 
   public ReplicateTLink<T> useDisk() {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/ReplicateTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/ReplicateTLink.java
@@ -14,21 +14,21 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 
 public class ReplicateTLink<T> extends BatchIteratorLinkWrapper<T> {
   private boolean useDisk = false;
 
-  public ReplicateTLink(BatchTSetEnvironment tSetEnv, int reps, MessageType dataType) {
-    super(tSetEnv, "replicate", 1, reps, dataType);
+  public ReplicateTLink(BatchTSetEnvironment tSetEnv, int reps, Schema schema) {
+    super(tSetEnv, "replicate", 1, reps, schema);
   }
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.BROADCAST, this.getDataType());
+    Edge e = new Edge(getId(), OperationNames.BROADCAST, this.getSchema().getDataType());
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/ReplicateTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/ReplicateTLink.java
@@ -14,6 +14,7 @@
 package edu.iu.dsc.tws.tset.links.batch;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -21,13 +22,13 @@ import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 public class ReplicateTLink<T> extends BatchIteratorLinkWrapper<T> {
   private boolean useDisk = false;
 
-  public ReplicateTLink(BatchTSetEnvironment tSetEnv, int reps) {
-    super(tSetEnv, "replicate", 1, reps);
+  public ReplicateTLink(BatchTSetEnvironment tSetEnv, int reps, MessageType dataType) {
+    super(tSetEnv, "replicate", 1, reps, dataType);
   }
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.BROADCAST, getMessageType());
+    Edge e = new Edge(getId(), OperationNames.BROADCAST, this.getDataType());
     e.addProperty(CommunicationContext.USE_DISK, this.useDisk);
     return e;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SAllGatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SAllGatherTLink.java
@@ -13,7 +13,6 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
@@ -30,18 +29,13 @@ public class SAllGatherTLink<T> extends StreamingGatherLink<T> {
   }
 
   @Override
+  public Edge getEdge() {
+    return new Edge(getId(), OperationNames.ALLGATHER, getMessageType());
+  }
+
+  @Override
   public SAllGatherTLink<T> setName(String n) {
     rename(n);
     return this;
-  }
-
-  @Override
-  public SAllGatherTLink<T> withDataType(MessageType dataType) {
-    return (SAllGatherTLink<T>) super.withDataType(dataType);
-  }
-
-  @Override
-  public Edge getEdge() {
-    return new Edge(getId(), OperationNames.ALLGATHER, getDataType());
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SAllGatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SAllGatherTLink.java
@@ -13,6 +13,7 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
@@ -29,13 +30,18 @@ public class SAllGatherTLink<T> extends StreamingGatherLink<T> {
   }
 
   @Override
-  public Edge getEdge() {
-    return new Edge(getId(), OperationNames.ALLGATHER, getMessageType());
-  }
-
-  @Override
   public SAllGatherTLink<T> setName(String n) {
     rename(n);
     return this;
+  }
+
+  @Override
+  public SAllGatherTLink<T> withDataType(MessageType dataType) {
+    return (SAllGatherTLink<T>) super.withDataType(dataType);
+  }
+
+  @Override
+  public Edge getEdge() {
+    return new Edge(getId(), OperationNames.ALLGATHER, getDataType());
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SAllGatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SAllGatherTLink.java
@@ -13,9 +13,9 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 
 /**
@@ -26,13 +26,13 @@ import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 public class SAllGatherTLink<T> extends StreamingGatherLink<T> {
 
   public SAllGatherTLink(StreamingTSetEnvironment tSetEnv, int sourceParalellism,
-                         MessageType dataType) {
-    super(tSetEnv, "sallgather", sourceParalellism, dataType);
+                         Schema schema) {
+    super(tSetEnv, "sallgather", sourceParalellism, schema);
   }
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.ALLGATHER, getDataType());
+    return new Edge(getId(), OperationNames.ALLGATHER, this.getSchema().getDataType());
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SAllGatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SAllGatherTLink.java
@@ -13,6 +13,7 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
@@ -24,13 +25,14 @@ import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
  */
 public class SAllGatherTLink<T> extends StreamingGatherLink<T> {
 
-  public SAllGatherTLink(StreamingTSetEnvironment tSetEnv, int sourceParalellism) {
-    super(tSetEnv, "sallgather", sourceParalellism);
+  public SAllGatherTLink(StreamingTSetEnvironment tSetEnv, int sourceParalellism,
+                         MessageType dataType) {
+    super(tSetEnv, "sallgather", sourceParalellism, dataType);
   }
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.ALLGATHER, getMessageType());
+    return new Edge(getId(), OperationNames.ALLGATHER, getDataType());
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SAllReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SAllReduceTLink.java
@@ -13,6 +13,7 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
@@ -27,14 +28,14 @@ public class SAllReduceTLink<T> extends StreamingSingleLink<T> {
   private ReduceFunc<T> reduceFn;
 
   public SAllReduceTLink(StreamingTSetEnvironment tSetEnv, ReduceFunc<T> rFn,
-                         int sourceParallelism) {
-    super(tSetEnv, "sallreduce", sourceParallelism);
+                         int sourceParallelism, MessageType dataType) {
+    super(tSetEnv, "sallreduce", sourceParallelism, dataType);
     this.reduceFn = rFn;
   }
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.ALLREDUCE, getMessageType(), reduceFn);
+    return new Edge(getId(), OperationNames.ALLREDUCE, getDataType(), reduceFn);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SAllReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SAllReduceTLink.java
@@ -13,6 +13,7 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
@@ -33,13 +34,18 @@ public class SAllReduceTLink<T> extends StreamingSingleLink<T> {
   }
 
   @Override
-  public Edge getEdge() {
-    return new Edge(getId(), OperationNames.ALLREDUCE, getMessageType(), reduceFn);
-  }
-
-  @Override
   public SAllReduceTLink<T> setName(String n) {
     rename(n);
     return this;
+  }
+
+  @Override
+  public SAllReduceTLink<T> withDataType(MessageType dataType) {
+    return (SAllReduceTLink<T>) super.withDataType(dataType);
+  }
+
+  @Override
+  public Edge getEdge() {
+    return new Edge(getId(), OperationNames.ALLREDUCE, getDataType(), reduceFn);
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SAllReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SAllReduceTLink.java
@@ -13,10 +13,10 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 
 /**
@@ -27,15 +27,15 @@ import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 public class SAllReduceTLink<T> extends StreamingSingleLink<T> {
   private ReduceFunc<T> reduceFn;
 
-  public SAllReduceTLink(StreamingTSetEnvironment tSetEnv, ReduceFunc<T> rFn,
-                         int sourceParallelism, MessageType dataType) {
-    super(tSetEnv, "sallreduce", sourceParallelism, dataType);
+  public SAllReduceTLink(StreamingTSetEnvironment tSetEnv, ReduceFunc<T> rFn, int sourceParallelism,
+                         Schema schema) {
+    super(tSetEnv, "sallreduce", sourceParallelism, schema);
     this.reduceFn = rFn;
   }
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.ALLREDUCE, getDataType(), reduceFn);
+    return new Edge(getId(), OperationNames.ALLREDUCE, this.getSchema().getDataType(), reduceFn);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SAllReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SAllReduceTLink.java
@@ -13,7 +13,6 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
@@ -34,18 +33,13 @@ public class SAllReduceTLink<T> extends StreamingSingleLink<T> {
   }
 
   @Override
+  public Edge getEdge() {
+    return new Edge(getId(), OperationNames.ALLREDUCE, getMessageType(), reduceFn);
+  }
+
+  @Override
   public SAllReduceTLink<T> setName(String n) {
     rename(n);
     return this;
-  }
-
-  @Override
-  public SAllReduceTLink<T> withDataType(MessageType dataType) {
-    return (SAllReduceTLink<T>) super.withDataType(dataType);
-  }
-
-  @Override
-  public Edge getEdge() {
-    return new Edge(getId(), OperationNames.ALLREDUCE, getDataType(), reduceFn);
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SDirectTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SDirectTLink.java
@@ -13,6 +13,7 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
@@ -24,13 +25,18 @@ public class SDirectTLink<T> extends StreamingSingleLink<T> {
   }
 
   @Override
-  public Edge getEdge() {
-    return new Edge(getId(), OperationNames.DIRECT, getMessageType());
-  }
-
-  @Override
   public SDirectTLink<T> setName(String n) {
     rename(n);
     return this;
+  }
+
+  @Override
+  public SDirectTLink<T> withDataType(MessageType dataType) {
+    return (SDirectTLink<T>) super.withDataType(dataType);
+  }
+
+  @Override
+  public Edge getEdge() {
+    return new Edge(getId(), OperationNames.DIRECT, getDataType());
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SDirectTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SDirectTLink.java
@@ -13,7 +13,6 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
@@ -25,18 +24,13 @@ public class SDirectTLink<T> extends StreamingSingleLink<T> {
   }
 
   @Override
+  public Edge getEdge() {
+    return new Edge(getId(), OperationNames.DIRECT, getMessageType());
+  }
+
+  @Override
   public SDirectTLink<T> setName(String n) {
     rename(n);
     return this;
-  }
-
-  @Override
-  public SDirectTLink<T> withDataType(MessageType dataType) {
-    return (SDirectTLink<T>) super.withDataType(dataType);
-  }
-
-  @Override
-  public Edge getEdge() {
-    return new Edge(getId(), OperationNames.DIRECT, getDataType());
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SDirectTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SDirectTLink.java
@@ -13,21 +13,21 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 
 public class SDirectTLink<T> extends StreamingSingleLink<T> {
 
   public SDirectTLink(StreamingTSetEnvironment tSetEnv, int sourceParallelism,
-                      MessageType dataType) {
-    super(tSetEnv, "sdirect", sourceParallelism, dataType);
+                      Schema schema) {
+    super(tSetEnv, "sdirect", sourceParallelism, schema);
   }
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.DIRECT, getDataType());
+    return new Edge(getId(), OperationNames.DIRECT, this.getSchema().getDataType());
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SDirectTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SDirectTLink.java
@@ -13,19 +13,21 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 
 public class SDirectTLink<T> extends StreamingSingleLink<T> {
 
-  public SDirectTLink(StreamingTSetEnvironment tSetEnv, int sourceParallelism) {
-    super(tSetEnv, "sdirect", sourceParallelism);
+  public SDirectTLink(StreamingTSetEnvironment tSetEnv, int sourceParallelism,
+                      MessageType dataType) {
+    super(tSetEnv, "sdirect", sourceParallelism, dataType);
   }
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.DIRECT, getMessageType());
+    return new Edge(getId(), OperationNames.DIRECT, getDataType());
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SGatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SGatherTLink.java
@@ -13,6 +13,7 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
@@ -29,13 +30,18 @@ public class SGatherTLink<T> extends StreamingGatherLink<T> {
   }
 
   @Override
-  public Edge getEdge() {
-    return new Edge(getId(), OperationNames.GATHER, getMessageType());
-  }
-
-  @Override
   public SGatherTLink<T> setName(String n) {
     rename(n);
     return this;
+  }
+
+  @Override
+  public SGatherTLink<T> withDataType(MessageType dataType) {
+    return (SGatherTLink<T>) super.withDataType(dataType);
+  }
+
+  @Override
+  public Edge getEdge() {
+    return new Edge(getId(), OperationNames.GATHER, getDataType());
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SGatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SGatherTLink.java
@@ -13,9 +13,9 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 
 /**
@@ -26,13 +26,13 @@ import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 public class SGatherTLink<T> extends StreamingGatherLink<T> {
 
   public SGatherTLink(StreamingTSetEnvironment tSetEnv, int sourceParallelism,
-                      MessageType dataType) {
-    super(tSetEnv, "sgather", sourceParallelism, 1, dataType);
+                      Schema schema) {
+    super(tSetEnv, "sgather", sourceParallelism, 1, schema);
   }
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.GATHER, getDataType());
+    return new Edge(getId(), OperationNames.GATHER, this.getSchema().getDataType());
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SGatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SGatherTLink.java
@@ -13,6 +13,7 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
@@ -24,13 +25,14 @@ import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
  */
 public class SGatherTLink<T> extends StreamingGatherLink<T> {
 
-  public SGatherTLink(StreamingTSetEnvironment tSetEnv, int sourceParallelism) {
-    super(tSetEnv, "sgather", sourceParallelism, 1);
+  public SGatherTLink(StreamingTSetEnvironment tSetEnv, int sourceParallelism,
+                      MessageType dataType) {
+    super(tSetEnv, "sgather", sourceParallelism, 1, dataType);
   }
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.GATHER, getMessageType());
+    return new Edge(getId(), OperationNames.GATHER, getDataType());
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SGatherTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SGatherTLink.java
@@ -13,7 +13,6 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
@@ -30,18 +29,13 @@ public class SGatherTLink<T> extends StreamingGatherLink<T> {
   }
 
   @Override
+  public Edge getEdge() {
+    return new Edge(getId(), OperationNames.GATHER, getMessageType());
+  }
+
+  @Override
   public SGatherTLink<T> setName(String n) {
     rename(n);
     return this;
-  }
-
-  @Override
-  public SGatherTLink<T> withDataType(MessageType dataType) {
-    return (SGatherTLink<T>) super.withDataType(dataType);
-  }
-
-  @Override
-  public Edge getEdge() {
-    return new Edge(getId(), OperationNames.GATHER, getDataType());
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SKeyedDirectTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SKeyedDirectTLink.java
@@ -12,7 +12,6 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
@@ -31,18 +30,13 @@ public class SKeyedDirectTLink<K, V> extends StreamingSingleLink<Tuple<K, V>> {
   }
 
   @Override
+  public Edge getEdge() {
+    return new Edge(getId(), OperationNames.DIRECT, getMessageType());
+  }
+
+  @Override
   public SKeyedDirectTLink<K, V> setName(String n) {
     rename(n);
     return this;
-  }
-
-  @Override
-  public SKeyedDirectTLink<K, V> withDataType(MessageType dataType) {
-    return (SKeyedDirectTLink<K, V>) super.withDataType(dataType);
-  }
-
-  @Override
-  public Edge getEdge() {
-    return new Edge(getId(), OperationNames.DIRECT, getDataType());
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SKeyedDirectTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SKeyedDirectTLink.java
@@ -12,6 +12,7 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
@@ -30,13 +31,18 @@ public class SKeyedDirectTLink<K, V> extends StreamingSingleLink<Tuple<K, V>> {
   }
 
   @Override
-  public Edge getEdge() {
-    return new Edge(getId(), OperationNames.DIRECT, getMessageType());
-  }
-
-  @Override
   public SKeyedDirectTLink<K, V> setName(String n) {
     rename(n);
     return this;
+  }
+
+  @Override
+  public SKeyedDirectTLink<K, V> withDataType(MessageType dataType) {
+    return (SKeyedDirectTLink<K, V>) super.withDataType(dataType);
+  }
+
+  @Override
+  public Edge getEdge() {
+    return new Edge(getId(), OperationNames.DIRECT, getDataType());
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SKeyedDirectTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SKeyedDirectTLink.java
@@ -12,21 +12,21 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.MapFunc;
+import edu.iu.dsc.tws.api.tset.schema.KeyedSchema;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 import edu.iu.dsc.tws.tset.sets.streaming.SKeyedTSet;
 
 public class SKeyedDirectTLink<K, V> extends StreamingSingleLink<Tuple<K, V>> {
 
   public SKeyedDirectTLink(StreamingTSetEnvironment tSetEnv, int sourceParallelism,
-                           MessageType keyType, MessageType dataType) {
+                           KeyedSchema schema) {
     // NOTE: key type is omitted. Check getEdge() method
-    super(tSetEnv, "skdirect", sourceParallelism, dataType);
+    super(tSetEnv, "skdirect", sourceParallelism, schema);
   }
 
   public SKeyedTSet<K, V> mapToTuple() {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SKeyedDirectTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SKeyedDirectTLink.java
@@ -12,6 +12,8 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
@@ -21,8 +23,10 @@ import edu.iu.dsc.tws.tset.sets.streaming.SKeyedTSet;
 
 public class SKeyedDirectTLink<K, V> extends StreamingSingleLink<Tuple<K, V>> {
 
-  public SKeyedDirectTLink(StreamingTSetEnvironment tSetEnv, int sourceParallelism) {
-    super(tSetEnv, "skdirect", sourceParallelism);
+  public SKeyedDirectTLink(StreamingTSetEnvironment tSetEnv, int sourceParallelism,
+                           MessageType keyType, MessageType dataType) {
+    // NOTE: key type is omitted. Check getEdge() method
+    super(tSetEnv, "skdirect", sourceParallelism, dataType);
   }
 
   public SKeyedTSet<K, V> mapToTuple() {
@@ -31,7 +35,11 @@ public class SKeyedDirectTLink<K, V> extends StreamingSingleLink<Tuple<K, V>> {
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.DIRECT, getMessageType());
+    // NOTE: There is no keyed direct in the communication layer!!! Hence this is an keyed direct
+    // emulation. Therefore, we can not use user provided data types here because we will be using
+    // Tuple<K, V> object through a DirectLink here.
+    // todo fix this ambiguity!
+    return new Edge(getId(), OperationNames.DIRECT, MessageTypes.OBJECT);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SKeyedPartitionTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SKeyedPartitionTLink.java
@@ -13,6 +13,7 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
@@ -21,17 +22,20 @@ import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 
 public class SKeyedPartitionTLink<K, V> extends StreamingSingleLink<Tuple<K, V>> {
   private PartitionFunc<K> partitionFunction;
+  private MessageType kType;
 
   public SKeyedPartitionTLink(StreamingTSetEnvironment tSetEnv, PartitionFunc<K> parFn,
-                              int sourceParallelism) {
-    super(tSetEnv, "skpartition", sourceParallelism);
+                              int sourceParallelism, MessageType keyType, MessageType dataType) {
+    super(tSetEnv, "skpartition", sourceParallelism, dataType);
     this.partitionFunction = parFn;
+    this.kType = keyType;
   }
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.KEYED_PARTITION, getMessageType());
+    Edge e = new Edge(getId(), OperationNames.KEYED_PARTITION, getDataType());
     e.setKeyed(true);
+    e.setKeyType(kType);
     e.setPartitioner(partitionFunction);
     return e;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SKeyedPartitionTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SKeyedPartitionTLink.java
@@ -13,7 +13,6 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
@@ -30,21 +29,16 @@ public class SKeyedPartitionTLink<K, V> extends StreamingSingleLink<Tuple<K, V>>
   }
 
   @Override
-  public SKeyedPartitionTLink<K, V> setName(String n) {
-    rename(n);
-    return this;
-  }
-
-  @Override
-  public SKeyedPartitionTLink<K, V> withDataType(MessageType dataType) {
-    return (SKeyedPartitionTLink<K, V>) super.withDataType(dataType);
-  }
-
-  @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.KEYED_PARTITION, getDataType());
+    Edge e = new Edge(getId(), OperationNames.KEYED_PARTITION, getMessageType());
     e.setKeyed(true);
     e.setPartitioner(partitionFunction);
     return e;
+  }
+
+  @Override
+  public SKeyedPartitionTLink<K, V> setName(String n) {
+    rename(n);
+    return this;
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SKeyedPartitionTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SKeyedPartitionTLink.java
@@ -13,6 +13,7 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
@@ -29,16 +30,21 @@ public class SKeyedPartitionTLink<K, V> extends StreamingSingleLink<Tuple<K, V>>
   }
 
   @Override
-  public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.KEYED_PARTITION, getMessageType());
-    e.setKeyed(true);
-    e.setPartitioner(partitionFunction);
-    return e;
-  }
-
-  @Override
   public SKeyedPartitionTLink<K, V> setName(String n) {
     rename(n);
     return this;
+  }
+
+  @Override
+  public SKeyedPartitionTLink<K, V> withDataType(MessageType dataType) {
+    return (SKeyedPartitionTLink<K, V>) super.withDataType(dataType);
+  }
+
+  @Override
+  public Edge getEdge() {
+    Edge e = new Edge(getId(), OperationNames.KEYED_PARTITION, getDataType());
+    e.setKeyed(true);
+    e.setPartitioner(partitionFunction);
+    return e;
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SKeyedPartitionTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SKeyedPartitionTLink.java
@@ -13,29 +13,27 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
+import edu.iu.dsc.tws.api.tset.schema.KeyedSchema;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 
 public class SKeyedPartitionTLink<K, V> extends StreamingSingleLink<Tuple<K, V>> {
   private PartitionFunc<K> partitionFunction;
-  private MessageType kType;
 
   public SKeyedPartitionTLink(StreamingTSetEnvironment tSetEnv, PartitionFunc<K> parFn,
-                              int sourceParallelism, MessageType keyType, MessageType dataType) {
-    super(tSetEnv, "skpartition", sourceParallelism, dataType);
+                              int sourceParallelism, KeyedSchema schema) {
+    super(tSetEnv, "skpartition", sourceParallelism, schema);
     this.partitionFunction = parFn;
-    this.kType = keyType;
   }
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.KEYED_PARTITION, getDataType());
+    Edge e = new Edge(getId(), OperationNames.KEYED_PARTITION, this.getSchema().getDataType());
     e.setKeyed(true);
-    e.setKeyType(kType);
+    e.setKeyType(this.getSchema().getKeyType());
     e.setPartitioner(partitionFunction);
     return e;
   }
@@ -44,5 +42,10 @@ public class SKeyedPartitionTLink<K, V> extends StreamingSingleLink<Tuple<K, V>>
   public SKeyedPartitionTLink<K, V> setName(String n) {
     rename(n);
     return this;
+  }
+
+  @Override
+  protected KeyedSchema getSchema() {
+    return (KeyedSchema) super.getSchema();
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SPartitionTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SPartitionTLink.java
@@ -13,6 +13,7 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
@@ -39,17 +40,22 @@ public class SPartitionTLink<T> extends StreamingSingleLink<T> {
   }
 
   @Override
+  public SPartitionTLink<T> setName(String n) {
+    rename(n);
+    return this;
+  }
+
+  @Override
+  public SPartitionTLink<T> withDataType(MessageType dataType) {
+    return (SPartitionTLink<T>) super.withDataType(dataType);
+  }
+
+  @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.PARTITION, getMessageType());
+    Edge e = new Edge(getId(), OperationNames.PARTITION, getDataType());
     if (partitionFunction != null) {
       e.setPartitioner(partitionFunction);
     }
     return e;
-  }
-
-  @Override
-  public SPartitionTLink<T> setName(String n) {
-    rename(n);
-    return this;
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SPartitionTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SPartitionTLink.java
@@ -13,10 +13,10 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 
 public class SPartitionTLink<T> extends StreamingSingleLink<T> {
@@ -24,24 +24,24 @@ public class SPartitionTLink<T> extends StreamingSingleLink<T> {
   private PartitionFunc<T> partitionFunction;
 
   public SPartitionTLink(StreamingTSetEnvironment tSetEnv, int sourceParallelism,
-                         MessageType dataType) {
-    this(tSetEnv, null, sourceParallelism, dataType);
+                         Schema schema) {
+    this(tSetEnv, null, sourceParallelism, schema);
   }
 
   public SPartitionTLink(StreamingTSetEnvironment tSetEnv, PartitionFunc<T> parFn,
-                         int sourceParallelism, MessageType dataType) {
-    this(tSetEnv, parFn, sourceParallelism, sourceParallelism, dataType);
+                         int sourceParallelism, Schema schema) {
+    this(tSetEnv, parFn, sourceParallelism, sourceParallelism, schema);
   }
 
   public SPartitionTLink(StreamingTSetEnvironment tSetEnv, PartitionFunc<T> parFn,
-                         int sourceParallelism, int targetParallelism, MessageType dataType) {
-    super(tSetEnv, "spartition", sourceParallelism, targetParallelism, dataType);
+                         int sourceParallelism, int targetParallelism, Schema schema) {
+    super(tSetEnv, "spartition", sourceParallelism, targetParallelism, schema);
     this.partitionFunction = parFn;
   }
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.PARTITION, getDataType());
+    Edge e = new Edge(getId(), OperationNames.PARTITION, this.getSchema().getDataType());
     if (partitionFunction != null) {
       e.setPartitioner(partitionFunction);
     }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SPartitionTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SPartitionTLink.java
@@ -13,7 +13,6 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
@@ -40,22 +39,17 @@ public class SPartitionTLink<T> extends StreamingSingleLink<T> {
   }
 
   @Override
-  public SPartitionTLink<T> setName(String n) {
-    rename(n);
-    return this;
-  }
-
-  @Override
-  public SPartitionTLink<T> withDataType(MessageType dataType) {
-    return (SPartitionTLink<T>) super.withDataType(dataType);
-  }
-
-  @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.PARTITION, getDataType());
+    Edge e = new Edge(getId(), OperationNames.PARTITION, getMessageType());
     if (partitionFunction != null) {
       e.setPartitioner(partitionFunction);
     }
     return e;
+  }
+
+  @Override
+  public SPartitionTLink<T> setName(String n) {
+    rename(n);
+    return this;
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SPartitionTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SPartitionTLink.java
@@ -13,6 +13,7 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
@@ -22,25 +23,25 @@ public class SPartitionTLink<T> extends StreamingSingleLink<T> {
 
   private PartitionFunc<T> partitionFunction;
 
-  public SPartitionTLink(StreamingTSetEnvironment tSetEnv, int sourceParallelism) {
-    this(tSetEnv, null, sourceParallelism);
+  public SPartitionTLink(StreamingTSetEnvironment tSetEnv, int sourceParallelism,
+                         MessageType dataType) {
+    this(tSetEnv, null, sourceParallelism, dataType);
   }
 
   public SPartitionTLink(StreamingTSetEnvironment tSetEnv, PartitionFunc<T> parFn,
-                         int sourceParallelism) {
-    this(tSetEnv, parFn, sourceParallelism, sourceParallelism);
+                         int sourceParallelism, MessageType dataType) {
+    this(tSetEnv, parFn, sourceParallelism, sourceParallelism, dataType);
   }
 
   public SPartitionTLink(StreamingTSetEnvironment tSetEnv, PartitionFunc<T> parFn,
-                         int sourceParallelism, int targetParallelism) {
-    super(tSetEnv, "spartition", sourceParallelism,
-        targetParallelism);
+                         int sourceParallelism, int targetParallelism, MessageType dataType) {
+    super(tSetEnv, "spartition", sourceParallelism, targetParallelism, dataType);
     this.partitionFunction = parFn;
   }
 
   @Override
   public Edge getEdge() {
-    Edge e = new Edge(getId(), OperationNames.PARTITION, getMessageType());
+    Edge e = new Edge(getId(), OperationNames.PARTITION, getDataType());
     if (partitionFunction != null) {
       e.setPartitioner(partitionFunction);
     }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SReduceTLink.java
@@ -13,6 +13,7 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
@@ -28,13 +29,18 @@ public class SReduceTLink<T> extends StreamingSingleLink<T> {
   }
 
   @Override
-  public Edge getEdge() {
-    return new Edge(getId(), OperationNames.REDUCE, getMessageType(), reduceFn);
-  }
-
-  @Override
   public SReduceTLink<T> setName(String n) {
     rename(n);
     return this;
+  }
+
+  @Override
+  public SReduceTLink<T> withDataType(MessageType dataType) {
+    return (SReduceTLink<T>) super.withDataType(dataType);
+  }
+
+  @Override
+  public Edge getEdge() {
+    return new Edge(getId(), OperationNames.REDUCE, getDataType(), reduceFn);
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SReduceTLink.java
@@ -13,6 +13,7 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
@@ -22,14 +23,14 @@ public class SReduceTLink<T> extends StreamingSingleLink<T> {
   private ReduceFunc<T> reduceFn;
 
   public SReduceTLink(StreamingTSetEnvironment tSetEnv, ReduceFunc<T> rFn,
-                      int sourceParallelism) {
-    super(tSetEnv, "sreduce", sourceParallelism, 1);
+                      int sourceParallelism, MessageType dataType) {
+    super(tSetEnv, "sreduce", sourceParallelism, 1, dataType);
     this.reduceFn = rFn;
   }
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.REDUCE, getMessageType(), reduceFn);
+    return new Edge(getId(), OperationNames.REDUCE, getDataType(), reduceFn);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SReduceTLink.java
@@ -13,7 +13,6 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
@@ -29,18 +28,13 @@ public class SReduceTLink<T> extends StreamingSingleLink<T> {
   }
 
   @Override
+  public Edge getEdge() {
+    return new Edge(getId(), OperationNames.REDUCE, getMessageType(), reduceFn);
+  }
+
+  @Override
   public SReduceTLink<T> setName(String n) {
     rename(n);
     return this;
-  }
-
-  @Override
-  public SReduceTLink<T> withDataType(MessageType dataType) {
-    return (SReduceTLink<T>) super.withDataType(dataType);
-  }
-
-  @Override
-  public Edge getEdge() {
-    return new Edge(getId(), OperationNames.REDUCE, getDataType(), reduceFn);
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SReduceTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SReduceTLink.java
@@ -13,24 +13,24 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 
 public class SReduceTLink<T> extends StreamingSingleLink<T> {
   private ReduceFunc<T> reduceFn;
 
   public SReduceTLink(StreamingTSetEnvironment tSetEnv, ReduceFunc<T> rFn,
-                      int sourceParallelism, MessageType dataType) {
-    super(tSetEnv, "sreduce", sourceParallelism, 1, dataType);
+                      int sourceParallelism, Schema schema) {
+    super(tSetEnv, "sreduce", sourceParallelism, 1, schema);
     this.reduceFn = rFn;
   }
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.REDUCE, getDataType(), reduceFn);
+    return new Edge(getId(), OperationNames.REDUCE, this.getSchema().getDataType(), reduceFn);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SReplicateTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SReplicateTLink.java
@@ -13,6 +13,7 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
@@ -23,13 +24,18 @@ public class SReplicateTLink<T> extends StreamingSingleLink<T> {
   }
 
   @Override
-  public Edge getEdge() {
-    return new Edge(getId(), OperationNames.BROADCAST, getMessageType());
-  }
-
-  @Override
   public SReplicateTLink<T> setName(String n) {
     rename(n);
     return this;
+  }
+
+  @Override
+  public SReplicateTLink<T> withDataType(MessageType dataType) {
+    return (SReplicateTLink<T>) super.withDataType(dataType);
+  }
+
+  @Override
+  public Edge getEdge() {
+    return new Edge(getId(), OperationNames.BROADCAST, getDataType());
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SReplicateTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SReplicateTLink.java
@@ -13,19 +13,19 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 
 public class SReplicateTLink<T> extends StreamingSingleLink<T> {
-  public SReplicateTLink(StreamingTSetEnvironment tSetEnv, int reps, MessageType dataType) {
-    super(tSetEnv, "sreplicate", 1, reps, dataType);
+  public SReplicateTLink(StreamingTSetEnvironment tSetEnv, int reps, Schema schema) {
+    super(tSetEnv, "sreplicate", 1, reps, schema);
   }
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.BROADCAST, getDataType());
+    return new Edge(getId(), OperationNames.BROADCAST, this.getSchema().getDataType());
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SReplicateTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SReplicateTLink.java
@@ -13,18 +13,19 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 
 public class SReplicateTLink<T> extends StreamingSingleLink<T> {
-  public SReplicateTLink(StreamingTSetEnvironment tSetEnv, int reps) {
-    super(tSetEnv, "sreplicate", 1, reps);
+  public SReplicateTLink(StreamingTSetEnvironment tSetEnv, int reps, MessageType dataType) {
+    super(tSetEnv, "sreplicate", 1, reps, dataType);
   }
 
   @Override
   public Edge getEdge() {
-    return new Edge(getId(), OperationNames.BROADCAST, getMessageType());
+    return new Edge(getId(), OperationNames.BROADCAST, getDataType());
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SReplicateTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/SReplicateTLink.java
@@ -13,7 +13,6 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.OperationNames;
 import edu.iu.dsc.tws.api.compute.graph.Edge;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
@@ -24,18 +23,13 @@ public class SReplicateTLink<T> extends StreamingSingleLink<T> {
   }
 
   @Override
+  public Edge getEdge() {
+    return new Edge(getId(), OperationNames.BROADCAST, getMessageType());
+  }
+
+  @Override
   public SReplicateTLink<T> setName(String n) {
     rename(n);
     return this;
-  }
-
-  @Override
-  public SReplicateTLink<T> withDataType(MessageType dataType) {
-    return (SReplicateTLink<T>) super.withDataType(dataType);
-  }
-
-  @Override
-  public Edge getEdge() {
-    return new Edge(getId(), OperationNames.BROADCAST, getDataType());
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingGatherLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingGatherLink.java
@@ -15,11 +15,11 @@ package edu.iu.dsc.tws.tset.links.streaming;
 
 import java.util.Iterator;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.ApplyFunc;
 import edu.iu.dsc.tws.api.tset.fn.FlatMapFunc;
 import edu.iu.dsc.tws.api.tset.fn.MapFunc;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 import edu.iu.dsc.tws.tset.fn.GatherFlatMapCompute;
 import edu.iu.dsc.tws.tset.fn.GatherForEachCompute;
@@ -38,13 +38,13 @@ import edu.iu.dsc.tws.tset.sets.streaming.SKeyedTSet;
 public abstract class StreamingGatherLink<T>
     extends StreamingTLinkImpl<Iterator<Tuple<Integer, T>>, T> {
 
-  StreamingGatherLink(StreamingTSetEnvironment env, String n, int sourceP, MessageType dataType) {
-    this(env, n, sourceP, sourceP, dataType);
+  StreamingGatherLink(StreamingTSetEnvironment env, String n, int sourceP, Schema schema) {
+    this(env, n, sourceP, sourceP, schema);
   }
 
   StreamingGatherLink(StreamingTSetEnvironment env, String n, int sourceP, int targetP,
-                      MessageType dataType) {
-    super(env, n, sourceP, targetP, dataType);
+                      Schema schema) {
+    super(env, n, sourceP, targetP, schema);
   }
 /*  public <P> StreamingComputeTSet<P, Iterator<T>>
 computeWithoutKey(Compute<P, Iterator<T>> computeFunction) {
@@ -74,7 +74,7 @@ computeWithoutKey(Compute<P, Iterator<T>> computeFunction) {
   @Override
   public <K, V> SKeyedTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T> genTupleFn) {
     SKeyedTSet<K, V> set = new SKeyedTSet<>(getTSetEnv(), new GatherMapCompute<>(genTupleFn),
-        getTargetParallelism());
+        getTargetParallelism(), getSchema());
     addChildToGraph(set);
     return set;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingGatherLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingGatherLink.java
@@ -15,6 +15,7 @@ package edu.iu.dsc.tws.tset.links.streaming;
 
 import java.util.Iterator;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.ApplyFunc;
 import edu.iu.dsc.tws.api.tset.fn.FlatMapFunc;
@@ -37,12 +38,13 @@ import edu.iu.dsc.tws.tset.sets.streaming.SKeyedTSet;
 public abstract class StreamingGatherLink<T>
     extends StreamingTLinkImpl<Iterator<Tuple<Integer, T>>, T> {
 
-  StreamingGatherLink(StreamingTSetEnvironment env, String n, int sourceP) {
-    this(env, n, sourceP, sourceP);
+  StreamingGatherLink(StreamingTSetEnvironment env, String n, int sourceP, MessageType dataType) {
+    this(env, n, sourceP, sourceP, dataType);
   }
 
-  StreamingGatherLink(StreamingTSetEnvironment env, String n, int sourceP, int targetP) {
-    super(env, n, sourceP, targetP);
+  StreamingGatherLink(StreamingTSetEnvironment env, String n, int sourceP, int targetP,
+                      MessageType dataType) {
+    super(env, n, sourceP, targetP, dataType);
   }
 /*  public <P> StreamingComputeTSet<P, Iterator<T>>
 computeWithoutKey(Compute<P, Iterator<T>> computeFunction) {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingIteratorLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingIteratorLink.java
@@ -15,6 +15,7 @@ package edu.iu.dsc.tws.tset.links.streaming;
 
 import java.util.Iterator;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.ApplyFunc;
 import edu.iu.dsc.tws.api.tset.fn.FlatMapFunc;
@@ -28,12 +29,13 @@ import edu.iu.dsc.tws.tset.sets.streaming.SKeyedTSet;
 
 public abstract class StreamingIteratorLink<T> extends StreamingTLinkImpl<Iterator<T>, T> {
 
-  StreamingIteratorLink(StreamingTSetEnvironment env, String n, int sourceP) {
-    this(env, n, sourceP, sourceP);
+  StreamingIteratorLink(StreamingTSetEnvironment env, String n, int sourceP, MessageType dataType) {
+    this(env, n, sourceP, sourceP, dataType);
   }
 
-  StreamingIteratorLink(StreamingTSetEnvironment env, String n, int sourceP, int targetP) {
-    super(env, n, sourceP, targetP);
+  StreamingIteratorLink(StreamingTSetEnvironment env, String n, int sourceP, int targetP,
+                        MessageType dataType) {
+    super(env, n, sourceP, targetP, dataType);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingIteratorLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingIteratorLink.java
@@ -15,11 +15,11 @@ package edu.iu.dsc.tws.tset.links.streaming;
 
 import java.util.Iterator;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.ApplyFunc;
 import edu.iu.dsc.tws.api.tset.fn.FlatMapFunc;
 import edu.iu.dsc.tws.api.tset.fn.MapFunc;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 import edu.iu.dsc.tws.tset.fn.FlatMapIterCompute;
 import edu.iu.dsc.tws.tset.fn.ForEachIterCompute;
@@ -29,13 +29,13 @@ import edu.iu.dsc.tws.tset.sets.streaming.SKeyedTSet;
 
 public abstract class StreamingIteratorLink<T> extends StreamingTLinkImpl<Iterator<T>, T> {
 
-  StreamingIteratorLink(StreamingTSetEnvironment env, String n, int sourceP, MessageType dataType) {
-    this(env, n, sourceP, sourceP, dataType);
+  StreamingIteratorLink(StreamingTSetEnvironment env, String n, int sourceP, Schema schema) {
+    this(env, n, sourceP, sourceP, schema);
   }
 
   StreamingIteratorLink(StreamingTSetEnvironment env, String n, int sourceP, int targetP,
-                        MessageType dataType) {
-    super(env, n, sourceP, targetP, dataType);
+                        Schema schema) {
+    super(env, n, sourceP, targetP, schema);
   }
 
   @Override
@@ -58,7 +58,7 @@ public abstract class StreamingIteratorLink<T> extends StreamingTLinkImpl<Iterat
   @Override
   public <K, V> SKeyedTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T> mapToTupFn) {
     SKeyedTSet<K, V> set = new SKeyedTSet<>(getTSetEnv(), new MapIterCompute<>(mapToTupFn),
-        getTargetParallelism());
+        getTargetParallelism(), getSchema());
 
     addChildToGraph(set);
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingSingleLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingSingleLink.java
@@ -13,6 +13,7 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.ApplyFunc;
 import edu.iu.dsc.tws.api.tset.fn.FlatMapFunc;
@@ -26,12 +27,13 @@ import edu.iu.dsc.tws.tset.sets.streaming.SKeyedTSet;
 
 public abstract class StreamingSingleLink<T> extends StreamingTLinkImpl<T, T> {
 
-  StreamingSingleLink(StreamingTSetEnvironment env, String n, int sourceP) {
-    super(env, n, sourceP, sourceP);
+  StreamingSingleLink(StreamingTSetEnvironment env, String n, int sourceP, MessageType dataType) {
+    super(env, n, sourceP, sourceP, dataType);
   }
 
-  StreamingSingleLink(StreamingTSetEnvironment env, String n, int sourceP, int targetP) {
-    super(env, n, sourceP, targetP);
+  StreamingSingleLink(StreamingTSetEnvironment env, String n, int sourceP, int targetP,
+                      MessageType dataType) {
+    super(env, n, sourceP, targetP, dataType);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingSingleLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingSingleLink.java
@@ -13,11 +13,11 @@
 
 package edu.iu.dsc.tws.tset.links.streaming;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.ApplyFunc;
 import edu.iu.dsc.tws.api.tset.fn.FlatMapFunc;
 import edu.iu.dsc.tws.api.tset.fn.MapFunc;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 import edu.iu.dsc.tws.tset.fn.FlatMapCompute;
 import edu.iu.dsc.tws.tset.fn.ForEachCompute;
@@ -27,13 +27,13 @@ import edu.iu.dsc.tws.tset.sets.streaming.SKeyedTSet;
 
 public abstract class StreamingSingleLink<T> extends StreamingTLinkImpl<T, T> {
 
-  StreamingSingleLink(StreamingTSetEnvironment env, String n, int sourceP, MessageType dataType) {
-    super(env, n, sourceP, sourceP, dataType);
+  StreamingSingleLink(StreamingTSetEnvironment env, String n, int sourceP, Schema schema) {
+    super(env, n, sourceP, sourceP, schema);
   }
 
   StreamingSingleLink(StreamingTSetEnvironment env, String n, int sourceP, int targetP,
-                      MessageType dataType) {
-    super(env, n, sourceP, targetP, dataType);
+                      Schema schema) {
+    super(env, n, sourceP, targetP, schema);
   }
 
   @Override
@@ -54,7 +54,7 @@ public abstract class StreamingSingleLink<T> extends StreamingTLinkImpl<T, T> {
   @Override
   public <K, O> SKeyedTSet<K, O> mapToTuple(MapFunc<Tuple<K, O>, T> genTupleFn) {
     SKeyedTSet<K, O> set = new SKeyedTSet<>(getTSetEnv(), new MapCompute<>(genTupleFn),
-        getTargetParallelism());
+        getTargetParallelism(), getSchema());
 
     addChildToGraph(set);
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingTLinkImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingTLinkImpl.java
@@ -16,12 +16,9 @@ package edu.iu.dsc.tws.tset.links.streaming;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
-import edu.iu.dsc.tws.api.tset.link.TLink;
 import edu.iu.dsc.tws.api.tset.link.streaming.StreamingTLink;
 import edu.iu.dsc.tws.task.window.util.WindowParameter;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
@@ -34,7 +31,7 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
     implements StreamingTLink<T1, T0> {
 
   private WindowParameter windowParameter;
-  private MessageType dType = MessageTypes.OBJECT;
+
 
   StreamingTLinkImpl(StreamingTSetEnvironment env, String n, int sourceP, int targetP) {
     super(env, n, sourceP, targetP);
@@ -127,17 +124,6 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
     this.windowParameter.withSlidingDurationWindow(windowLen, windowLenTimeUnit, slidingLen,
         slidingWindowTimeUnit);
     return window("w-duration-sliding-compute-prev");
-  }
-
-
-  @Override
-  public TLink<T1, T0> withDataType(MessageType dataType) {
-    this.dType = dataType;
-    return this;
-  }
-
-  protected MessageType getDataType() {
-    return this.dType;
   }
 
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingTLinkImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingTLinkImpl.java
@@ -16,6 +16,7 @@ package edu.iu.dsc.tws.tset.links.streaming;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
@@ -31,10 +32,12 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
     implements StreamingTLink<T1, T0> {
 
   private WindowParameter windowParameter;
+  private MessageType dType;
 
-
-  StreamingTLinkImpl(StreamingTSetEnvironment env, String n, int sourceP, int targetP) {
+  StreamingTLinkImpl(StreamingTSetEnvironment env, String n, int sourceP, int targetP,
+                     MessageType dataType) {
     super(env, n, sourceP, targetP);
+    this.dType = dataType;
   }
 
   @Override
@@ -124,6 +127,11 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
     this.windowParameter.withSlidingDurationWindow(windowLen, windowLenTimeUnit, slidingLen,
         slidingWindowTimeUnit);
     return window("w-duration-sliding-compute-prev");
+  }
+
+
+  protected MessageType getDataType() {
+    return dType;
   }
 
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingTLinkImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingTLinkImpl.java
@@ -16,28 +16,26 @@ package edu.iu.dsc.tws.tset.links.streaming;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
 import edu.iu.dsc.tws.api.tset.link.streaming.StreamingTLink;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.task.window.util.WindowParameter;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
-import edu.iu.dsc.tws.tset.links.BaseTLink;
+import edu.iu.dsc.tws.tset.links.BaseTLinkWithSchema;
 import edu.iu.dsc.tws.tset.sets.streaming.SComputeTSet;
 import edu.iu.dsc.tws.tset.sets.streaming.SSinkTSet;
 import edu.iu.dsc.tws.tset.sets.streaming.WindowComputeTSet;
 
-public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
+public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLinkWithSchema<T1, T0>
     implements StreamingTLink<T1, T0> {
 
   private WindowParameter windowParameter;
-  private MessageType dType;
 
   StreamingTLinkImpl(StreamingTSetEnvironment env, String n, int sourceP, int targetP,
-                     MessageType dataType) {
-    super(env, n, sourceP, targetP);
-    this.dType = dataType;
+                     Schema schema) {
+    super(env, n, sourceP, targetP, schema);
   }
 
   @Override
@@ -48,9 +46,10 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
   public <P> SComputeTSet<P, T1> compute(String n, ComputeFunc<P, T1> computeFunction) {
     SComputeTSet<P, T1> set;
     if (n != null && !n.isEmpty()) {
-      set = new SComputeTSet<>(getTSetEnv(), n, computeFunction, getTargetParallelism());
+      set = new SComputeTSet<>(getTSetEnv(), n, computeFunction, getTargetParallelism(),
+          getSchema());
     } else {
-      set = new SComputeTSet<>(getTSetEnv(), computeFunction, getTargetParallelism());
+      set = new SComputeTSet<>(getTSetEnv(), computeFunction, getTargetParallelism(), getSchema());
     }
     addChildToGraph(set);
 
@@ -61,10 +60,10 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
     WindowComputeTSet<P, Iterator<T1>> set;
     if (n != null && !n.isEmpty()) {
       set = new WindowComputeTSet<>(getTSetEnv(), n, getTargetParallelism(),
-          this.windowParameter);
+          this.windowParameter, getSchema());
     } else {
       set = new WindowComputeTSet<>(getTSetEnv(), getTargetParallelism(),
-          this.windowParameter);
+          this.windowParameter, getSchema());
     }
     addChildToGraph(set);
 
@@ -74,9 +73,10 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
   public <P> SComputeTSet<P, T1> compute(String n, ComputeCollectorFunc<P, T1> computeFunction) {
     SComputeTSet<P, T1> set;
     if (n != null && !n.isEmpty()) {
-      set = new SComputeTSet<>(getTSetEnv(), n, computeFunction, getTargetParallelism());
+      set = new SComputeTSet<>(getTSetEnv(), n, computeFunction, getTargetParallelism(),
+          getSchema());
     } else {
-      set = new SComputeTSet<>(getTSetEnv(), computeFunction, getTargetParallelism());
+      set = new SComputeTSet<>(getTSetEnv(), computeFunction, getTargetParallelism(), getSchema());
     }
     addChildToGraph(set);
 
@@ -95,7 +95,8 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
 
   @Override
   public SSinkTSet<T1> sink(SinkFunc<T1> sinkFunction) {
-    SSinkTSet<T1> sinkTSet = new SSinkTSet<>(getTSetEnv(), sinkFunction, getTargetParallelism());
+    SSinkTSet<T1> sinkTSet = new SSinkTSet<>(getTSetEnv(), sinkFunction, getTargetParallelism(),
+        getSchema());
     addChildToGraph(sinkTSet);
     return sinkTSet;
   }
@@ -128,10 +129,4 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
         slidingWindowTimeUnit);
     return window("w-duration-sliding-compute-prev");
   }
-
-
-  protected MessageType getDataType() {
-    return dType;
-  }
-
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingTLinkImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingTLinkImpl.java
@@ -16,9 +16,12 @@ package edu.iu.dsc.tws.tset.links.streaming;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
+import edu.iu.dsc.tws.api.tset.link.TLink;
 import edu.iu.dsc.tws.api.tset.link.streaming.StreamingTLink;
 import edu.iu.dsc.tws.task.window.util.WindowParameter;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
@@ -31,7 +34,7 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
     implements StreamingTLink<T1, T0> {
 
   private WindowParameter windowParameter;
-
+  private MessageType dType = MessageTypes.OBJECT;
 
   StreamingTLinkImpl(StreamingTSetEnvironment env, String n, int sourceP, int targetP) {
     super(env, n, sourceP, targetP);
@@ -124,6 +127,17 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLink<T1, T0>
     this.windowParameter.withSlidingDurationWindow(windowLen, windowLenTimeUnit, slidingLen,
         slidingWindowTimeUnit);
     return window("w-duration-sliding-compute-prev");
+  }
+
+
+  @Override
+  public TLink<T1, T0> withDataType(MessageType dataType) {
+    this.dType = dataType;
+    return this;
+  }
+
+  protected MessageType getDataType() {
+    return this.dType;
   }
 
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/BaseTSetWithSchema.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/BaseTSetWithSchema.java
@@ -54,11 +54,11 @@ public abstract class BaseTSetWithSchema<T> extends BaseTSet<T> {
     this.outSchema = outputSchema;
   }
 
-  protected Schema getOutputSchema() {
+  public Schema getOutputSchema() {
     return this.outSchema;
   }
 
-  protected Schema getInputSchema() {
+  public Schema getInputSchema() {
     return this.inSchema;
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/BaseTSetWithSchema.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/BaseTSetWithSchema.java
@@ -1,0 +1,64 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package edu.iu.dsc.tws.tset.sets;
+
+import edu.iu.dsc.tws.api.tset.schema.PrimitiveSchemas;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
+import edu.iu.dsc.tws.api.tset.sets.TSet;
+import edu.iu.dsc.tws.tset.env.TSetEnvironment;
+
+public abstract class BaseTSetWithSchema<T> extends BaseTSet<T> {
+  private Schema outSchema;
+  private Schema inSchema;
+
+  public BaseTSetWithSchema() {
+  }
+
+//  /**
+//   * Special constructor to be used by sources which don't have input schema
+//   */
+//  public BaseTSetWithSchema(TSetEnvironment env, String n, int parallel) {
+//    this(env, n, parallel, PrimitiveSchemas.NULL);
+//  }
+
+  /**
+   * General constructor for {@link TSet}s
+   *
+   * @param env         env
+   * @param name        name
+   * @param parallel    par
+   * @param inputSchema Schema from the preceding {@link edu.iu.dsc.tws.api.tset.link.TLink}
+   */
+  public BaseTSetWithSchema(TSetEnvironment env, String name, int parallel, Schema inputSchema) {
+    this(env, name, parallel, inputSchema, PrimitiveSchemas.OBJECT);
+  }
+
+  public BaseTSetWithSchema(TSetEnvironment env, String name, int parallel, Schema inputSchema,
+                            Schema outputSchema) {
+    super(env, name, parallel);
+    this.inSchema = inputSchema;
+    this.outSchema = outputSchema;
+  }
+
+  protected void setOutputSchema(Schema outputSchema) {
+    this.outSchema = outputSchema;
+  }
+
+  protected Schema getOutputSchema() {
+    return this.outSchema;
+  }
+
+  protected Schema getInputSchema() {
+    return this.inSchema;
+  }
+}

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/BuildableTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/BuildableTSet.java
@@ -18,6 +18,7 @@ import edu.iu.dsc.tws.api.compute.nodes.ICompute;
 import edu.iu.dsc.tws.api.compute.nodes.INode;
 import edu.iu.dsc.tws.api.compute.nodes.ISource;
 import edu.iu.dsc.tws.api.tset.TBase;
+import edu.iu.dsc.tws.api.tset.TSetConstants;
 import edu.iu.dsc.tws.task.graph.GraphBuilder;
 import edu.iu.dsc.tws.tset.Buildable;
 
@@ -36,6 +37,11 @@ public interface BuildableTSet extends TBase, Buildable {
     } else {
       throw new RuntimeException("Unknown INode " + getINode());
     }
+
+    graphBuilder.addConfiguration(getId(), TSetConstants.INPUT_SCHEMA_KEY,
+        ((BaseTSetWithSchema) this).getInputSchema());
+    graphBuilder.addConfiguration(getId(), TSetConstants.OUTPUT_SCHEMA_KEY,
+        ((BaseTSetWithSchema) this).getOutputSchema());
   }
 
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/BatchTSetImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/BatchTSetImpl.java
@@ -54,14 +54,15 @@ public abstract class BatchTSetImpl<T> extends BaseTSet<T> implements BatchTSet<
 
   @Override
   public DirectTLink<T> direct() {
-    DirectTLink<T> direct = new DirectTLink<>(getTSetEnv(), getParallelism());
+    DirectTLink<T> direct = new DirectTLink<>(getTSetEnv(), getParallelism(), getDataType());
     addChildToGraph(direct);
     return direct;
   }
 
   @Override
   public ReduceTLink<T> reduce(ReduceFunc<T> reduceFn) {
-    ReduceTLink<T> reduce = new ReduceTLink<>(getTSetEnv(), reduceFn, getParallelism());
+    ReduceTLink<T> reduce = new ReduceTLink<>(getTSetEnv(), reduceFn, getParallelism(),
+        getDataType());
     addChildToGraph(reduce);
     return reduce;
   }
@@ -69,7 +70,7 @@ public abstract class BatchTSetImpl<T> extends BaseTSet<T> implements BatchTSet<
   @Override
   public PartitionTLink<T> partition(PartitionFunc<T> partitionFn, int targetParallelism) {
     PartitionTLink<T> partition = new PartitionTLink<>(getTSetEnv(), partitionFn, getParallelism(),
-        targetParallelism);
+        targetParallelism, getDataType());
     addChildToGraph(partition);
     return partition;
   }
@@ -81,21 +82,22 @@ public abstract class BatchTSetImpl<T> extends BaseTSet<T> implements BatchTSet<
 
   @Override
   public GatherTLink<T> gather() {
-    GatherTLink<T> gather = new GatherTLink<>(getTSetEnv(), getParallelism());
+    GatherTLink<T> gather = new GatherTLink<>(getTSetEnv(), getParallelism(), getDataType());
     addChildToGraph(gather);
     return gather;
   }
 
   @Override
   public AllReduceTLink<T> allReduce(ReduceFunc<T> reduceFn) {
-    AllReduceTLink<T> reduce = new AllReduceTLink<>(getTSetEnv(), reduceFn, getParallelism());
+    AllReduceTLink<T> reduce = new AllReduceTLink<>(getTSetEnv(), reduceFn, getParallelism(),
+        getDataType());
     addChildToGraph(reduce);
     return reduce;
   }
 
   @Override
   public AllGatherTLink<T> allGather() {
-    AllGatherTLink<T> gather = new AllGatherTLink<>(getTSetEnv(), getParallelism());
+    AllGatherTLink<T> gather = new AllGatherTLink<>(getTSetEnv(), getParallelism(), getDataType());
     addChildToGraph(gather);
     return gather;
   }
@@ -119,7 +121,7 @@ public abstract class BatchTSetImpl<T> extends BaseTSet<T> implements BatchTSet<
     // now the following relationship is created
     // this -- directThis -- unionTSet
 
-    DirectTLink<T> directOther = new DirectTLink<>(getTSetEnv(), getParallelism());
+    DirectTLink<T> directOther = new DirectTLink<>(getTSetEnv(), getParallelism(), getDataType());
     addChildToGraph(other, directOther);
     addChildToGraph(directOther, unionTSet);
     // now the following relationship is created
@@ -142,7 +144,7 @@ public abstract class BatchTSetImpl<T> extends BaseTSet<T> implements BatchTSet<
         throw new IllegalStateException("Parallelism of the TSets need to be the same in order to"
             + "perform a union operation");
       }
-      DirectTLink<T> directOther = new DirectTLink<>(getTSetEnv(), getParallelism());
+      DirectTLink<T> directOther = new DirectTLink<>(getTSetEnv(), getParallelism(), getDataType());
       addChildToGraph(tSet, directOther);
       addChildToGraph(directOther, unionTSet);
       // now the following relationship is created
@@ -159,7 +161,7 @@ public abstract class BatchTSetImpl<T> extends BaseTSet<T> implements BatchTSet<
       throw new RuntimeException("Replication can not be done on tsets with parallelism != 1");
     }
 
-    ReplicateTLink<T> cloneTSet = new ReplicateTLink<>(getTSetEnv(), replications);
+    ReplicateTLink<T> cloneTSet = new ReplicateTLink<>(getTSetEnv(), replications, getDataType());
     addChildToGraph(cloneTSet);
     return cloneTSet;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/BatchTSetImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/BatchTSetImpl.java
@@ -15,6 +15,8 @@ package edu.iu.dsc.tws.tset.sets.batch;
 import java.util.Collection;
 import java.util.Iterator;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.MapFunc;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
@@ -35,6 +37,7 @@ import edu.iu.dsc.tws.tset.sets.BaseTSet;
 import edu.iu.dsc.tws.tset.sets.batch.functions.IdentityFunction;
 
 public abstract class BatchTSetImpl<T> extends BaseTSet<T> implements BatchTSet<T> {
+  private MessageType dType = MessageTypes.OBJECT;
 
   public BatchTSetImpl() {
     //non arg constructor needed for kryo
@@ -186,5 +189,15 @@ public abstract class BatchTSetImpl<T> extends BaseTSet<T> implements BatchTSet<
   public BatchTSetImpl<T> addInput(String key, StorableTBase<?> input) {
     getTSetEnv().addInput(getId(), input.getId(), key);
     return this;
+  }
+
+  @Override
+  public BatchTSetImpl<T> withDataType(MessageType dataType) {
+    this.dType = dataType;
+    return this;
+  }
+
+  protected MessageType getDataType() {
+    return this.dType;
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/BatchTupleTSetImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/BatchTupleTSetImpl.java
@@ -21,7 +21,6 @@ import edu.iu.dsc.tws.api.compute.TaskPartitioner;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
-import edu.iu.dsc.tws.api.tset.sets.TupleTSet;
 import edu.iu.dsc.tws.api.tset.sets.batch.BatchTupleTSet;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.links.batch.JoinTLink;
@@ -192,7 +191,7 @@ public abstract class BatchTupleTSetImpl<K, V> extends BaseTSet<V> implements Ba
   }
 
   @Override
-  public TupleTSet<K, V> withDataType(MessageType dataType) {
+  public BatchTupleTSetImpl<K, V> withDataType(MessageType dataType) {
     this.dType = dataType;
     return this;
   }
@@ -202,7 +201,7 @@ public abstract class BatchTupleTSetImpl<K, V> extends BaseTSet<V> implements Ba
   }
 
   @Override
-  public TupleTSet<K, V> withKeyType(MessageType keyType) {
+  public BatchTupleTSetImpl<K, V> withKeyType(MessageType keyType) {
     this.kType = keyType;
     return this;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/BatchTupleTSetImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/BatchTupleTSetImpl.java
@@ -217,7 +217,7 @@ public abstract class BatchTupleTSetImpl<K, V> extends BaseTSetWithSchema<V> imp
    *
    * @return keyed schema
    */
-  protected KeyedSchema getOutputSchema() {
+  public KeyedSchema getOutputSchema() {
     return (KeyedSchema) super.getOutputSchema();
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/BatchTupleTSetImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/BatchTupleTSetImpl.java
@@ -15,11 +15,14 @@ package edu.iu.dsc.tws.tset.sets.batch;
 import java.util.Comparator;
 
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.compute.TaskPartitioner;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
+import edu.iu.dsc.tws.api.tset.schema.JoinSchema;
+import edu.iu.dsc.tws.api.tset.schema.KeyedSchema;
+import edu.iu.dsc.tws.api.tset.schema.PrimitiveSchemas;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
+import edu.iu.dsc.tws.api.tset.schema.TupleSchema;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
 import edu.iu.dsc.tws.api.tset.sets.batch.BatchTupleTSet;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -29,7 +32,7 @@ import edu.iu.dsc.tws.tset.links.batch.KeyedGatherTLink;
 import edu.iu.dsc.tws.tset.links.batch.KeyedGatherUngroupedTLink;
 import edu.iu.dsc.tws.tset.links.batch.KeyedPartitionTLink;
 import edu.iu.dsc.tws.tset.links.batch.KeyedReduceTLink;
-import edu.iu.dsc.tws.tset.sets.BaseTSet;
+import edu.iu.dsc.tws.tset.sets.BaseTSetWithSchema;
 
 /**
  * Attaches a key to the oncoming data.
@@ -37,13 +40,22 @@ import edu.iu.dsc.tws.tset.sets.BaseTSet;
  * @param <K> key type
  * @param <V> data (value) type
  */
-public abstract class BatchTupleTSetImpl<K, V> extends BaseTSet<V> implements BatchTupleTSet<K, V> {
+public abstract class BatchTupleTSetImpl<K, V> extends BaseTSetWithSchema<V> implements
+    BatchTupleTSet<K, V> {
 
-  private MessageType kType = MessageTypes.OBJECT;
-  private MessageType dType = MessageTypes.OBJECT;
-
-  BatchTupleTSetImpl(BatchTSetEnvironment tSetEnv, String name, int parallelism) {
-    super(tSetEnv, name, parallelism);
+  /**
+   * General constructor for batch {@link edu.iu.dsc.tws.api.tset.sets.TupleTSet}s
+   *
+   * @param tSetEnv     env
+   * @param name        name
+   * @param parallelism par
+   * @param inputSchema Schema from the preceding {@link edu.iu.dsc.tws.api.tset.link.TLink}
+   */
+  BatchTupleTSetImpl(BatchTSetEnvironment tSetEnv, String name, int parallelism,
+                     Schema inputSchema) {
+    // since the output schema will be a KeyedSchema, it needs to be initialized by a KeyedSchema
+    // of OBJECT type
+    super(tSetEnv, name, parallelism, inputSchema, PrimitiveSchemas.OBJECT_TUPLE2);
   }
 
   protected BatchTupleTSetImpl() {
@@ -59,7 +71,7 @@ public abstract class BatchTupleTSetImpl<K, V> extends BaseTSet<V> implements Ba
   @Override
   public KeyedDirectTLink<K, V> keyedDirect() {
     KeyedDirectTLink<K, V> kDirect = new KeyedDirectTLink<>(getTSetEnv(), getParallelism(),
-        getKeyType(), getDataType());
+        getOutputSchema());
     addChildToGraph(kDirect);
     return kDirect;
   }
@@ -67,7 +79,7 @@ public abstract class BatchTupleTSetImpl<K, V> extends BaseTSet<V> implements Ba
   @Override
   public KeyedReduceTLink<K, V> keyedReduce(ReduceFunc<V> reduceFn) {
     KeyedReduceTLink<K, V> reduce = new KeyedReduceTLink<>(getTSetEnv(), reduceFn,
-        getParallelism(), getKeyType(), getDataType());
+        getParallelism(), getOutputSchema());
     addChildToGraph(reduce);
     return reduce;
   }
@@ -75,7 +87,7 @@ public abstract class BatchTupleTSetImpl<K, V> extends BaseTSet<V> implements Ba
   @Override
   public KeyedPartitionTLink<K, V> keyedPartition(PartitionFunc<K> partitionFn) {
     KeyedPartitionTLink<K, V> partition = new KeyedPartitionTLink<>(getTSetEnv(), partitionFn,
-        getParallelism(), getKeyType(), getDataType());
+        getParallelism(), getOutputSchema());
     addChildToGraph(partition);
     return partition;
   }
@@ -83,7 +95,7 @@ public abstract class BatchTupleTSetImpl<K, V> extends BaseTSet<V> implements Ba
   @Override
   public KeyedGatherTLink<K, V> keyedGather() {
     KeyedGatherTLink<K, V> gather = new KeyedGatherTLink<>(getTSetEnv(), getParallelism(),
-        getKeyType(), getDataType());
+        getOutputSchema());
     addChildToGraph(gather);
     return gather;
   }
@@ -91,7 +103,7 @@ public abstract class BatchTupleTSetImpl<K, V> extends BaseTSet<V> implements Ba
   @Override
   public KeyedGatherTLink<K, V> keyedGather(PartitionFunc<K> partitionFn) {
     KeyedGatherTLink<K, V> gather = new KeyedGatherTLink<>(getTSetEnv(),
-        partitionFn, getParallelism(), getKeyType(), getDataType());
+        partitionFn, getParallelism(), getOutputSchema());
     addChildToGraph(gather);
     return gather;
   }
@@ -100,7 +112,7 @@ public abstract class BatchTupleTSetImpl<K, V> extends BaseTSet<V> implements Ba
   public KeyedGatherTLink<K, V> keyedGather(PartitionFunc<K> partitionFn,
                                             Comparator<K> comparator) {
     KeyedGatherTLink<K, V> gather = new KeyedGatherTLink<>(getTSetEnv(), partitionFn,
-        getParallelism(), comparator, getKeyType(), getDataType());
+        getParallelism(), comparator, getOutputSchema());
     addChildToGraph(gather);
     return gather;
   }
@@ -108,7 +120,7 @@ public abstract class BatchTupleTSetImpl<K, V> extends BaseTSet<V> implements Ba
   @Override
   public KeyedGatherUngroupedTLink<K, V> keyedGatherUngrouped() {
     KeyedGatherUngroupedTLink<K, V> gather = new KeyedGatherUngroupedTLink<>(getTSetEnv(),
-        getParallelism(), getKeyType(), getDataType());
+        getParallelism(), getOutputSchema());
     addChildToGraph(gather);
     return gather;
   }
@@ -116,7 +128,7 @@ public abstract class BatchTupleTSetImpl<K, V> extends BaseTSet<V> implements Ba
   @Override
   public KeyedGatherUngroupedTLink<K, V> keyedGatherUngrouped(PartitionFunc<K> partitionFn) {
     KeyedGatherUngroupedTLink<K, V> gather = new KeyedGatherUngroupedTLink<>(getTSetEnv(),
-        partitionFn, getParallelism(), getKeyType(), getDataType());
+        partitionFn, getParallelism(), getOutputSchema());
     addChildToGraph(gather);
     return gather;
   }
@@ -125,7 +137,7 @@ public abstract class BatchTupleTSetImpl<K, V> extends BaseTSet<V> implements Ba
   public KeyedGatherUngroupedTLink<K, V> keyedGatherUngrouped(PartitionFunc<K> partitionFn,
                                                               Comparator<K> comparator) {
     KeyedGatherUngroupedTLink<K, V> gather = new KeyedGatherUngroupedTLink<>(getTSetEnv(),
-        partitionFn, getParallelism(), comparator, getKeyType(), getDataType());
+        partitionFn, getParallelism(), comparator, getOutputSchema());
     addChildToGraph(gather);
     return gather;
   }
@@ -136,12 +148,16 @@ public abstract class BatchTupleTSetImpl<K, V> extends BaseTSet<V> implements Ba
                                        Comparator<K> keyComparator,
                                        TaskPartitioner<K> partitioner) {
     JoinTLink<K, V, VR> join;
+
+    JoinSchema joinSchema = new JoinSchema(this.getOutputSchema(),
+        ((BatchTupleTSetImpl<K, VR>) rightTSet).getOutputSchema());
+
     if (partitioner != null) {
       join = new JoinTLink<>(getTSetEnv(), type, keyComparator, partitioner, this, rightTSet,
-          getKeyType(), getDataType(), ((BatchTupleTSetImpl<K, VR>) rightTSet).getDataType());
+          joinSchema);
     } else {
-      join = new JoinTLink<>(getTSetEnv(), type, keyComparator, this, rightTSet, getKeyType(),
-          getDataType(), ((BatchTupleTSetImpl<K, VR>) rightTSet).getDataType());
+      join = new JoinTLink<>(getTSetEnv(), type, keyComparator, this, rightTSet,
+          joinSchema);
     }
     addChildToGraph(join);
 
@@ -191,23 +207,17 @@ public abstract class BatchTupleTSetImpl<K, V> extends BaseTSet<V> implements Ba
   }
 
   @Override
-  public BatchTupleTSetImpl<K, V> withDataType(MessageType dataType) {
-    this.dType = dataType;
+  public BatchTupleTSetImpl<K, V> withSchema(TupleSchema schema) {
+    this.setOutputSchema(schema);
     return this;
   }
 
-  protected MessageType getDataType() {
-    return this.dType;
+  /**
+   * Output schema of a BatchTupleTSet is definitely a {@link KeyedSchema}.
+   *
+   * @return keyed schema
+   */
+  protected KeyedSchema getOutputSchema() {
+    return (KeyedSchema) super.getOutputSchema();
   }
-
-  @Override
-  public BatchTupleTSetImpl<K, V> withKeyType(MessageType keyType) {
-    this.kType = keyType;
-    return this;
-  }
-
-  protected MessageType getKeyType() {
-    return this.kType;
-  }
-
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/CachedTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/CachedTSet.java
@@ -12,8 +12,8 @@
 
 package edu.iu.dsc.tws.tset.sets.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 
@@ -28,8 +28,9 @@ public class CachedTSet<T> extends StoredTSet<T> {
   so, we would need to have several types of sink functions that can convert the comms message to
    T. example: for direct, sink func would convert Iterator<T> to T.
    */
-  public CachedTSet(BatchTSetEnvironment tSetEnv, SinkFunc<?> sinkFunc, int parallelism) {
-    super(tSetEnv, "cached", sinkFunc, parallelism);
+  public CachedTSet(BatchTSetEnvironment tSetEnv, SinkFunc<?> sinkFunc, int parallelism,
+                    Schema inputSchema) {
+    super(tSetEnv, "cached", sinkFunc, parallelism, inputSchema);
   }
 
   @Override
@@ -64,7 +65,7 @@ public class CachedTSet<T> extends StoredTSet<T> {
   }
 
   @Override
-  public CachedTSet<T> withDataType(MessageType dataType) {
-    return (CachedTSet<T>) super.withDataType(dataType);
+  public CachedTSet<T> withSchema(Schema schema) {
+    return (CachedTSet<T>) super.withSchema(schema);
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/CachedTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/CachedTSet.java
@@ -12,6 +12,7 @@
 
 package edu.iu.dsc.tws.tset.sets.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -60,5 +61,10 @@ public class CachedTSet<T> extends StoredTSet<T> {
   @Override
   public CachedTSet<T> addInput(String key, StorableTBase<?> input) {
     return (CachedTSet<T>) super.addInput(key, input);
+  }
+
+  @Override
+  public CachedTSet<T> withDataType(MessageType dataType) {
+    return (CachedTSet<T>) super.withDataType(dataType);
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/CheckpointedTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/CheckpointedTSet.java
@@ -11,8 +11,8 @@
 //  limitations under the License.
 package edu.iu.dsc.tws.tset.sets.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.nodes.INode;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.ops.CheckpointedSourceOp;
 import edu.iu.dsc.tws.tset.sources.DiskPartitionBackedSource;
@@ -33,8 +33,8 @@ public class CheckpointedTSet<T> extends PersistedTSet<T> {
   private DiskPartitionBackedSource<T> sourceFunc;
 
   public CheckpointedTSet(BatchTSetEnvironment tSetEnv, DiskPartitionBackedSource<T> sourceFn,
-                          int parallelism) {
-    super(tSetEnv, null, parallelism);
+                          int parallelism, Schema inputSchema) {
+    super(tSetEnv, null, parallelism, inputSchema);
     this.sourceFunc = sourceFn;
   }
 
@@ -47,8 +47,8 @@ public class CheckpointedTSet<T> extends PersistedTSet<T> {
   }
 
   @Override
-  public CheckpointedTSet<T> withDataType(MessageType dataType) {
-    return (CheckpointedTSet<T>) super.withDataType(dataType);
+  public CheckpointedTSet<T> withSchema(Schema schema) {
+    return (CheckpointedTSet<T>) super.withSchema(schema);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/CheckpointedTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/CheckpointedTSet.java
@@ -11,6 +11,7 @@
 //  limitations under the License.
 package edu.iu.dsc.tws.tset.sets.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.nodes.INode;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.ops.CheckpointedSourceOp;
@@ -43,6 +44,11 @@ public class CheckpointedTSet<T> extends PersistedTSet<T> {
       storedSource = getTSetEnv().createSource(sourceFunc, getParallelism());
     }
     return storedSource;
+  }
+
+  @Override
+  public CheckpointedTSet<T> withDataType(MessageType dataType) {
+    return (CheckpointedTSet<T>) super.withDataType(dataType);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/ComputeTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/ComputeTSet.java
@@ -12,6 +12,7 @@
 
 package edu.iu.dsc.tws.tset.sets.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.nodes.ICompute;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
@@ -60,6 +61,10 @@ public class ComputeTSet<O, I> extends BatchTSetImpl<O> {
   @Override
   public ComputeTSet<O, I> addInput(String key, StorableTBase<?> input) {
     return (ComputeTSet<O, I>) super.addInput(key, input);
+  }
+
+  public ComputeTSet<O, I> withDataType(MessageType dataType) {
+    return (ComputeTSet<O, I>) super.withDataType(dataType);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/ComputeTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/ComputeTSet.java
@@ -12,11 +12,11 @@
 
 package edu.iu.dsc.tws.tset.sets.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.nodes.ICompute;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 import edu.iu.dsc.tws.api.tset.fn.TFunction;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.ops.ComputeCollectorOp;
@@ -31,24 +31,24 @@ public class ComputeTSet<O, I> extends BatchTSetImpl<O> {
   }
 
   public ComputeTSet(BatchTSetEnvironment tSetEnv, ComputeFunc<O, I> computeFn,
-                     int parallelism) {
-    this(tSetEnv, "compute", computeFn, parallelism);
+                     int parallelism, Schema inputSchema) {
+    this(tSetEnv, "compute", computeFn, parallelism, inputSchema);
   }
 
   public ComputeTSet(BatchTSetEnvironment tSetEnv, ComputeCollectorFunc<O, I> computeFn,
-                     int parallelism) {
-    this(tSetEnv, "computec", computeFn, parallelism);
+                     int parallelism, Schema inputSchema) {
+    this(tSetEnv, "computec", computeFn, parallelism, inputSchema);
   }
 
   public ComputeTSet(BatchTSetEnvironment tSetEnv, String name, ComputeFunc<O, I> computeFn,
-                     int parallelism) {
-    super(tSetEnv, name, parallelism);
+                     int parallelism, Schema inputSchema) {
+    super(tSetEnv, name, parallelism, inputSchema);
     this.computeFunc = computeFn;
   }
 
   public ComputeTSet(BatchTSetEnvironment tSetEnv, String name,
-                     ComputeCollectorFunc<O, I> computeFn, int parallelism) {
-    super(tSetEnv, name, parallelism);
+                     ComputeCollectorFunc<O, I> computeFn, int parallelism, Schema inputSchema) {
+    super(tSetEnv, name, parallelism, inputSchema);
     this.computeFunc = computeFn;
   }
 
@@ -63,8 +63,9 @@ public class ComputeTSet<O, I> extends BatchTSetImpl<O> {
     return (ComputeTSet<O, I>) super.addInput(key, input);
   }
 
-  public ComputeTSet<O, I> withDataType(MessageType dataType) {
-    return (ComputeTSet<O, I>) super.withDataType(dataType);
+  @Override
+  public ComputeTSet<O, I> withSchema(Schema schema) {
+    return (ComputeTSet<O, I>) super.withSchema(schema);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedCachedTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedCachedTSet.java
@@ -13,6 +13,7 @@ package edu.iu.dsc.tws.tset.sets.batch;
 
 import java.util.Iterator;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -27,6 +28,16 @@ public class KeyedCachedTSet<K, V> extends KeyedStoredTSet<K, V> {
   @Override
   public KeyedCachedTSet<K, V> setName(String n) {
     return (KeyedCachedTSet<K, V>) super.setName(n);
+  }
+
+  @Override
+  public KeyedCachedTSet<K, V> withDataType(MessageType dataType) {
+    return (KeyedCachedTSet<K, V>) super.withDataType(dataType);
+  }
+
+  @Override
+  public KeyedCachedTSet<K, V> withKeyType(MessageType keyType) {
+    return (KeyedCachedTSet<K, V>) super.withKeyType(keyType);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedCachedTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedCachedTSet.java
@@ -13,16 +13,17 @@ package edu.iu.dsc.tws.tset.sets.batch;
 
 import java.util.Iterator;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
+import edu.iu.dsc.tws.api.tset.schema.KeyedSchema;
+import edu.iu.dsc.tws.api.tset.schema.TupleSchema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 
 public class KeyedCachedTSet<K, V> extends KeyedStoredTSet<K, V> {
 
   public KeyedCachedTSet(BatchTSetEnvironment tSetEnv, SinkFunc<Iterator<Tuple<K, V>>> sinkFunc,
-                         int parallelism) {
-    super(tSetEnv, "kcached", sinkFunc, parallelism);
+                         int parallelism, KeyedSchema inputSchema) {
+    super(tSetEnv, "kcached", sinkFunc, parallelism, inputSchema);
   }
 
   @Override
@@ -31,13 +32,8 @@ public class KeyedCachedTSet<K, V> extends KeyedStoredTSet<K, V> {
   }
 
   @Override
-  public KeyedCachedTSet<K, V> withDataType(MessageType dataType) {
-    return (KeyedCachedTSet<K, V>) super.withDataType(dataType);
-  }
-
-  @Override
-  public KeyedCachedTSet<K, V> withKeyType(MessageType keyType) {
-    return (KeyedCachedTSet<K, V>) super.withKeyType(keyType);
+  public KeyedCachedTSet<K, V> withSchema(TupleSchema schema) {
+    return (KeyedCachedTSet<K, V>) super.withSchema(schema);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedCheckpointedTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedCheckpointedTSet.java
@@ -14,6 +14,7 @@ package edu.iu.dsc.tws.tset.sets.batch;
 
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.nodes.INode;
+import edu.iu.dsc.tws.api.tset.schema.KeyedSchema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.ops.CheckpointedSourceOp;
 import edu.iu.dsc.tws.tset.sources.DiskPartitionBackedSource;
@@ -34,8 +35,9 @@ public class KeyedCheckpointedTSet<K, V> extends KeyedPersistedTSet<K, V> {
   private DiskPartitionBackedSource<Tuple<K, V>> sourceFunc;
 
   public KeyedCheckpointedTSet(BatchTSetEnvironment tSetEnv,
-                               DiskPartitionBackedSource<Tuple<K, V>> sourceFn, int parallelism) {
-    super(tSetEnv, null, parallelism);
+                               DiskPartitionBackedSource<Tuple<K, V>> sourceFn, int parallelism,
+                               KeyedSchema inputSchema) {
+    super(tSetEnv, null, parallelism, inputSchema);
     this.sourceFunc = sourceFn;
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedPersistedTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedPersistedTSet.java
@@ -13,17 +13,19 @@ package edu.iu.dsc.tws.tset.sets.batch;
 
 import java.util.Iterator;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
+import edu.iu.dsc.tws.api.tset.schema.KeyedSchema;
+import edu.iu.dsc.tws.api.tset.schema.TupleSchema;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 
 public class KeyedPersistedTSet<K, V> extends KeyedStoredTSet<K, V> {
 
   public KeyedPersistedTSet(BatchTSetEnvironment tSetEnv,
-                            SinkFunc<Iterator<Tuple<K, V>>> storingSinkFn, int parallelism) {
-    super(tSetEnv, "kpersisted", storingSinkFn, parallelism);
+                            SinkFunc<Iterator<Tuple<K, V>>> storingSinkFn, int parallelism,
+                            KeyedSchema inputSchema) {
+    super(tSetEnv, "kpersisted", storingSinkFn, parallelism, inputSchema);
   }
 
   @Override
@@ -37,13 +39,8 @@ public class KeyedPersistedTSet<K, V> extends KeyedStoredTSet<K, V> {
   }
 
   @Override
-  public KeyedPersistedTSet<K, V> withDataType(MessageType dataType) {
-    return (KeyedPersistedTSet<K, V>) super.withDataType(dataType);
-  }
-
-  @Override
-  public KeyedPersistedTSet<K, V> withKeyType(MessageType keyType) {
-    return (KeyedPersistedTSet<K, V>) super.withKeyType(keyType);
+  public KeyedPersistedTSet<K, V> withSchema(TupleSchema schema) {
+    return (KeyedPersistedTSet<K, V>) super.withSchema(schema);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedPersistedTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedPersistedTSet.java
@@ -13,6 +13,7 @@ package edu.iu.dsc.tws.tset.sets.batch;
 
 import java.util.Iterator;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
@@ -33,6 +34,16 @@ public class KeyedPersistedTSet<K, V> extends KeyedStoredTSet<K, V> {
   @Override
   public KeyedPersistedTSet<K, V> addInput(String key, StorableTBase<?> input) {
     return (KeyedPersistedTSet<K, V>) super.addInput(key, input);
+  }
+
+  @Override
+  public KeyedPersistedTSet<K, V> withDataType(MessageType dataType) {
+    return (KeyedPersistedTSet<K, V>) super.withDataType(dataType);
+  }
+
+  @Override
+  public KeyedPersistedTSet<K, V> withKeyType(MessageType keyType) {
+    return (KeyedPersistedTSet<K, V>) super.withKeyType(keyType);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedSourceTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedSourceTSet.java
@@ -12,10 +12,11 @@
 
 package edu.iu.dsc.tws.tset.sets.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.nodes.INode;
 import edu.iu.dsc.tws.api.tset.fn.SourceFunc;
+import edu.iu.dsc.tws.api.tset.schema.PrimitiveSchemas;
+import edu.iu.dsc.tws.api.tset.schema.TupleSchema;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.ops.KeyedSourceOp;
@@ -30,7 +31,8 @@ public class KeyedSourceTSet<K, V> extends BatchTupleTSetImpl<K, V> {
 
   public KeyedSourceTSet(BatchTSetEnvironment tSetEnv, String name, SourceFunc<Tuple<K, V>> src,
                          int parallelism) {
-    super(tSetEnv, name, parallelism);
+    // no schema is preceding a keyedsource tset. Hence, the input schema will be NULL type.
+    super(tSetEnv, name, parallelism, PrimitiveSchemas.NULL);
     this.source = src;
   }
 
@@ -41,13 +43,8 @@ public class KeyedSourceTSet<K, V> extends BatchTupleTSetImpl<K, V> {
   }
 
   @Override
-  public KeyedSourceTSet<K, V> withDataType(MessageType dataType) {
-    return (KeyedSourceTSet<K, V>) super.withDataType(dataType);
-  }
-
-  @Override
-  public KeyedSourceTSet<K, V> withKeyType(MessageType keyType) {
-    return (KeyedSourceTSet<K, V>) super.withKeyType(keyType);
+  public KeyedSourceTSet<K, V> withSchema(TupleSchema schema) {
+    return (KeyedSourceTSet<K, V>) super.withSchema(schema);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedSourceTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedSourceTSet.java
@@ -12,6 +12,7 @@
 
 package edu.iu.dsc.tws.tset.sets.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.nodes.INode;
 import edu.iu.dsc.tws.api.tset.fn.SourceFunc;
@@ -37,6 +38,16 @@ public class KeyedSourceTSet<K, V> extends BatchTupleTSetImpl<K, V> {
   public KeyedSourceTSet<K, V> addInput(String key, StorableTBase<?> input) {
     getTSetEnv().addInput(getId(), input.getId(), key);
     return this;
+  }
+
+  @Override
+  public KeyedSourceTSet<K, V> withDataType(MessageType dataType) {
+    return (KeyedSourceTSet<K, V>) super.withDataType(dataType);
+  }
+
+  @Override
+  public KeyedSourceTSet<K, V> withKeyType(MessageType keyType) {
+    return (KeyedSourceTSet<K, V>) super.withKeyType(keyType);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedStoredTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedStoredTSet.java
@@ -154,7 +154,7 @@ public abstract class KeyedStoredTSet<K, V> extends BatchTupleTSetImpl<K, V>
   }
 
   @Override
-  protected KeyedSchema getInputSchema() {
+  public KeyedSchema getInputSchema() {
     return (KeyedSchema) super.getInputSchema();
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedStoredTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedStoredTSet.java
@@ -26,6 +26,7 @@ import edu.iu.dsc.tws.api.dataset.DataPartitionConsumer;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
+import edu.iu.dsc.tws.api.tset.schema.KeyedSchema;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
 import edu.iu.dsc.tws.api.tset.sets.batch.BatchTupleTSet;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -47,8 +48,9 @@ public abstract class KeyedStoredTSet<K, V> extends BatchTupleTSetImpl<K, V>
   protected KeyedSourceTSet<K, V> storedSource;
 
   KeyedStoredTSet(BatchTSetEnvironment tSetEnv, String name,
-                  SinkFunc<Iterator<Tuple<K, V>>> storingSinkFn, int parallelism) {
-    super(tSetEnv, name, parallelism);
+                  SinkFunc<Iterator<Tuple<K, V>>> storingSinkFn, int parallelism,
+                  KeyedSchema inputSchema) {
+    super(tSetEnv, name, parallelism, inputSchema);
     this.storingSinkFunc = storingSinkFn;
     this.storedSourcePrefix = "kstored(" + getId() + ")";
   }
@@ -151,4 +153,8 @@ public abstract class KeyedStoredTSet<K, V> extends BatchTupleTSetImpl<K, V>
     return new SinkOp<>(storingSinkFunc, this, getInputs());
   }
 
+  @Override
+  protected KeyedSchema getInputSchema() {
+    return (KeyedSchema) super.getInputSchema();
+  }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedTSet.java
@@ -13,12 +13,14 @@
 
 package edu.iu.dsc.tws.tset.sets.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.nodes.ICompute;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 import edu.iu.dsc.tws.api.tset.fn.TFunction;
+import edu.iu.dsc.tws.api.tset.schema.KeyedSchema;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
+import edu.iu.dsc.tws.api.tset.schema.TupleSchema;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.ops.ComputeCollectorToTupleOp;
 import edu.iu.dsc.tws.tset.ops.ComputeToTupleOp;
@@ -36,9 +38,14 @@ public class KeyedTSet<K, V> extends BatchTupleTSetImpl<K, V> {
     //non arg constructor for kryo
   }
 
+  /**
+   * NOTE: KeyedTSets input usually comes from a non keyed
+   * {@link edu.iu.dsc.tws.api.tset.link.TLink}. Hence the input schema is a not a
+   * {@link KeyedSchema}
+   */
   public KeyedTSet(BatchTSetEnvironment tSetEnv, TFunction<Tuple<K, V>, ?> mapFunc,
-                   int parallelism) {
-    super(tSetEnv, "keyed", parallelism);
+                   int parallelism, Schema inputSchema) {
+    super(tSetEnv, "keyed", parallelism, inputSchema);
     this.mapToTupleFunc = mapFunc;
   }
 
@@ -48,13 +55,8 @@ public class KeyedTSet<K, V> extends BatchTupleTSetImpl<K, V> {
   }
 
   @Override
-  public KeyedTSet<K, V> withDataType(MessageType dataType) {
-    return (KeyedTSet<K, V>) super.withDataType(dataType);
-  }
-
-  @Override
-  public KeyedTSet<K, V> withKeyType(MessageType keyType) {
-    return (KeyedTSet<K, V>) super.withKeyType(keyType);
+  public KeyedTSet<K, V> withSchema(TupleSchema schema) {
+    return (KeyedTSet<K, V>) super.withSchema(schema);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedTSet.java
@@ -13,6 +13,7 @@
 
 package edu.iu.dsc.tws.tset.sets.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.nodes.ICompute;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
@@ -44,6 +45,16 @@ public class KeyedTSet<K, V> extends BatchTupleTSetImpl<K, V> {
   @Override
   public KeyedTSet<K, V> setName(String n) {
     return (KeyedTSet<K, V>) super.setName(n);
+  }
+
+  @Override
+  public KeyedTSet<K, V> withDataType(MessageType dataType) {
+    return (KeyedTSet<K, V>) super.withDataType(dataType);
+  }
+
+  @Override
+  public KeyedTSet<K, V> withKeyType(MessageType keyType) {
+    return (KeyedTSet<K, V>) super.withKeyType(keyType);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/PersistedTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/PersistedTSet.java
@@ -11,15 +11,16 @@
 //  limitations under the License.
 package edu.iu.dsc.tws.tset.sets.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 
 public class PersistedTSet<T> extends StoredTSet<T> {
 
-  public PersistedTSet(BatchTSetEnvironment tSetEnv, SinkFunc<?> sinkFunc, int parallelism) {
-    super(tSetEnv, "persisted", sinkFunc, parallelism);
+  public PersistedTSet(BatchTSetEnvironment tSetEnv, SinkFunc<?> sinkFunc, int parallelism,
+                       Schema inputSchema) {
+    super(tSetEnv, "persisted", sinkFunc, parallelism, inputSchema);
   }
 
   @Override
@@ -53,7 +54,7 @@ public class PersistedTSet<T> extends StoredTSet<T> {
     return (PersistedTSet<T>) super.addInput(key, input);
   }
 
-  public PersistedTSet<T> withDataType(MessageType dataType) {
-    return (PersistedTSet<T>) super.withDataType(dataType);
+  public PersistedTSet<T> withSchema(Schema schema) {
+    return (PersistedTSet<T>) super.withSchema(schema);
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/PersistedTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/PersistedTSet.java
@@ -11,6 +11,7 @@
 //  limitations under the License.
 package edu.iu.dsc.tws.tset.sets.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -50,5 +51,9 @@ public class PersistedTSet<T> extends StoredTSet<T> {
   @Override
   public PersistedTSet<T> addInput(String key, StorableTBase<?> input) {
     return (PersistedTSet<T>) super.addInput(key, input);
+  }
+
+  public PersistedTSet<T> withDataType(MessageType dataType) {
+    return (PersistedTSet<T>) super.withDataType(dataType);
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/SinkTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/SinkTSet.java
@@ -13,19 +13,17 @@
 
 package edu.iu.dsc.tws.tset.sets.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.compute.nodes.ICompute;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.api.tset.sets.AcceptingData;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.ops.SinkOp;
-import edu.iu.dsc.tws.tset.sets.BaseTSet;
+import edu.iu.dsc.tws.tset.sets.BaseTSetWithSchema;
 
-public class SinkTSet<T> extends BaseTSet<T> implements AcceptingData<T> {
+public class SinkTSet<T> extends BaseTSetWithSchema<T> implements AcceptingData<T> {
   private SinkFunc<T> sinkFunc;
-  private MessageType dType = MessageTypes.OBJECT;
 
   /**
    * Creates SinkTSet with the given parameters, the parallelism of the TSet is taken as 1
@@ -33,8 +31,8 @@ public class SinkTSet<T> extends BaseTSet<T> implements AcceptingData<T> {
    * @param tSetEnv The TSetEnv used for execution
    * @param s       The Sink function to be used
    */
-  public SinkTSet(BatchTSetEnvironment tSetEnv, SinkFunc<T> s) {
-    this(tSetEnv, s, 1);
+  public SinkTSet(BatchTSetEnvironment tSetEnv, SinkFunc<T> s, Schema inputSchema) {
+    this(tSetEnv, s, 1, inputSchema);
   }
 
   /**
@@ -44,8 +42,9 @@ public class SinkTSet<T> extends BaseTSet<T> implements AcceptingData<T> {
    * @param sinkFn      The Sink function to be used
    * @param parallelism the parallelism of the sink
    */
-  public SinkTSet(BatchTSetEnvironment tSetEnv, SinkFunc<T> sinkFn, int parallelism) {
-    super(tSetEnv, "sink", parallelism);
+  public SinkTSet(BatchTSetEnvironment tSetEnv, SinkFunc<T> sinkFn, int parallelism,
+                  Schema inputSchema) {
+    super(tSetEnv, "sink", parallelism, inputSchema);
     this.sinkFunc = sinkFn;
   }
 
@@ -68,8 +67,8 @@ public class SinkTSet<T> extends BaseTSet<T> implements AcceptingData<T> {
     return this;
   }
 
-  public SinkTSet<T> withDataType(MessageType dataType) {
-    this.dType = dataType;
+  public SinkTSet<T> withSchema(Schema schema) {
+    this.setOutputSchema(schema);
     return this;
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/SinkTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/SinkTSet.java
@@ -13,6 +13,8 @@
 
 package edu.iu.dsc.tws.tset.sets.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.compute.nodes.ICompute;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
 import edu.iu.dsc.tws.api.tset.sets.AcceptingData;
@@ -23,6 +25,7 @@ import edu.iu.dsc.tws.tset.sets.BaseTSet;
 
 public class SinkTSet<T> extends BaseTSet<T> implements AcceptingData<T> {
   private SinkFunc<T> sinkFunc;
+  private MessageType dType = MessageTypes.OBJECT;
 
   /**
    * Creates SinkTSet with the given parameters, the parallelism of the TSet is taken as 1
@@ -62,6 +65,11 @@ public class SinkTSet<T> extends BaseTSet<T> implements AcceptingData<T> {
   @Override
   public SinkTSet<T> addInput(String key, StorableTBase<?> input) {
     getTSetEnv().addInput(getId(), input.getId(), key);
+    return this;
+  }
+
+  public SinkTSet<T> withDataType(MessageType dataType) {
+    this.dType = dataType;
     return this;
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/SourceTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/SourceTSet.java
@@ -25,6 +25,7 @@
 
 package edu.iu.dsc.tws.tset.sets.batch;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.nodes.INode;
 import edu.iu.dsc.tws.api.tset.fn.SourceFunc;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
@@ -53,13 +54,18 @@ public class SourceTSet<T> extends BatchTSetImpl<T> {
   }
 
   @Override
-  public INode getINode() {
-    return new SourceOp<>(source, this, getInputs());
-  }
-
-  @Override
   public SourceTSet<T> setName(String name) {
     rename(name);
     return this;
+  }
+
+  @Override
+  public SourceTSet<T> withDataType(MessageType dataType) {
+    return (SourceTSet<T>) super.withDataType(dataType);
+  }
+
+  @Override
+  public INode getINode() {
+    return new SourceOp<>(source, this, getInputs());
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/SourceTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/SourceTSet.java
@@ -25,9 +25,10 @@
 
 package edu.iu.dsc.tws.tset.sets.batch;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.nodes.INode;
 import edu.iu.dsc.tws.api.tset.fn.SourceFunc;
+import edu.iu.dsc.tws.api.tset.schema.PrimitiveSchemas;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
 import edu.iu.dsc.tws.tset.ops.SourceOp;
@@ -44,7 +45,7 @@ public class SourceTSet<T> extends BatchTSetImpl<T> {
   }
 
   public SourceTSet(BatchTSetEnvironment tSetEnv, String name, SourceFunc<T> src, int parallelism) {
-    super(tSetEnv, name, parallelism);
+    super(tSetEnv, name, parallelism, PrimitiveSchemas.NULL);
     this.source = src;
   }
 
@@ -60,8 +61,8 @@ public class SourceTSet<T> extends BatchTSetImpl<T> {
   }
 
   @Override
-  public SourceTSet<T> withDataType(MessageType dataType) {
-    return (SourceTSet<T>) super.withDataType(dataType);
+  public SourceTSet<T> withSchema(Schema schema) {
+    return (SourceTSet<T>) super.withSchema(schema);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/StoredTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/StoredTSet.java
@@ -27,6 +27,7 @@ import edu.iu.dsc.tws.api.tset.fn.MapFunc;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
 import edu.iu.dsc.tws.api.tset.fn.ReduceFunc;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.api.tset.sets.StorableTBase;
 import edu.iu.dsc.tws.api.tset.sets.TSet;
 import edu.iu.dsc.tws.tset.env.BatchTSetEnvironment;
@@ -56,8 +57,8 @@ public abstract class StoredTSet<T> extends BatchTSetImpl<T> implements Storable
    T. example: for direct, sink func would convert Iterator<T> to T.
    */
   StoredTSet(BatchTSetEnvironment tSetEnv, String name, SinkFunc<?> sinkFunc,
-             int parallelism) {
-    super(tSetEnv, name, parallelism);
+             int parallelism, Schema inputSchema) {
+    super(tSetEnv, name, parallelism, inputSchema);
     this.storingSinkFunc = sinkFunc;
     this.storedSourcePrefix = "stored(" + getId() + ")";
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SComputeTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SComputeTSet.java
@@ -14,11 +14,11 @@ package edu.iu.dsc.tws.tset.sets.streaming;
 
 import java.util.Collections;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.nodes.ICompute;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 import edu.iu.dsc.tws.api.tset.fn.TFunction;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 import edu.iu.dsc.tws.tset.ops.ComputeCollectorOp;
 import edu.iu.dsc.tws.tset.ops.ComputeOp;
@@ -27,24 +27,24 @@ public class SComputeTSet<O, I> extends StreamingTSetImpl<O> {
   private TFunction<O, I> computeFunc;
 
   public SComputeTSet(StreamingTSetEnvironment tSetEnv, ComputeFunc<O, I> computeFunction,
-                      int parallelism) {
-    this(tSetEnv, "scompute", computeFunction, parallelism);
+                      int parallelism, Schema inputSchema) {
+    this(tSetEnv, "scompute", computeFunction, parallelism, inputSchema);
   }
 
   public SComputeTSet(StreamingTSetEnvironment tSetEnv, ComputeCollectorFunc<O, I> compOp,
-                      int parallelism) {
-    this(tSetEnv, "scomputec", compOp, parallelism);
+                      int parallelism, Schema inputSchema) {
+    this(tSetEnv, "scomputec", compOp, parallelism, inputSchema);
   }
 
   public SComputeTSet(StreamingTSetEnvironment tSetEnv, String name,
-                      ComputeFunc<O, I> computeFunction, int parallelism) {
-    super(tSetEnv, name, parallelism);
+                      ComputeFunc<O, I> computeFunction, int parallelism, Schema inputSchema) {
+    super(tSetEnv, name, parallelism, inputSchema);
     this.computeFunc = computeFunction;
   }
 
   public SComputeTSet(StreamingTSetEnvironment tSetEnv, String name,
-                      ComputeCollectorFunc<O, I> compOp, int parallelism) {
-    super(tSetEnv, name, parallelism);
+                      ComputeCollectorFunc<O, I> compOp, int parallelism, Schema inputSchema) {
+    super(tSetEnv, name, parallelism, inputSchema);
     this.computeFunc = compOp;
   }
 
@@ -55,15 +55,15 @@ public class SComputeTSet<O, I> extends StreamingTSetImpl<O> {
   }
 
   @Override
-  public SComputeTSet<O, I> withDataType(MessageType dataType) {
-    return (SComputeTSet<O, I>) super.withDataType(dataType);
+  public SComputeTSet<O, I> withSchema(Schema schema) {
+    return (SComputeTSet<O, I>) super.withSchema(schema);
   }
 
   @Override
   public ICompute<I> getINode() {
     // todo: fix empty map
     if (computeFunc instanceof ComputeFunc) {
-      return new ComputeOp<O, I>((ComputeFunc<O, I>) computeFunc, this,
+      return new ComputeOp<>((ComputeFunc<O, I>) computeFunc, this,
           Collections.emptyMap());
     } else if (computeFunc instanceof ComputeCollectorFunc) {
       return new ComputeCollectorOp<>((ComputeCollectorFunc<O, I>) computeFunc, this,

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SComputeTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SComputeTSet.java
@@ -14,6 +14,7 @@ package edu.iu.dsc.tws.tset.sets.streaming;
 
 import java.util.Collections;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.nodes.ICompute;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
@@ -53,6 +54,10 @@ public class SComputeTSet<O, I> extends StreamingTSetImpl<O> {
     return this;
   }
 
+  @Override
+  public SComputeTSet<O, I> withDataType(MessageType dataType) {
+    return (SComputeTSet<O, I>) super.withDataType(dataType);
+  }
 
   @Override
   public ICompute<I> getINode() {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SKeyedSourceTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SKeyedSourceTSet.java
@@ -14,6 +14,7 @@ package edu.iu.dsc.tws.tset.sets.streaming;
 
 import java.util.Collections;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.nodes.INode;
 import edu.iu.dsc.tws.api.tset.fn.SourceFunc;
@@ -39,6 +40,16 @@ public class SKeyedSourceTSet<K, V> extends StreamingTupleTSetImpl<K, V> {
   public SKeyedSourceTSet<K, V> setName(String n) {
     rename(n);
     return this;
+  }
+
+  @Override
+  public SKeyedSourceTSet<K, V> withDataType(MessageType dataType) {
+    return (SKeyedSourceTSet<K, V>) super.withDataType(dataType);
+  }
+
+  @Override
+  public SKeyedSourceTSet<K, V> withKeyType(MessageType keyType) {
+    return (SKeyedSourceTSet<K, V>) super.withKeyType(keyType);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SKeyedSourceTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SKeyedSourceTSet.java
@@ -14,10 +14,11 @@ package edu.iu.dsc.tws.tset.sets.streaming;
 
 import java.util.Collections;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.nodes.INode;
 import edu.iu.dsc.tws.api.tset.fn.SourceFunc;
+import edu.iu.dsc.tws.api.tset.schema.PrimitiveSchemas;
+import edu.iu.dsc.tws.api.tset.schema.TupleSchema;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 import edu.iu.dsc.tws.tset.ops.KeyedSourceOp;
 
@@ -26,13 +27,13 @@ public class SKeyedSourceTSet<K, V> extends StreamingTupleTSetImpl<K, V> {
 
   public SKeyedSourceTSet(StreamingTSetEnvironment tSetEnv, SourceFunc<Tuple<K, V>> src,
                           int parallelism) {
-    super(tSetEnv, "sksource", parallelism);
+    super(tSetEnv, "sksource", parallelism, PrimitiveSchemas.NULL_TUPLE2);
     this.source = src;
   }
 
   public SKeyedSourceTSet(StreamingTSetEnvironment tSetEnv, String name,
                           SourceFunc<Tuple<K, V>> src, int parallelism) {
-    super(tSetEnv, name, parallelism);
+    super(tSetEnv, name, parallelism, PrimitiveSchemas.NULL_TUPLE2);
     this.source = src;
   }
 
@@ -43,13 +44,8 @@ public class SKeyedSourceTSet<K, V> extends StreamingTupleTSetImpl<K, V> {
   }
 
   @Override
-  public SKeyedSourceTSet<K, V> withDataType(MessageType dataType) {
-    return (SKeyedSourceTSet<K, V>) super.withDataType(dataType);
-  }
-
-  @Override
-  public SKeyedSourceTSet<K, V> withKeyType(MessageType keyType) {
-    return (SKeyedSourceTSet<K, V>) super.withKeyType(keyType);
+  public SKeyedSourceTSet<K, V> withSchema(TupleSchema schema) {
+    return (SKeyedSourceTSet<K, V>) super.withSchema(schema);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SKeyedTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SKeyedTSet.java
@@ -15,10 +15,11 @@ package edu.iu.dsc.tws.tset.sets.streaming;
 
 import java.util.Collections;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.nodes.ICompute;
 import edu.iu.dsc.tws.api.tset.fn.TFunction;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
+import edu.iu.dsc.tws.api.tset.schema.TupleSchema;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 import edu.iu.dsc.tws.tset.fn.GatherMapCompute;
 import edu.iu.dsc.tws.tset.fn.MapCompute;
@@ -36,8 +37,8 @@ public class SKeyedTSet<K, V> extends StreamingTupleTSetImpl<K, V> {
   private TFunction<Tuple<K, V>, ?> mapToTupleFunc;
 
   public SKeyedTSet(StreamingTSetEnvironment tSetEnv, TFunction<Tuple<K, V>, ?> mapFn,
-                    int parallelism) {
-    super(tSetEnv, "skeyed", parallelism);
+                    int parallelism, Schema inputSchema) {
+    super(tSetEnv, "skeyed", parallelism, inputSchema);
     this.mapToTupleFunc = mapFn;
   }
 
@@ -48,15 +49,9 @@ public class SKeyedTSet<K, V> extends StreamingTupleTSetImpl<K, V> {
   }
 
   @Override
-  public SKeyedTSet<K, V> withDataType(MessageType dataType) {
-    return (SKeyedTSet<K, V>) super.withDataType(dataType);
+  public SKeyedTSet<K, V> withSchema(TupleSchema schema) {
+    return (SKeyedTSet<K, V>) super.withSchema(schema);
   }
-
-  @Override
-  public SKeyedTSet<K, V> withKeyType(MessageType keyType) {
-    return (SKeyedTSet<K, V>) super.withKeyType(keyType);
-  }
-
 
   @Override
   public ICompute getINode() {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SKeyedTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SKeyedTSet.java
@@ -15,6 +15,7 @@ package edu.iu.dsc.tws.tset.sets.streaming;
 
 import java.util.Collections;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.compute.nodes.ICompute;
 import edu.iu.dsc.tws.api.tset.fn.TFunction;
@@ -41,6 +42,23 @@ public class SKeyedTSet<K, V> extends StreamingTupleTSetImpl<K, V> {
   }
 
   @Override
+  public SKeyedTSet<K, V> setName(String name) {
+    rename(name);
+    return this;
+  }
+
+  @Override
+  public SKeyedTSet<K, V> withDataType(MessageType dataType) {
+    return (SKeyedTSet<K, V>) super.withDataType(dataType);
+  }
+
+  @Override
+  public SKeyedTSet<K, V> withKeyType(MessageType keyType) {
+    return (SKeyedTSet<K, V>) super.withKeyType(keyType);
+  }
+
+
+  @Override
   public ICompute getINode() {
 
     if (mapToTupleFunc instanceof MapCompute) {
@@ -55,11 +73,5 @@ public class SKeyedTSet<K, V> extends StreamingTupleTSetImpl<K, V> {
     }
 
     throw new RuntimeException("Unknown map function passed to keyed tset" + mapToTupleFunc);
-  }
-
-  @Override
-  public SKeyedTSet<K, V> setName(String name) {
-    rename(name);
-    return this;
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SSinkTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SSinkTSet.java
@@ -15,6 +15,7 @@ package edu.iu.dsc.tws.tset.sets.streaming;
 
 import java.util.Collections;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.nodes.ICompute;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
@@ -46,13 +47,17 @@ public class SSinkTSet<T> extends StreamingTSetImpl<T> {
   }
 
   @Override
-  public ICompute getINode() {
-    return new SinkOp<>(sink, this, Collections.emptyMap());
-  }
-
-  @Override
   public SSinkTSet<T> setName(String n) {
     rename(n);
     return this;
+  }
+
+  public SSinkTSet<T> withDataType(MessageType dataType) {
+    return (SSinkTSet<T>) super.withDataType(dataType);
+  }
+
+  @Override
+  public ICompute getINode() {
+    return new SinkOp<>(sink, this, Collections.emptyMap());
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SSinkTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SSinkTSet.java
@@ -15,9 +15,9 @@ package edu.iu.dsc.tws.tset.sets.streaming;
 
 import java.util.Collections;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.nodes.ICompute;
 import edu.iu.dsc.tws.api.tset.fn.SinkFunc;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 import edu.iu.dsc.tws.tset.ops.SinkOp;
 
@@ -30,8 +30,8 @@ public class SSinkTSet<T> extends StreamingTSetImpl<T> {
    * @param tSetEnv The TSetEnv used for execution
    * @param s       The Sink function to be used
    */
-  public SSinkTSet(StreamingTSetEnvironment tSetEnv, SinkFunc<T> s) {
-    this(tSetEnv, s, 1);
+  public SSinkTSet(StreamingTSetEnvironment tSetEnv, SinkFunc<T> s, Schema inputSchema) {
+    this(tSetEnv, s, 1, inputSchema);
   }
 
   /**
@@ -41,8 +41,9 @@ public class SSinkTSet<T> extends StreamingTSetImpl<T> {
    * @param s           The Sink function to be used
    * @param parallelism the parallelism of the sink
    */
-  public SSinkTSet(StreamingTSetEnvironment tSetEnv, SinkFunc<T> s, int parallelism) {
-    super(tSetEnv, "ssink", parallelism);
+  public SSinkTSet(StreamingTSetEnvironment tSetEnv, SinkFunc<T> s, int parallelism,
+                   Schema inputSchema) {
+    super(tSetEnv, "ssink", parallelism, inputSchema);
     this.sink = s;
   }
 
@@ -52,8 +53,8 @@ public class SSinkTSet<T> extends StreamingTSetImpl<T> {
     return this;
   }
 
-  public SSinkTSet<T> withDataType(MessageType dataType) {
-    return (SSinkTSet<T>) super.withDataType(dataType);
+  public SSinkTSet<T> withSchema(Schema schema) {
+    return (SSinkTSet<T>) super.withSchema(schema);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SSourceTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SSourceTSet.java
@@ -15,6 +15,7 @@ package edu.iu.dsc.tws.tset.sets.streaming;
 
 import java.util.Collections;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.nodes.INode;
 import edu.iu.dsc.tws.api.tset.fn.SourceFunc;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
@@ -38,6 +39,10 @@ public class SSourceTSet<T> extends StreamingTSetImpl<T> {
   public SSourceTSet<T> setName(String n) {
     rename(n);
     return this;
+  }
+
+  public SSourceTSet<T> withDataType(MessageType dataType) {
+    return (SSourceTSet<T>) super.withDataType(dataType);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SSourceTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SSourceTSet.java
@@ -15,9 +15,10 @@ package edu.iu.dsc.tws.tset.sets.streaming;
 
 import java.util.Collections;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.nodes.INode;
 import edu.iu.dsc.tws.api.tset.fn.SourceFunc;
+import edu.iu.dsc.tws.api.tset.schema.PrimitiveSchemas;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 import edu.iu.dsc.tws.tset.ops.SourceOp;
 
@@ -25,13 +26,13 @@ public class SSourceTSet<T> extends StreamingTSetImpl<T> {
   private SourceFunc<T> source;
 
   public SSourceTSet(StreamingTSetEnvironment tSetEnv, SourceFunc<T> src, int parallelism) {
-    super(tSetEnv, "ssource", parallelism);
+    super(tSetEnv, "ssource", parallelism, PrimitiveSchemas.NULL);
     this.source = src;
   }
 
   public SSourceTSet(StreamingTSetEnvironment tSetEnv, String name, SourceFunc<T> src,
                      int parallelism) {
-    super(tSetEnv, name, parallelism);
+    super(tSetEnv, name, parallelism, PrimitiveSchemas.NULL);
     this.source = src;
   }
 
@@ -41,8 +42,8 @@ public class SSourceTSet<T> extends StreamingTSetImpl<T> {
     return this;
   }
 
-  public SSourceTSet<T> withDataType(MessageType dataType) {
-    return (SSourceTSet<T>) super.withDataType(dataType);
+  public SSourceTSet<T> withSchema(Schema schema) {
+    return (SSourceTSet<T>) super.withSchema(schema);
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/StreamingTSetImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/StreamingTSetImpl.java
@@ -60,14 +60,15 @@ public abstract class StreamingTSetImpl<T> extends BaseTSet<T> implements Stream
 
   @Override
   public SDirectTLink<T> direct() {
-    SDirectTLink<T> direct = new SDirectTLink<>(getTSetEnv(), getParallelism());
+    SDirectTLink<T> direct = new SDirectTLink<>(getTSetEnv(), getParallelism(), getDataType());
     addChildToGraph(direct);
     return direct;
   }
 
   @Override
   public SReduceTLink<T> reduce(ReduceFunc<T> reduceFn) {
-    SReduceTLink<T> reduce = new SReduceTLink<>(getTSetEnv(), reduceFn, getParallelism());
+    SReduceTLink<T> reduce = new SReduceTLink<>(getTSetEnv(), reduceFn, getParallelism(),
+        getDataType());
     addChildToGraph(reduce);
     return reduce;
   }
@@ -75,7 +76,7 @@ public abstract class StreamingTSetImpl<T> extends BaseTSet<T> implements Stream
   @Override
   public SPartitionTLink<T> partition(PartitionFunc<T> partitionFn, int targetParallelism) {
     SPartitionTLink<T> partition = new SPartitionTLink<>(getTSetEnv(),
-        partitionFn, getParallelism(), targetParallelism);
+        partitionFn, getParallelism(), targetParallelism, getDataType());
     addChildToGraph(partition);
     return partition;
   }
@@ -87,7 +88,7 @@ public abstract class StreamingTSetImpl<T> extends BaseTSet<T> implements Stream
 
   @Override
   public SGatherTLink<T> gather() {
-    SGatherTLink<T> gather = new SGatherTLink<>(getTSetEnv(), getParallelism());
+    SGatherTLink<T> gather = new SGatherTLink<>(getTSetEnv(), getParallelism(), getDataType());
     addChildToGraph(gather);
     return gather;
   }
@@ -95,15 +96,15 @@ public abstract class StreamingTSetImpl<T> extends BaseTSet<T> implements Stream
   @Override
   public SAllReduceTLink<T> allReduce(ReduceFunc<T> reduceFn) {
     SAllReduceTLink<T> allreduce = new SAllReduceTLink<>(getTSetEnv(), reduceFn,
-        getParallelism());
+        getParallelism(), getDataType());
     addChildToGraph(allreduce);
     return allreduce;
   }
 
   @Override
   public SAllGatherTLink<T> allGather() {
-    SAllGatherTLink<T> allgather = new SAllGatherTLink<>(getTSetEnv(),
-        getParallelism());
+    SAllGatherTLink<T> allgather = new SAllGatherTLink<>(getTSetEnv(), getParallelism(),
+        getDataType());
     addChildToGraph(allgather);
     return allgather;
   }
@@ -121,7 +122,7 @@ public abstract class StreamingTSetImpl<T> extends BaseTSet<T> implements Stream
     // now the following relationship is created
     // this -- directThis -- unionTSet
 
-    SDirectTLink<T> directOther = new SDirectTLink<>(getTSetEnv(), getParallelism());
+    SDirectTLink<T> directOther = new SDirectTLink<>(getTSetEnv(), getParallelism(), getDataType());
     addChildToGraph(other, directOther);
     addChildToGraph(directOther, union);
     // now the following relationship is created
@@ -143,7 +144,8 @@ public abstract class StreamingTSetImpl<T> extends BaseTSet<T> implements Stream
         throw new IllegalStateException("Parallelism of the TSets need to be the same in order to"
             + "perform a union operation");
       }
-      SDirectTLink<T> directOther = new SDirectTLink<>(getTSetEnv(), getParallelism());
+      SDirectTLink<T> directOther = new SDirectTLink<>(getTSetEnv(), getParallelism(),
+          getDataType());
       addChildToGraph(other, directOther);
       addChildToGraph(directOther, union);
     }
@@ -163,8 +165,7 @@ public abstract class StreamingTSetImpl<T> extends BaseTSet<T> implements Stream
           + getParallelism());
     }
 
-    SReplicateTLink<T> cloneTSet = new SReplicateTLink<>(getTSetEnv(),
-        replications);
+    SReplicateTLink<T> cloneTSet = new SReplicateTLink<>(getTSetEnv(), replications, getDataType());
     addChildToGraph(cloneTSet);
     return cloneTSet;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/StreamingTSetImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/StreamingTSetImpl.java
@@ -27,6 +27,8 @@ package edu.iu.dsc.tws.tset.sets.streaming;
 
 import java.util.Collection;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.MapFunc;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
@@ -45,6 +47,7 @@ import edu.iu.dsc.tws.tset.links.streaming.SReplicateTLink;
 import edu.iu.dsc.tws.tset.sets.BaseTSet;
 
 public abstract class StreamingTSetImpl<T> extends BaseTSet<T> implements StreamingTSet<T> {
+  private MessageType dType = MessageTypes.OBJECT;
 
   public StreamingTSetImpl(StreamingTSetEnvironment tSetEnv, String name, int parallelism) {
     super(tSetEnv, name, parallelism);
@@ -164,5 +167,15 @@ public abstract class StreamingTSetImpl<T> extends BaseTSet<T> implements Stream
         replications);
     addChildToGraph(cloneTSet);
     return cloneTSet;
+  }
+
+  @Override
+  public StreamingTSetImpl<T> withDataType(MessageType dataType) {
+    this.dType = dataType;
+    return this;
+  }
+
+  protected MessageType getDataType() {
+    return this.dType;
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/StreamingTupleTSetImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/StreamingTupleTSetImpl.java
@@ -15,7 +15,6 @@ package edu.iu.dsc.tws.tset.sets.streaming;
 import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
-import edu.iu.dsc.tws.api.tset.sets.TupleTSet;
 import edu.iu.dsc.tws.api.tset.sets.streaming.StreamingTupleTSet;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 import edu.iu.dsc.tws.tset.links.streaming.SKeyedDirectTLink;
@@ -59,7 +58,7 @@ public abstract class StreamingTupleTSetImpl<K, V> extends BaseTSet<V> implement
   }
 
   @Override
-  public TupleTSet<K, V> withDataType(MessageType dataType) {
+  public StreamingTupleTSetImpl<K, V> withDataType(MessageType dataType) {
     this.dType = dataType;
     return this;
   }
@@ -69,7 +68,7 @@ public abstract class StreamingTupleTSetImpl<K, V> extends BaseTSet<V> implement
   }
 
   @Override
-  public TupleTSet<K, V> withKeyType(MessageType keyType) {
+  public StreamingTupleTSetImpl<K, V> withKeyType(MessageType keyType) {
     this.kType = keyType;
     return this;
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/StreamingTupleTSetImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/StreamingTupleTSetImpl.java
@@ -12,7 +12,10 @@
 
 package edu.iu.dsc.tws.tset.sets.streaming;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.tset.fn.PartitionFunc;
+import edu.iu.dsc.tws.api.tset.sets.TupleTSet;
 import edu.iu.dsc.tws.api.tset.sets.streaming.StreamingTupleTSet;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 import edu.iu.dsc.tws.tset.links.streaming.SKeyedDirectTLink;
@@ -27,6 +30,8 @@ import edu.iu.dsc.tws.tset.sets.BaseTSet;
  */
 public abstract class StreamingTupleTSetImpl<K, V> extends BaseTSet<V> implements
     StreamingTupleTSet<K, V> {
+  private MessageType kType = MessageTypes.OBJECT;
+  private MessageType dType = MessageTypes.OBJECT;
 
   StreamingTupleTSetImpl(StreamingTSetEnvironment tSetEnv, String name, int parallelism) {
     super(tSetEnv, name, parallelism);
@@ -40,15 +45,36 @@ public abstract class StreamingTupleTSetImpl<K, V> extends BaseTSet<V> implement
   @Override
   public SKeyedPartitionTLink<K, V> keyedPartition(PartitionFunc<K> partitionFn) {
     SKeyedPartitionTLink<K, V> partition = new SKeyedPartitionTLink<>(getTSetEnv(), partitionFn,
-        getParallelism());
+        getParallelism(), getKeyType(), getDataType());
     addChildToGraph(partition);
     return partition;
   }
 
   @Override
   public SKeyedDirectTLink<K, V> keyedDirect() {
-    SKeyedDirectTLink<K, V> direct = new SKeyedDirectTLink<>(getTSetEnv(), getParallelism());
+    SKeyedDirectTLink<K, V> direct = new SKeyedDirectTLink<>(getTSetEnv(), getParallelism(),
+        getKeyType(), getDataType());
     addChildToGraph(direct);
     return direct;
+  }
+
+  @Override
+  public TupleTSet<K, V> withDataType(MessageType dataType) {
+    this.dType = dataType;
+    return this;
+  }
+
+  protected MessageType getDataType() {
+    return this.dType;
+  }
+
+  @Override
+  public TupleTSet<K, V> withKeyType(MessageType keyType) {
+    this.kType = keyType;
+    return this;
+  }
+
+  protected MessageType getKeyType() {
+    return this.kType;
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/StreamingTupleTSetImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/StreamingTupleTSetImpl.java
@@ -65,7 +65,7 @@ public abstract class StreamingTupleTSetImpl<K, V> extends BaseTSetWithSchema<V>
   }
 
   @Override
-  protected KeyedSchema getOutputSchema() {
+  public KeyedSchema getOutputSchema() {
     return (KeyedSchema) super.getOutputSchema();
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/WindowComputeTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/WindowComputeTSet.java
@@ -14,11 +14,10 @@ package edu.iu.dsc.tws.tset.sets.streaming;
 import java.util.Collections;
 import java.util.Iterator;
 
-import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.nodes.ICompute;
-import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 import edu.iu.dsc.tws.api.tset.fn.TFunction;
+import edu.iu.dsc.tws.api.tset.schema.Schema;
 import edu.iu.dsc.tws.task.window.util.WindowParameter;
 import edu.iu.dsc.tws.tset.env.StreamingTSetEnvironment;
 import edu.iu.dsc.tws.tset.fn.AggregateFunc;
@@ -41,42 +40,42 @@ public class WindowComputeTSet<O, I> extends StreamingTSetImpl<O> {
 
   private WindowParameter windowParameter;
 
-  public WindowComputeTSet(StreamingTSetEnvironment tSetEnv, ComputeFunc<O, I> computeFunction,
-                           int parallelism, WindowParameter winParam) {
-    this(tSetEnv, "wcompute", computeFunction, parallelism, winParam);
-  }
+//  public WindowComputeTSet(StreamingTSetEnvironment tSetEnv, ComputeFunc<O, I> computeFunction,
+//                           int parallelism, WindowParameter winParam) {
+//    this(tSetEnv, "wcompute", computeFunction, parallelism, winParam);
+//  }
 
   public WindowComputeTSet(StreamingTSetEnvironment tSetEnv,
-                           int parallelism, WindowParameter winParam) {
-    this(tSetEnv, "wcompute", parallelism, winParam);
+                           int parallelism, WindowParameter winParam, Schema inputSchema) {
+    this(tSetEnv, "wcompute", parallelism, winParam, inputSchema);
   }
 
-  public WindowComputeTSet(StreamingTSetEnvironment tSetEnv, ComputeCollectorFunc<O, I> compOp,
-                           int parallelism, WindowParameter winParam) {
-    this(tSetEnv, "wcomputec", compOp, parallelism, winParam);
-  }
+//  public WindowComputeTSet(StreamingTSetEnvironment tSetEnv, ComputeCollectorFunc<O, I> compOp,
+//                           int parallelism, WindowParameter winParam) {
+//    this(tSetEnv, "wcomputec", compOp, parallelism, winParam);
+//  }
 
-  public WindowComputeTSet(StreamingTSetEnvironment tSetEnv, String name,
-                           ComputeFunc<O, I> computeFunction, int parallelism,
-                           WindowParameter winParam) {
-    super(tSetEnv, name, parallelism);
-    this.computeFunc = computeFunction;
-    this.windowParameter = winParam;
-  }
+//  public WindowComputeTSet(StreamingTSetEnvironment tSetEnv, String name,
+//                           ComputeFunc<O, I> computeFunction, int parallelism,
+//                           WindowParameter winParam) {
+//    super(tSetEnv, name, parallelism);
+//    this.computeFunc = computeFunction;
+//    this.windowParameter = winParam;
+//  }
 
   public WindowComputeTSet(StreamingTSetEnvironment tSetEnv, String name, int parallelism,
-                           WindowParameter winParam) {
-    super(tSetEnv, name, parallelism);
+                           WindowParameter winParam, Schema inputSchema) {
+    super(tSetEnv, name, parallelism, inputSchema);
     this.windowParameter = winParam;
   }
 
-  public WindowComputeTSet(StreamingTSetEnvironment tSetEnv, String name,
-                           ComputeCollectorFunc<O, I> compOp, int parallelism,
-                           WindowParameter winParam) {
-    super(tSetEnv, name, parallelism);
-    this.computeFunc = compOp;
-    this.windowParameter = winParam;
-  }
+//  public WindowComputeTSet(StreamingTSetEnvironment tSetEnv, String name,
+//                           ComputeCollectorFunc<O, I> compOp, int parallelism,
+//                           WindowParameter winParam) {
+//    super(tSetEnv, name, parallelism);
+//    this.computeFunc = compOp;
+//    this.windowParameter = winParam;
+//  }
 
   @Override
   public WindowComputeTSet<O, I> setName(String name) {
@@ -137,7 +136,7 @@ public class WindowComputeTSet<O, I> extends StreamingTSetImpl<O> {
     return this;
   }
 
-  public WindowComputeTSet<O, I> withDataType(MessageType dataType) {
-    return (WindowComputeTSet<O, I>) super.withDataType(dataType);
+  public WindowComputeTSet<O, I> withSchema(Schema schema) {
+    return (WindowComputeTSet<O, I>) super.withSchema(schema);
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/WindowComputeTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/WindowComputeTSet.java
@@ -14,6 +14,7 @@ package edu.iu.dsc.tws.tset.sets.streaming;
 import java.util.Collections;
 import java.util.Iterator;
 
+import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.compute.nodes.ICompute;
 import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
@@ -136,5 +137,7 @@ public class WindowComputeTSet<O, I> extends StreamingTSetImpl<O> {
     return this;
   }
 
-
+  public WindowComputeTSet<O, I> withDataType(MessageType dataType) {
+    return (WindowComputeTSet<O, I>) super.withDataType(dataType);
+  }
 }


### PR DESCRIPTION
this PR is without exposing the schema to TSet functions in the runtime through the tset context. It seems like this is not possible without making Message Types, packers and schema serializable. But since it is an explicit type declaration by the users themselves, they know the message type when writing the logic in the tset function. We'll discuss this further offline. 