### PR TITLE
Client Logger at @k8s

### DIFF
--- a/docker/kubernetes/image/rootfs/twister2/init_openmpi.sh
+++ b/docker/kubernetes/image/rootfs/twister2/init_openmpi.sh
@@ -66,6 +66,7 @@ if [ "$lastFourChars" = "-0-0" ]; then
 else
   echo "This is not the first pod: $HOSTNAME"
   echo "Starting to sleep to infinity ..."
+  echo "All worker logs sent to worker-0. Please check worker-0 logs."
   sleep infinity
 fi
 

--- a/docs/docs/deployment/kubernetes/twister2-install-kubernetes.md
+++ b/docs/docs/deployment/kubernetes/twister2-install-kubernetes.md
@@ -66,14 +66,41 @@ waits to upload the job package to workers.
 
 ### Job Logs
 
-You can see the job logs either from Kubernetes Dashboard website, using kubectl command or 
-through persistent storage logs if enabled. 
-The workers in HelloWorld job prints a log message and sleeps 1 minutes before exiting. 
-So the user can check Kubernetes Dashboard website for worker log messages. 
-There must be a StatefulSet with the job name. List the pods in that StatefulSet. 
+There are a number of ways to check the logs of a Twister2 job. 
+* Saving Log Files in Submitting Client
+* Saving Log Files in Persistent Storage
+* Getting Log Files from Kubernetes Dashboard
+* Getting Log Files with kubectl
+
+#### Saving Log Files in Submitting Client
+Before submitting the job, you need to set the following parameter to true: 
+```text
+kubernetes.log.in.client 
+```
+Log files of all workers and the job master will be saved to the directory: 
+```text
+$HOME/.twister2/jobID
+```
+Loggers will run in the submitting client. So, you should let the submitting client run during
+the job execution. 
+
+#### Saving Log Files in Persistent Storage
+When a persistent storage is enabled for a job, 
+log files are written to that directory by default. 
+They are saved in the directory called "logs" under the persistent storage directory. 
+
+You need to learn the persistent logging directory of your storage provisioner. 
+You can learn it from Kubernetes Dashboard by checking the provisioner entity or consulting your administrator. 
+
+#### Getting Log Files from Kubernetes Dashboard
+Go to Kubernetes Dashboard website. 
+There must be at least two StatefulSets with the jobID. 
+One of them is for the job master and the other(s) is for workers. 
+List the pods in a StatefulSet. 
 Check the output for each pod by clicking on the right hand side button. 
 You will see the output for each worker in that window.
 
+#### Getting Log Files with kubectl
 To see the logs by using kubectl, you first need to learn the pod names in the job. 
 You can execute "kubectl get pods" command to list the pods in the cluster. 
 The pod names for the job are in the form of <job-name><ss-index><pod-index>.
@@ -81,11 +108,6 @@ You can see the logs of each pod by executing the command:
 ```bash
     $ kubectl logs <podname>
 ```
-
-You can also check the log files from persistent storage if the persistent storage is enabled. 
-You need to learn the persistent logging directory of your storage provisioner. 
-You can learn it from Kubernetes Dashboard by checking the provisioner entity or consulting your administrator. 
-Check that directory for the job logs.
 
 ### Logs for MPI Enabled Jobs
 
@@ -115,12 +137,15 @@ Twister2Job.loadTwister2Job()
 
 ### Job Names
 
-We are using job names as StatefulSet and Service names. In addition we are using job names as labels. 
+We are using job names in jobIDs. 
+In addition, we are using jobIDs as StatefulSet and Service names. 
+Furthermore, we are using jobIDs in labels to identify job pods. 
 Therefore job names must follow Kubernetes naming rules: [Kubernetes resource naming rules](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/).
 
-Job names should consist of lower case alphanumeric characters and dash\(-\) only. Their length can be 50 chars at most. 
+Job names should consist of lower case alphanumeric characters and dash\(-\) only. 
+Their length can be 30 chars at most. 
 If job names do not conform to these rules, we automatically change them to accommodate those rules. 
