### PR TITLE
network interface parameter and jvm memory fraction at k8s

### DIFF
--- a/twister2/api/src/java/edu/iu/dsc/tws/api/config/SchedulerContext.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/config/SchedulerContext.java
@@ -101,6 +101,8 @@ public class SchedulerContext extends Context {
   public static final boolean K8S_CHECK_PODS_REACHABLE_DEFAULT = false;
   public static final String K8S_CHECK_PODS_REACHABLE = "kubernetes.check.pods.reachable";
 
+  public static final String NETWORK_INTERFACES = "twister2.network.interfaces.for.workers";
+
   public static String uploaderClass(Config cfg) {
     return cfg.getStringValue(UPLOADER_CLASS);
   }
@@ -200,6 +202,7 @@ public class SchedulerContext extends Context {
   public static String downloadMethod(Config cfg) {
     return cfg.getStringValue(DOWNLOAD_METHOD);
   }
+
   public static List<String> additionalPorts(Config cfg) {
     return cfg.getStringList(ADDITIONAL_PORTS);
   }
@@ -215,6 +218,10 @@ public class SchedulerContext extends Context {
 
   public static boolean checkPodsReachable(Config cfg) {
     return cfg.getBooleanValue(K8S_CHECK_PODS_REACHABLE, K8S_CHECK_PODS_REACHABLE_DEFAULT);
+  }
+
+  public static List<String> networkInterfaces(Config cfg) {
+    return cfg.getStringList(NETWORK_INTERFACES);
   }
 
   public static JobMasterAPI.NodeInfo getNodeInfo(Config cfg, String nodeIP) {

--- a/twister2/config/src/yaml/conf/common/network.yaml
+++ b/twister2/config/src/yaml/conf/common/network.yaml
@@ -1,3 +1,11 @@
+# when there are multiple network interfaces on nodes,
+# by default, workers use the ip returned by InetAddress.getLocalHost().getHostAddress()
+# Users can specify the specific network interface to use by the workers
+# list the network interfaces that can be used in order
+# twister2 will try to get the ip address of the network interfaces and
+# it will use the first network interface in this list that is up and not loop back address
+# twister2.network.interfaces.for.workers: ['interface1', 'interface2']
+
 ### DEFAULT CONFIGURATION FOR ALL OPERATIONS, THESE ARE OVERRIDDEN AT THE BOTTOM for specific
 ### operations
 #############################################################################################

--- a/twister2/config/src/yaml/conf/kubernetes/core.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/core.yaml
@@ -1,4 +1,14 @@
 ###################################################################
+# Pod memory configurations
+###################################################################
+
+# The percentage of memory that will be allocated to JVM in worker pods
+# By default, it is %80
+# If memory based volume is used more, or
+# you want to give OpenMPI or UCX more memory, this can be decreased.
+twister2.kubernetes.jvm.memory.fraction: 0.8
+
+###################################################################
 # Fault Tolerance configurations
 ###################################################################
 

--- a/twister2/config/src/yaml/conf/kubernetes/network.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/network.yaml
@@ -16,7 +16,7 @@ kubernetes.secret.name: "twister2-openmpi-ssh-key"
 # password free ssh is setup among pods
 # password free ssh can be checked before running mpirun explicitly
 # by default it is false
-# kubernetes.check.pwd.free.ssh: true
+# twister2.kubernetes.check.pwd.free.ssh: true
 
 #############################################################################
 # Worker port settings

--- a/twister2/config/src/yaml/conf/kubernetes/network.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/network.yaml
@@ -12,6 +12,12 @@ twister2.network.channel.class: "edu.iu.dsc.tws.comms.tcp.TWSTCPChannel"
 # Its name must be specified here
 kubernetes.secret.name: "twister2-openmpi-ssh-key"
 
+# when pods are started in OpenMPI enabled jobs,
+# password free ssh is setup among pods
+# password free ssh can be checked before running mpirun explicitly
+# by default it is false
+# kubernetes.check.pwd.free.ssh: true
+
 #############################################################################
 # Worker port settings
 #############################################################################

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesContext.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesContext.java
@@ -91,7 +91,10 @@ public class KubernetesContext extends SchedulerContext {
       "twister2.kubernetes.uploader.web.server.label";
 
   public static final boolean K8S_CHECK_PWD_FREE_SSH_DEFAULT = false;
-  public static final String K8S_CHECK_PWD_FREE_SSH = "kubernetes.check.pwd.free.ssh";
+  public static final String K8S_CHECK_PWD_FREE_SSH = "twister2.kubernetes.check.pwd.free.ssh";
+
+  public static final double K8S_JVM_MEMORY_FRACTION_DEFAULT = 0.8;
+  public static final String K8S_JVM_MEMORY_FRACTION = "twister2.kubernetes.jvm.memory.fraction";
 
   public static String twister2DockerImageForK8s(Config cfg) {
     return cfg.getStringValue(TWISTER2_DOCKER_IMAGE_FOR_K8S);
@@ -189,6 +192,10 @@ public class KubernetesContext extends SchedulerContext {
 
   public static boolean checkPwdFreeSsh(Config cfg) {
     return cfg.getBooleanValue(K8S_CHECK_PWD_FREE_SSH, K8S_CHECK_PWD_FREE_SSH_DEFAULT);
+  }
+
+  public static double jvmMemoryFraction(Config cfg) {
+    return cfg.getDoubleValue(K8S_JVM_MEMORY_FRACTION, K8S_JVM_MEMORY_FRACTION_DEFAULT);
   }
 
 }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesContext.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesContext.java
@@ -90,6 +90,9 @@ public class KubernetesContext extends SchedulerContext {
   public static final String K8S_UPLOADER_WEB_SERVER_LABEL =
       "twister2.kubernetes.uploader.web.server.label";
 
+  public static final boolean K8S_CHECK_PWD_FREE_SSH_DEFAULT = false;
+  public static final String K8S_CHECK_PWD_FREE_SSH = "kubernetes.check.pwd.free.ssh";
+
   public static String twister2DockerImageForK8s(Config cfg) {
     return cfg.getStringValue(TWISTER2_DOCKER_IMAGE_FOR_K8S);
   }
@@ -182,6 +185,10 @@ public class KubernetesContext extends SchedulerContext {
   public static String uploaderWebServerLabel(Config cfg) {
     return cfg.getStringValue(K8S_UPLOADER_WEB_SERVER_LABEL,
         K8S_UPLOADER_WEB_SERVER_LABEL_DEFAULT);
+  }
+
+  public static boolean checkPwdFreeSsh(Config cfg) {
+    return cfg.getBooleanValue(K8S_CHECK_PWD_FREE_SSH, K8S_CHECK_PWD_FREE_SSH_DEFAULT);
   }
 
 }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/RequestObjectBuilder.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/RequestObjectBuilder.java
@@ -297,7 +297,7 @@ public final class RequestObjectBuilder {
     container.setImagePullPolicy(KubernetesContext.imagePullPolicy(config));
     String startScript = null;
     double cpuPerContainer = computeResource.getCpu();
-    int ramPerContainer = computeResource.getRamMegaBytes() + 128;
+    int ramPerContainer = computeResource.getRamMegaBytes();
 
     if (SchedulerContext.useOpenMPI(config)) {
       startScript = "./init_openmpi.sh";
@@ -358,9 +358,11 @@ public final class RequestObjectBuilder {
     port.setProtocol(KubernetesContext.workerTransportProtocol(config));
     container.setPorts(Arrays.asList(port));
 
-    container.setEnv(
-        constructEnvironmentVariables(
-            containerName, containerPort, encodedNodeInfoList, computeResource.getRamMegaBytes()));
+    int jvmMemory =
+        (int) (computeResource.getRamMegaBytes() * KubernetesContext.jvmMemoryFraction(config));
+
+    container.setEnv(constructEnvironmentVariables(
+        containerName, containerPort, encodedNodeInfoList, jvmMemory));
 
     return container;
   }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPIWorker.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPIWorker.java
@@ -63,6 +63,7 @@ import edu.iu.dsc.tws.rsched.core.WorkerRuntime;
 import edu.iu.dsc.tws.rsched.schedulers.nomad.NomadContext;
 import edu.iu.dsc.tws.rsched.schedulers.nomad.NomadTerminator;
 import edu.iu.dsc.tws.rsched.utils.JobUtils;
+import edu.iu.dsc.tws.rsched.utils.ResourceSchedulerUtils;
 
 import mpi.Intracomm;
 import mpi.MPI;
@@ -357,7 +358,7 @@ public final class MPIWorker {
 
     try {
       int port = JobMasterContext.jobMasterPort(cfg);
-      String hostAddress = InetAddress.getLocalHost().getHostAddress();
+      String hostAddress = ResourceSchedulerUtils.getHostIP();
       LOG.log(Level.INFO, String.format("Starting the job manager: %s:%d", hostAddress, port));
       JobMasterAPI.NodeInfo jobMasterNodeInfo = null;
       IScalerPerCluster clusterScaler = null;
@@ -365,7 +366,7 @@ public final class MPIWorker {
       NomadTerminator nt = new NomadTerminator();
 
       JobMaster jobMaster = new JobMaster(
-          cfg, hostAddress, port, nt, job, jobMasterNodeInfo, clusterScaler, initialState);
+          cfg, "0.0.0.0", port, nt, job, jobMasterNodeInfo, clusterScaler, initialState);
       jobMaster.addShutdownHook(false);
       Thread jmThread = jobMaster.startJobMasterThreaded();
 
@@ -377,9 +378,6 @@ public final class MPIWorker {
       }
 
       LOG.log(Level.INFO, "Master done... ");
-    } catch (UnknownHostException e) {
-      LOG.log(Level.SEVERE, "Exception when getting local host address: ", e);
-      throw new RuntimeException(e);
     } catch (Twister2Exception e) {
       LOG.log(Level.SEVERE, "Exception when starting Job master: ", e);
       throw new RuntimeException(e);
@@ -443,7 +441,7 @@ public final class MPIWorker {
       // initialize the logger
       initLogger(cfg, intracomm.getRank(), twister2Home);
 
-      Map<Integer, JobMasterAPI.WorkerInfo> infos = createWorkerInfoMap(cfg, intracomm, job);
+      Map<Integer, JobMasterAPI.WorkerInfo> infos = createWorkerInfoMap(intracomm);
       MPIWorkerController wc = new MPIWorkerController(intracomm.getRank(), infos);
       IPersistentVolume persistentVolume = initPersistenceVolume(cfg, job.getJobName(), rank);
 
@@ -491,15 +489,11 @@ public final class MPIWorker {
   /**
    * create a AllocatedResources
    *
-   * @param cfg configuration
    * @return a map of rank to hostname
    */
-  public Map<Integer, JobMasterAPI.WorkerInfo> createWorkerInfoMap(Config cfg,
-                                                                   Intracomm intracomm,
-                                                                   JobAPI.Job job) {
+  public Map<Integer, JobMasterAPI.WorkerInfo> createWorkerInfoMap(Intracomm intracomm) {
     try {
-      JobMasterAPI.WorkerInfo workerInfo = createWorkerInfo(cfg, intracomm.getRank(), job);
-      byte[] workerBytes = workerInfo.toByteArray();
+      byte[] workerBytes = wInfo.toByteArray();
       int length = workerBytes.length;
 
       IntBuffer countSend = MPI.newIntBuffer(1);
@@ -553,15 +547,23 @@ public final class MPIWorker {
    */
   private JobMasterAPI.WorkerInfo createWorkerInfo(Config cfg, int workerId,
                                                    JobAPI.Job job) throws MPIException {
-    String processName;
-    try {
-      processName = InetAddress.getLocalHost().getHostAddress();
-    } catch (UnknownHostException e) {
-      throw new RuntimeException("Failed to get ip address", e);
+    String workerIP;
+    List<String> networkInterfaces = SchedulerContext.networkInterfaces(cfg);
+    if (networkInterfaces == null) {
+      try {
+        workerIP = InetAddress.getLocalHost().getHostAddress();
+      } catch (UnknownHostException e) {
+        throw new RuntimeException("Failed to get ip address", e);
+      }
+    } else {
+      workerIP = ResourceSchedulerUtils.getLocalIPFromNetworkInterfaces(networkInterfaces);
+      if (workerIP == null) {
+        throw new RuntimeException("Failed to get ip address from network interfaces: "
+            + networkInterfaces);
+      }
     }
 
-    JobMasterAPI.NodeInfo nodeInfo = NodeInfoUtils.createNodeInfo(processName,
-        "default", "default");
+    JobMasterAPI.NodeInfo nodeInfo = NodeInfoUtils.createNodeInfo(workerIP, "default", "default");
     JobAPI.ComputeResource computeResource = JobUtils.getComputeResource(job, workerId);
     List<String> portNames = SchedulerContext.additionalPorts(cfg);
     final Map<String, Integer> freePorts = new HashMap<>();
@@ -586,9 +588,9 @@ public final class MPIWorker {
     }
     Integer workerPort = freePorts.get("__worker__");
     freePorts.remove("__worker__");
-    LOG.fine("Worker info host:" + processName + ":" + workerPort);
-    return WorkerInfoUtils.createWorkerInfo(workerId,
-        processName, workerPort, nodeInfo, computeResource, freePorts);
+    LOG.fine("Worker info host:" + workerIP + ":" + workerPort);
+    return WorkerInfoUtils.createWorkerInfo(
+        workerId, workerIP, workerPort, nodeInfo, computeResource, freePorts);
   }
 
   /**

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/utils/ResourceSchedulerUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/utils/ResourceSchedulerUtils.java
@@ -14,9 +14,13 @@ package edu.iu.dsc.tws.rsched.utils;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
 import java.net.Socket;
+import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -133,4 +137,49 @@ public final class ResourceSchedulerUtils {
       return null;
     }
   }
+
+  /**
+   * get ipv4 address of first matching network interface in the given list
+   * network interface can not be loop back and it has to be up
+   * @param interfaceNames
+   * @return
+   */
+  public static String getLocalIPFromNetworkInterfaces(List<String> interfaceNames) {
+
+    try {
+      for (String nwInterfaceName: interfaceNames) {
+        NetworkInterface networkInterface = NetworkInterface.getByName(nwInterfaceName);
+        if (networkInterface != null
+            && !networkInterface.isLoopback()
+            && networkInterface.isUp()) {
+          List<InterfaceAddress> addressList = networkInterface.getInterfaceAddresses();
+          for (InterfaceAddress adress: addressList) {
+            if (isValidIPv4(adress.getAddress().getHostAddress())) {
+              return adress.getAddress().getHostAddress();
+            }
+          }
+        }
+      }
+
+    } catch (SocketException e) {
+      LOG.log(Level.SEVERE, "Error retrieving network interface list", e);
+    }
+
+    return null;
+  }
+
+  /**
+   * this is from:
+   * https://stackoverflow.com/questions/5667371/validate-ipv4-address-in-java
+   * @param ip
+   * @return
+   */
+  @SuppressWarnings("LineLength")
+  public static boolean isValidIPv4(final String ip) {
+    String pattern = "^((0|1\\d?\\d?|2[0-4]?\\d?|25[0-5]?|[3-9]\\d?)\\.){3}(0|1\\d?\\d?|2[0-4]?\\d?|25[0-5]?|[3-9]\\d?)$";
+
+    return ip.matches(pattern);
+  }
+
+
 }


### PR DESCRIPTION
Following parameter added to specify network interfaces to be used by twister2 workers when there are multiple network interfaces in machines: 
twister2.network.interfaces.for.workers

Currently, it is only implemented in standalone. I think It is not needed for kubernetes. We can easily implement it if needed. 

Another parameter added to specify jvm memory fraction in Kubernetes. By default, it is set to 0.8. Non-jvm memory usages include: 
* memory based disk
* OpenMPI memory use
* UCX memory use

I also made checking password free ssh optional.  