### PR TITLE
enabling multiple job submissions and ucx classpath fix

### DIFF
--- a/docker/kubernetes/image/rootfs/twister2/init.sh
+++ b/docker/kubernetes/image/rootfs/twister2/init.sh
@@ -19,12 +19,15 @@ if [ $? -ne 0 ]; then
 fi
 
 # update the classpath with the user job jar package
-CLASSPATH=$POD_MEMORY_VOLUME/$JOB_ARCHIVE_DIRECTORY/$USER_JOB_JAR_FILE:$CLASSPATH
+CLASSPATH=$POD_MEMORY_VOLUME/$JOB_ARCHIVE_DIRECTORY/$USER_JOB_JAR_FILE:/twister2/lib/ucx/:$CLASSPATH
 LOGGER_PROPERTIES_FILE=$POD_MEMORY_VOLUME/$JOB_ARCHIVE_DIRECTORY/$LOGGER_PROPERTIES_FILE
 
 # start the class to run
 echo "Starting $CLASS_TO_RUN .... "
-java -Xms${JVM_MEMORY_MB}m -Xmx${JVM_MEMORY_MB}m -Djava.util.logging.config.file=$LOGGER_PROPERTIES_FILE $CLASS_TO_RUN
+java -Xms${JVM_MEMORY_MB}m -Xmx${JVM_MEMORY_MB}m \
+  -Djava.util.logging.config.file=$LOGGER_PROPERTIES_FILE \
+  $CLASS_TO_RUN
+
 result=$?
 echo "$CLASS_TO_RUN is done. return code: $result"
 # return the exit code of twister2-worker or jm,

--- a/scripts/package/BUILD
+++ b/scripts/package/BUILD
@@ -331,6 +331,7 @@ pack_tw2(
         ":twister2-restarter",
         ":twister2-tset",
         ":twister2-ucx-native-libs",
+        ":twister2-ucx-native-libs-dir"
     ],
 )
 
@@ -393,6 +394,7 @@ pack_tw2(
         ":twister2-test-values",
         ":twister2-tset",
         ":twister2-ucx-native-libs",
+        ":twister2-ucx-native-libs-dir"
     ],
 )
 
@@ -708,5 +710,12 @@ pack_tw2(
     name = "twister2-ucx-native-libs",
     srcs = twister2_ucx_native_libs(),
     package_dir = "lib/ucx",
+    version = T2_VERSION,
+)
+
+pack_tw2(
+    name = "twister2-ucx-native-libs-dir",
+    srcs = ["EMPTY"],
+    package_dir = "lib/ucx/ucx",
     version = T2_VERSION,
 )

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/ResourceAllocator.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/core/ResourceAllocator.java
@@ -351,6 +351,12 @@ public class ResourceAllocator {
       clearTemporaryFiles(jobDirectory);
     }
 
+    if (SchedulerContext.clusterType(updatedConfig).equals("standalone")
+        && SchedulerContext.uploaderClass(updatedConfig)
+        .equals("edu.iu.dsc.tws.rsched.uploaders.localfs.LocalFileSystemUploader")) {
+      uploader.undo(updatedConfig, updatedJob.getJobId());
+    }
+
     return state;
   }
 

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/uploaders/localfs/LocalFileSystemUploader.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/uploaders/localfs/LocalFileSystemUploader.java
@@ -34,7 +34,7 @@ public class LocalFileSystemUploader implements IUploader {
 
   @Override
   public void initialize(Config config, JobAPI.Job job) {
-    this.destinationDirectory = FsContext.uploaderJobDirectory(config);
+    this.destinationDirectory = FsContext.uploaderJobDirectory(config) + "/" + job.getJobId();
   }
 
   @Override
@@ -77,20 +77,19 @@ public class LocalFileSystemUploader implements IUploader {
     try {
       FileUtils.copyDirectory(sourceLocation, destinationDirectory);
       return new URI(destinationDirectory);
-    }  catch (URISyntaxException e) {
+    } catch (URISyntaxException e) {
       throw new RuntimeException("Invalid file path for topology package destination: "
           + destinationDirectory, e);
     } catch (IOException e) {
       throw new RuntimeException(String.format("Failed to copy directory %s to %s",
-          filePath.toString(), destinationDirectory));
+          sourceLocation, destinationDirectory));
     }
   }
 
   @Override
   public boolean undo(Config cnfg, String jobID) {
-    LOG.info("Clean uploaded jar");
-    File file = new File(destinationDirectory);
-    return file.delete();
+    LOG.info("Cleaning upload directory: " + destinationDirectory);
+    return FileUtils.deleteDir(destinationDirectory);
   }
 
   @Override


### PR DESCRIPTION
Enabled multiple concurrent job submissions in LocalFileSystemUploader.java. 
Copied job package to a job specific folder under .twister2/repository/jobID
Removed job package after the job ends. 
Added ucx lib folder to classpath in k8s docker container.
Added an empty directory for ucx in lib/ucx/ucx