### PR TITLE
fixed reset by peer error

### DIFF
--- a/twister2/common/src/java/edu/iu/dsc/tws/common/net/tcp/request/RRServer.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/net/tcp/request/RRServer.java
@@ -119,11 +119,11 @@ public class RRServer {
   protected int pendingSendCount = 0;
 
   public RRServer(Config cfg, String host, int port, Progress looper, int serverID,
-                  ConnectHandler cHandler) {
+                  ConnectHandler cHandler, int backLog) {
     this.connectHandler = cHandler;
     this.loop = looper;
     this.serverID = serverID;
-    server = new Server(cfg, host, port, loop, new Handler(), false);
+    server = new Server(cfg, host, port, loop, new Handler(), false, backLog);
   }
 
   public void registerRequestHandler(Message.Builder builder, MessageHandler handler) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/jobmaster/JobMasterExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/internal/jobmaster/JobMasterExample.java
@@ -34,6 +34,7 @@ import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.exceptions.Twister2Exception;
 import edu.iu.dsc.tws.common.config.ConfigLoader;
 import edu.iu.dsc.tws.common.zk.ZKContext;
+import edu.iu.dsc.tws.examples.basic.HelloWorld;
 import edu.iu.dsc.tws.master.IJobTerminator;
 import edu.iu.dsc.tws.master.server.JobMaster;
 import edu.iu.dsc.tws.proto.jobmaster.JobMasterAPI;
@@ -66,24 +67,31 @@ public final class JobMasterExample {
   public static void main(String[] args) {
 
     if (args.length != 1) {
-      LOG.info("usage: java JobMasterExample start/restart");
+      LOG.info("usage: java JobMasterExample numberOfWorkers");
       return;
     }
+
+    int numberOfWorkers = Integer.parseInt(args[0]);
+    String host = "0.0.0.0";
 
     // we assume that the twister2Home is the current directory
 //    String configDir = "../twister2/config/src/yaml/";
     String configDir = "";
     String twister2Home = Paths.get(configDir).toAbsolutePath().toString();
     Config config = ConfigLoader.loadConfig(twister2Home, "conf", "kubernetes");
+    config = JobMasterClientExample.updateConfig(config, config, host);
     LOG.info("Loaded: " + config.size() + " configuration parameters.");
 
-    Twister2Job twister2Job = Twister2Job.loadTwister2Job(config, null);
+//    Twister2Job twister2Job = Twister2Job.loadTwister2Job(config, null);
+    Twister2Job twister2Job = Twister2Job.newBuilder()
+        .setJobName("hello-world-job")
+        .setWorkerClass(HelloWorld.class)
+        .addComputeResource(.2, 128, numberOfWorkers)
+        .build();
     twister2Job.setUserName(System.getProperty("user.name"));
 
     JobAPI.Job job = twister2Job.serialize();
     LOG.info("JobID: " + job.getJobId());
-
-    String host = "localhost";
 
     JobMasterAPI.JobMasterState initialState = JobMasterAPI.JobMasterState.JM_STARTED;
     JobMasterStarter.job = job;

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPILauncher.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPILauncher.java
@@ -14,8 +14,6 @@ package edu.iu.dsc.tws.rsched.schedulers.standalone;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -222,7 +220,7 @@ public class MPILauncher implements ILauncher {
         int port = NetworkUtils.getFreePort();
         String hostAddress = JobMasterContext.jobMasterIP(config);
         if (hostAddress == null) {
-          hostAddress = InetAddress.getLocalHost().getHostAddress();
+          hostAddress = ResourceSchedulerUtils.getHostIP();
         }
         // add the port and ip to config
         config = Config.newBuilder().putAll(config).put("__job_master_port__", port).
@@ -237,13 +235,10 @@ public class MPILauncher implements ILauncher {
         NomadTerminator nt = new NomadTerminator();
 
         jobMaster = new JobMaster(
-            config, hostAddress, port, nt, job, jobMasterNodeInfo, nullScaler, initialState);
+            config, "0.0.0.0", port, nt, job, jobMasterNodeInfo, nullScaler, initialState);
         jobMaster.addShutdownHook(true);
         jmThread = jobMaster.startJobMasterThreaded();
         ResourceRuntime.getInstance().setJobMasterHostPort(hostAddress, port);
-      } catch (UnknownHostException e) {
-        LOG.log(Level.SEVERE, "Exception when getting local host address: ", e);
-        throw new RuntimeException(e);
       } catch (Twister2Exception e) {
         LOG.log(Level.SEVERE, "Exception when starting Job master: ", e);
         throw new RuntimeException(e);


### PR DESCRIPTION
The reason for connection reset by peer error was the lower default value for tcp backLog variable. 
The maximum number of pending connections.
Its default value seems to be around 50 in Java. 

I set this value to numberOfWorkers/2
If numberOfWorkers/2 is less than 50, we use default value. 
If numberOfWorkers/2 is more than 2048, we use 2048. 