-We use the changed names as job names.  
+We use the changed names in jobIDs. 
 
 ## Job Package Uploader Settings
 

--- a/twister2/config/src/yaml/conf/kubernetes/resource.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/resource.yaml
@@ -20,6 +20,10 @@ twister2.resource.class.launcher: edu.iu.dsc.tws.rsched.schedulers.k8s.Kubernete
 # it could also be Always
 # kubernetes.image.pull.policy: "Always"
 
+# get log messages to twister2 client and save in files
+# it is false by default
+# kubernetes.log.in.client: true
+
 ################################################################################
 # Job configuration parameters for submission of twister2 jobs
 # Jobs can be loaded from these configurations or

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesContext.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesContext.java
@@ -24,6 +24,9 @@ public class KubernetesContext extends SchedulerContext {
   public static final String KUBERNETES_NAMESPACE_DEFAULT = "default";
   public static final String KUBERNETES_NAMESPACE = "kubernetes.namespace";
 
+  public static final boolean K8S_LOG_IN_CLIENT_DEFAULT = false;
+  public static final String K8S_LOG_IN_CLIENT = "kubernetes.log.in.client";
+
   public static final int K8S_WORKER_BASE_PORT_DEFAULT = 9000;
   public static final String K8S_WORKER_BASE_PORT = "kubernetes.worker.base.port";
 
@@ -93,6 +96,10 @@ public class KubernetesContext extends SchedulerContext {
 
   public static String namespace(Config cfg) {
     return cfg.getStringValue(KUBERNETES_NAMESPACE, KUBERNETES_NAMESPACE_DEFAULT);
+  }
+
+  public static boolean logInClient(Config cfg) {
+    return cfg.getBooleanValue(K8S_LOG_IN_CLIENT, K8S_LOG_IN_CLIENT_DEFAULT);
   }
 
   public static boolean nodeLocationsFromConfig(Config cfg) {

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesLauncher.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesLauncher.java
@@ -32,6 +32,7 @@ import edu.iu.dsc.tws.proto.jobmaster.JobMasterAPI;
 import edu.iu.dsc.tws.proto.system.job.JobAPI;
 import edu.iu.dsc.tws.proto.utils.NodeInfoUtils;
 import edu.iu.dsc.tws.rsched.schedulers.k8s.driver.K8sScaler;
+import edu.iu.dsc.tws.rsched.schedulers.k8s.logger.JobLogger;
 import edu.iu.dsc.tws.rsched.schedulers.k8s.master.JobMasterRequestObject;
 import edu.iu.dsc.tws.rsched.utils.JobUtils;
 
@@ -47,6 +48,7 @@ public class KubernetesLauncher implements ILauncher, IJobTerminator {
   private KubernetesController controller;
   private String namespace;
   private JobSubmissionStatus jobSubmissionStatus;
+  private JobLogger jobLogger;
 
   public KubernetesLauncher() {
     controller = new KubernetesController();
@@ -129,6 +131,11 @@ public class KubernetesLauncher implements ILauncher, IJobTerminator {
         clearupWhenSubmissionFails(jobID);
         return state;
       }
+    }
+
+    if (KubernetesContext.logInClient(config)) {
+      jobLogger = new JobLogger(namespace, job);
+      jobLogger.start();
     }
 
     state.setRequestGranted(true);

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/logger/JobLogger.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/logger/JobLogger.java
@@ -138,10 +138,12 @@ public class JobLogger extends Thread {
         ) {
 
           String podName = item.object.getMetadata().getName();
+          String podIP = item.object.getStatus().getPodIP();
+
           List<V1Container> containers = item.object.getSpec().getContainers();
           if (podName.endsWith("-jm-0")) {
             String contName = containers.get(0).getName();
-            String id = "job-master";
+            String id = "job-master-ip" + podIP;
             WorkerLogger workerLogger = new WorkerLogger(
                 namespace, podName, contName, id, logsDir, v1Api, this);
             startWorkerLogger(workerLogger);
@@ -154,7 +156,7 @@ public class JobLogger extends Thread {
             if (wID >= numberOfWorkers) {
               numberOfWorkers = wID + 1;
             }
-            String id = "worker" + wID;
+            String id = "worker" + wID + "-ip" + podIP;
             WorkerLogger workerLogger =
                 new WorkerLogger(namespace, podName, container.getName(), id, logsDir, v1Api, this);
             startWorkerLogger(workerLogger);

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/logger/JobLogger.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/logger/JobLogger.java
@@ -1,0 +1,196 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package edu.iu.dsc.tws.rsched.schedulers.k8s.logger;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.gson.reflect.TypeToken;
+
+import edu.iu.dsc.tws.proto.system.job.JobAPI;
+import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesController;
+import edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesUtils;
+import edu.iu.dsc.tws.rsched.schedulers.k8s.worker.K8sWorkerUtils;
+import edu.iu.dsc.tws.rsched.utils.FileUtils;
+
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.util.Watch;
+
+/**
+ * get logs of all workers in a job from Kubernetes master
+ * save it to local disk
+ */
+
+public class JobLogger extends Thread {
+  private static final Logger LOG = Logger.getLogger(JobLogger.class.getName());
+
+  private JobAPI.Job job;
+  private String namespace;
+  private List<String> containerNames;
+  private String logsDir;
+
+  private CoreV1Api v1Api;
+  private Watch<V1Pod> watcher;
+  private boolean stopLogger = false;
+
+  private List<WorkerLogger> loggers;
+  private int completedLoggerCounter = 0;
+
+  public JobLogger(String namespace, JobAPI.Job job) {
+    this.job = job;
+    this.namespace = namespace;
+
+    loggers = new LinkedList<>();
+
+    containerNames = new LinkedList<>();
+    for (int i = 0; i < job.getComputeResource(0).getWorkersPerPod(); i++) {
+      containerNames.add(KubernetesUtils.createContainerName(i));
+    }
+  }
+
+  @Override
+  public void run() {
+    v1Api = KubernetesController.createCoreV1Api();
+    logsDir = System.getProperty("user.home") + "/.twister2/" + job.getJobId();
+    if (!FileUtils.isDirectoryExists(logsDir)) {
+      FileUtils.createDirectory(logsDir);
+    }
+    LOG.info("Job logs directory: " + logsDir);
+
+    watchPodsToRunningStartLoggers();
+  }
+
+  /**
+   * TODO: need to take into account restarts and scaling up/down
+   * @param workerLogger
+   */
+  public void workerLoggerCompleted(WorkerLogger workerLogger) {
+    completedLoggerCounter++;
+    loggers.remove(workerLogger);
+
+    if (completedLoggerCounter == job.getNumberOfWorkers() + 1) {
+      stopLogger();
+      LOG.info("All workers completed. Job has finished.");
+    }
+  }
+
+  /**
+   * watch job pods until they become Running and start loggers for each container afterward
+   */
+  private void watchPodsToRunningStartLoggers() {
+
+    /** Pod Phases: Pending, Running, Succeeded, Failed, Unknown
+     * ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase */
+
+    String jobPodsLabel = KubernetesUtils.createJobPodsLabelWithKey(job.getJobId());
+
+    Integer timeoutSeconds = Integer.MAX_VALUE;
+    String podPhase = "Running";
+
+    try {
+      watcher = Watch.createWatch(
+          KubernetesController.getApiClient(),
+          v1Api.listNamespacedPodCall(namespace, null, null, null, null, jobPodsLabel,
+              null, null, timeoutSeconds, Boolean.TRUE, null),
+          new TypeToken<Watch.Response<V1Pod>>() {
+          }.getType());
+
+    } catch (ApiException e) {
+      String logMessage = "Exception when watching the pods to get the IPs: \n"
+          + "exCode: " + e.getCode() + "\n"
+          + "responseBody: " + e.getResponseBody();
+      LOG.log(Level.SEVERE, logMessage, e);
+      throw new RuntimeException(e);
+    }
+
+    // when we close the watcher to stop uploader,
+    // it throws RuntimeException
+    // we catch this exception and ignore it.
+    try {
+
+      for (Watch.Response<V1Pod> item : watcher) {
+
+        if (stopLogger) {
+          break;
+        }
+
+        // if DeletionTimestamp is not null,
+        // it means that the pod is in the process of being deleted
+        if (item.object != null
+            && item.object.getMetadata().getName().startsWith(job.getJobId())
+            && podPhase.equals(item.object.getStatus().getPhase())
+            && item.object.getMetadata().getDeletionTimestamp() == null
+        ) {
+
+          String podName = item.object.getMetadata().getName();
+          if (podName.endsWith("-jm-0")) {
+            WorkerLogger workerLogger = new WorkerLogger(
+                namespace, podName, "twister2-job-master-0", "job-master", logsDir, v1Api, this);
+            workerLogger.start();
+            loggers.add(workerLogger);
+            continue;
+          }
+
+          for (String cont: containerNames) {
+            String id = "worker-" + K8sWorkerUtils.calculateWorkerID(job, podName, cont);
+            WorkerLogger workerLogger =
+                new WorkerLogger(namespace, podName, cont, id, logsDir, v1Api, this);
+            workerLogger.start();
+            loggers.add(workerLogger);
+          }
+
+        }
+      }
+
+    } catch (RuntimeException e) {
+      if (stopLogger) {
+        LOG.fine("JobLogger is stopped.");
+        return;
+      } else {
+        throw e;
+      }
+    }
+
+    closeWatcher();
+  }
+
+  private void closeWatcher() {
+
+    if (watcher == null) {
+      return;
+    }
+
+    try {
+      watcher.close();
+    } catch (IOException e) {
+      LOG.log(Level.SEVERE, "Exception closing watcher.", e);
+    }
+
+    watcher = null;
+  }
+
+  public void stopLogger() {
+    stopLogger = true;
+    closeWatcher();
+
+    for (WorkerLogger logger: loggers) {
+      if (logger.isAlive()) {
+        logger.stopLogging();
+      }
+    }
+  }
+}

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/logger/JobLogger.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/logger/JobLogger.java
@@ -34,8 +34,9 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.util.Watch;
 
 /**
- * get logs of all workers in a job from Kubernetes master
- * save it to local disk
+ * get logs of all workers and the job master in a job from Kubernetes master
+ * save them to local disk under the directory:
+ *   $HOME/.twister2/jobID
  */
 
 public class JobLogger extends Thread {

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/logger/JobLogger.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/logger/JobLogger.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.TreeSet;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -61,7 +61,7 @@ public class JobLogger extends Thread {
     this.numberOfWorkers = job.getNumberOfWorkers();
 
     loggers = new LinkedList<>();
-    completedLoggers = new TreeSet<>();
+    completedLoggers = new ConcurrentSkipListSet<>();
   }
 
   @Override

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/logger/WorkerLogger.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/logger/WorkerLogger.java
@@ -1,0 +1,121 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package edu.iu.dsc.tws.rsched.schedulers.k8s.logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import okhttp3.Call;
+import okhttp3.Response;
+
+public class WorkerLogger extends Thread {
+  private static final Logger LOG = Logger.getLogger(WorkerLogger.class.getName());
+
+  private String namespace;
+  private String podName;
+  private String containerName;
+  private String id;
+  private String logFileName;
+  private String logsDir;
+  private CoreV1Api coreV1Api;
+  private JobLogger jobLogger;
+
+  public WorkerLogger(String namespace,
+                      String podName,
+                      String containerName,
+                      String id,
+                      String logsDir,
+                      CoreV1Api coreV1Api,
+                      JobLogger jobLogger) {
+    this.namespace = namespace;
+    this.podName = podName;
+    this.containerName = containerName;
+    this.id = id;
+    this.logsDir = logsDir;
+    this.coreV1Api = coreV1Api;
+    this.jobLogger = jobLogger;
+  }
+
+  @Override
+  public void run() {
+
+    Path logfile = createLogFile();
+    LOG.info("Saving " + id + " logs to: " + logFileName);
+
+    try {
+      InputStream logStream = streamContainerLog();
+      java.nio.file.Files.copy(logStream, logfile, StandardCopyOption.REPLACE_EXISTING);
+      logStream.close();
+      LOG.info("Logging completed for " + id + " to: " + logFileName);
+
+    } catch (ApiException e) {
+      LOG.log(Level.SEVERE, "Cannot get the log stream for " + id, e);
+    } catch (IOException e) {
+      LOG.log(Level.SEVERE, "Cannot get the log stream for " + id, e);
+    }
+
+    jobLogger.workerLoggerCompleted(this);
+  }
+
+  /**
+   * TODO: if file exist, take care of that case
+   * @return
+   */
+  private Path createLogFile() {
+    logFileName = logsDir + "/" + id + ".log";
+    Path logfile = Paths.get(logFileName);
+//    if (Files.notExists(logfile)) {
+//      return logfile;
+//    }
+
+    return logfile;
+  }
+
+  // Important note. You must close this stream or else you can leak connections.
+  public InputStream streamContainerLog() throws ApiException, IOException {
+
+    Integer sinceSeconds = null;
+    Integer tailLines = null;
+    boolean timestamps = false;
+
+    Call call = coreV1Api.readNamespacedPodLogCall(
+        podName,
+        namespace,
+        containerName,
+        true,
+        null,
+        "false",
+        false,
+        sinceSeconds,
+        tailLines,
+        timestamps,
+        null);
+    Response response = call.execute();
+    if (!response.isSuccessful()) {
+      throw new ApiException(response.code(), "Logs request failed: " + response.code());
+    }
+    return response.body().byteStream();
+  }
+
+
+  public void stopLogging() {
+
+  }
+
+}

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/logger/WorkerLogger.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/logger/WorkerLogger.java
@@ -33,6 +33,9 @@ import io.kubernetes.client.openapi.apis.CoreV1Api;
 import okhttp3.Call;
 import okhttp3.Response;
 
+/**
+ * save log of a worker or a job master to a log file
+ */
 public class WorkerLogger extends Thread {
   private static final Logger LOG = Logger.getLogger(WorkerLogger.class.getName());
 

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/logger/WorkerLogger.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/logger/WorkerLogger.java
@@ -16,6 +16,7 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -74,7 +75,9 @@ public class WorkerLogger extends Thread {
   }
 
   /**
-   * TODO: if file exist, take care of that case
+   * TODO: if the worker is coming from failure
+   *       currently, the old file is replaced.
+   *       we may append the logs to that file
    * @return
    */
   private Path createLogFile() {
@@ -118,4 +121,20 @@ public class WorkerLogger extends Thread {
 
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    WorkerLogger that = (WorkerLogger) o;
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
 }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/logger/WorkerLogger.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/logger/WorkerLogger.java
@@ -70,7 +70,7 @@ public class WorkerLogger extends Thread {
       LOG.log(Level.SEVERE, "Cannot get the log stream for " + id, e);
     }
 
-    jobLogger.workerLoggerCompleted(this);
+    jobLogger.workerLoggerCompleted(id);
   }
 
   /**


### PR DESCRIPTION
Implemented logging at client at k8s.
A configuration parameter added: kubernetes.log.in.client 
JobLogger runs when this parameter is true. 
Job log files are saved in the directory: $HOME/.twister2/jobID 
Log files names are in the form of: worker${ID}-ip{workerIP}-${logFileIndex}.log
Updated k8s documentation for logging.
Handled scaling up of workers. 
Handled restarted workers. New log files are generated for restarted workers with new counter index. 