### PR TITLE
[MAJOR API CHANGE] Tset generic swap and removing input generics from computeTset

### DIFF
--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/BaseComputeCollectorFunc.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/BaseComputeCollectorFunc.java
@@ -19,7 +19,7 @@ package edu.iu.dsc.tws.api.tset.fn;
  * @param <O> output type
  * @param <I> input type
  */
-public abstract class BaseComputeCollectorFunc<O, I> extends BaseTFunction<O, I> implements
-    ComputeCollectorFunc<O, I> {
+public abstract class BaseComputeCollectorFunc<I, O> extends BaseTFunction<I, O> implements
+    ComputeCollectorFunc<I, O> {
 
 }

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/BaseComputeFunc.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/BaseComputeFunc.java
@@ -18,7 +18,7 @@ package edu.iu.dsc.tws.api.tset.fn;
  * @param <O> output type
  * @param <I> input type
  */
-public abstract class BaseComputeFunc<O, I> extends BaseTFunction<O, I> implements
-    ComputeFunc<O, I> {
+public abstract class BaseComputeFunc<I, O> extends BaseTFunction<I, O> implements
+    ComputeFunc<I, O> {
 
 }

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/BaseMapFunc.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/BaseMapFunc.java
@@ -17,5 +17,5 @@ package edu.iu.dsc.tws.api.tset.fn;
  * @param <O> output type
  * @param <I> input type
  */
-public abstract class BaseMapFunc<O, I> extends BaseTFunction<O, I> implements MapFunc<O, I> {
+public abstract class BaseMapFunc<I, O> extends BaseTFunction<I, O> implements MapFunc<I, O> {
 }

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/BaseTFunction.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/BaseTFunction.java
@@ -14,7 +14,7 @@ package edu.iu.dsc.tws.api.tset.fn;
 import edu.iu.dsc.tws.api.dataset.DataPartition;
 import edu.iu.dsc.tws.api.tset.TSetContext;
 
-public abstract class BaseTFunction<O, I> implements TFunction<O, I> {
+public abstract class BaseTFunction<I, O> implements TFunction<I, O> {
   /**
    * The runtime context that is made available to users who create functions that
    * extend from the TBaseFunction abstract class

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/ComputeCollectorFunc.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/ComputeCollectorFunc.java
@@ -19,7 +19,7 @@ package edu.iu.dsc.tws.api.tset.fn;
  * @param <O> output type
  * @param <I> input type
  */
-public interface ComputeCollectorFunc<O, I> extends TFunction<O, I> {
+public interface ComputeCollectorFunc<I, O> extends TFunction<I, O> {
 
   void compute(I input, RecordCollector<O> output);
 }

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/ComputeFunc.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/ComputeFunc.java
@@ -18,7 +18,7 @@ package edu.iu.dsc.tws.api.tset.fn;
  * @param <O> output type
  * @param <I> input type
  */
-public interface ComputeFunc<O, I> extends TFunction<O, I> {
+public interface ComputeFunc<I, O> extends TFunction<I, O> {
 
   O compute(I input);
 }

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/FlatMapFunc.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/FlatMapFunc.java
@@ -29,7 +29,7 @@ package edu.iu.dsc.tws.api.tset.fn;
  * @param <O> output type
  * @param <I> input type
  */
-public interface FlatMapFunc<O, I> extends TFunction<O, I> {
+public interface FlatMapFunc<I, O> extends TFunction<I, O> {
 
   void flatMap(I input, RecordCollector<O> collector);
 }

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/MapFunc.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/MapFunc.java
@@ -29,7 +29,7 @@ package edu.iu.dsc.tws.api.tset.fn;
  * @param <I> input type
  * @param <O> output type
  */
-public interface MapFunc<O, I> extends TFunction<O, I> {
+public interface MapFunc<I, O> extends TFunction<I, O> {
 
   O map(I input);
 }

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/SelectorFunc.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/SelectorFunc.java
@@ -29,7 +29,7 @@ package edu.iu.dsc.tws.api.tset.fn;
  * @param <V> data type
  * @param <K> key type
  */
-public interface SelectorFunc<K, V> extends TFunction<K, V> {
+public interface SelectorFunc<V, K> extends TFunction<V, K> {
 
   K select(V t);
 }

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/TFunction.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/fn/TFunction.java
@@ -30,7 +30,7 @@ import edu.iu.dsc.tws.api.tset.TSetContext;
 /**
  * Base class for all the functions in TSet implementation
  */
-public interface TFunction<O, I> extends Serializable {
+public interface TFunction<I, O> extends Serializable {
 
   /**
    * Prepare the function. Use this context in case you need to add/get inputs

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/link/TLink.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/link/TLink.java
@@ -52,7 +52,7 @@ public interface TLink<T1, T0> extends TBase {
    * @param <O>             output tset base type
    * @return Compute TSet
    */
-  <O> TSet<O> compute(ComputeFunc<O, T1> computeFunction);
+  <O> TSet<O> compute(ComputeFunc<T1, O> computeFunction);
 
   /**
    * Creates a Compute {@link TSet} based on the {@link ComputeCollectorFunc} provided.
@@ -61,7 +61,7 @@ public interface TLink<T1, T0> extends TBase {
    * @param <O>             output type (for the {@link edu.iu.dsc.tws.api.tset.fn.RecordCollector})
    * @return Compute TSet
    */
-  <O> TSet<O> compute(ComputeCollectorFunc<O, T1> computeFunction);
+  <O> TSet<O> compute(ComputeCollectorFunc<T1, O> computeFunction);
 
   /**
    * Performs elementwise map operation based on the {@link MapFunc} provided
@@ -70,7 +70,7 @@ public interface TLink<T1, T0> extends TBase {
    * @param <O>   output type
    * @return Compute tset
    */
-  <O> TSet<O> map(MapFunc<O, T0> mapFn);
+  <O> TSet<O> map(MapFunc<T0, O> mapFn);
 
   /**
    * Performs flat map operation based on the {@link FlatMapFunc} provided
@@ -79,7 +79,7 @@ public interface TLink<T1, T0> extends TBase {
    * @param <O>   map function to T0 to multiple elements of {@literal <O>}
    * @return Compute TSet
    */
-  <O> TSet<O> flatmap(FlatMapFunc<O, T0> mapFn);
+  <O> TSet<O> flatmap(FlatMapFunc<T0, O> mapFn);
 
   /**
    * Maps the data passed through the TLink to {@link Tuple} based on a {@link MapFunc} and thereby
@@ -90,7 +90,7 @@ public interface TLink<T1, T0> extends TBase {
    * @param <V>        value type
    * @return Keyed TSet
    */
-  <K, V> TupleTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T0> genTupleFn);
+  <K, V> TupleTSet<K, V> mapToTuple(MapFunc<T0, Tuple<K, V>> genTupleFn);
 
   /**
    * Applies a function elementwise. Similar to compute, but the {@link ApplyFunc} does not

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/link/batch/BatchRowTLink.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/link/batch/BatchRowTLink.java
@@ -26,7 +26,7 @@ import edu.iu.dsc.tws.common.table.Row;
  * Table based communication links.
  */
 public interface BatchRowTLink extends TBase {
-  BatchRowTSet compute(ComputeCollectorFunc<Row, Iterator<Row>> computeFunction);
+  BatchRowTSet compute(ComputeCollectorFunc<Iterator<Row>, Row> computeFunction);
 
   BatchRowTSet map(MapFunc<Row, Row> mapFn);
 

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/link/batch/BatchTLink.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/link/batch/BatchTLink.java
@@ -38,19 +38,19 @@ public interface BatchTLink<T1, T0> extends TLink<T1, T0>, StoringData<T0> {
   BatchTLink<T1, T0> setName(String name);
 
   @Override
-  <O> BatchTSet<O> compute(ComputeFunc<O, T1> computeFunction);
+  <O> BatchTSet<O> compute(ComputeFunc<T1, O> computeFunction);
 
   @Override
-  <O> BatchTSet<O> compute(ComputeCollectorFunc<O, T1> computeFunction);
+  <O> BatchTSet<O> compute(ComputeCollectorFunc<T1, O> computeFunction);
 
   @Override
-  <O> BatchTSet<O> map(MapFunc<O, T0> mapFn);
+  <O> BatchTSet<O> map(MapFunc<T0, O> mapFn);
 
   @Override
-  <O> BatchTSet<O> flatmap(FlatMapFunc<O, T0> mapFn);
+  <O> BatchTSet<O> flatmap(FlatMapFunc<T0, O> mapFn);
 
   @Override
-  <K, V> BatchTupleTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T0> genTupleFn);
+  <K, V> BatchTupleTSet<K, V> mapToTuple(MapFunc<T0, Tuple<K, V>> genTupleFn);
 
   @Override
   TBase sink(SinkFunc<T1> sinkFunction);

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/link/streaming/StreamingTLink.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/link/streaming/StreamingTLink.java
@@ -36,19 +36,19 @@ public interface StreamingTLink<T1, T0> extends TLink<T1, T0> {
   StreamingTLink<T1, T0> setName(String name);
 
   @Override
-  <O> StreamingTSet<O> compute(ComputeFunc<O, T1> computeFunction);
+  <O> StreamingTSet<O> compute(ComputeFunc<T1, O> computeFunction);
 
   @Override
-  <O> StreamingTSet<O> compute(ComputeCollectorFunc<O, T1> computeFunction);
+  <O> StreamingTSet<O> compute(ComputeCollectorFunc<T1, O> computeFunction);
 
   @Override
-  <O> StreamingTSet<O> map(MapFunc<O, T0> mapFn);
+  <O> StreamingTSet<O> map(MapFunc<T0, O> mapFn);
 
   @Override
-  <O> StreamingTSet<O> flatmap(FlatMapFunc<O, T0> mapFn);
+  <O> StreamingTSet<O> flatmap(FlatMapFunc<T0, O> mapFn);
 
   @Override
-  <K, V> StreamingTupleTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T0> genTupleFn);
+  <K, V> StreamingTupleTSet<K, V> mapToTuple(MapFunc<T0, Tuple<K, V>> genTupleFn);
 
   @Override
   void forEach(ApplyFunc<T0> applyFunction);

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/sets/TSet.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/sets/TSet.java
@@ -137,7 +137,7 @@ public interface TSet<T> extends TBase {
    * @param mapToTupleFn Map function
    * @return Tuple TSet
    */
-  <K, V> TupleTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T> mapToTupleFn);
+  <K, V> TupleTSet<K, V> mapToTuple(MapFunc<T, Tuple<K, V>> mapToTupleFn);
 
   /**
    * Returns a Replicate {@link TLink} that would clone/broadcast the data from this {@link TSet}.

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/sets/batch/BatchTSet.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/sets/batch/BatchTSet.java
@@ -75,7 +75,7 @@ public interface BatchTSet<T> extends TSet<T>, AcceptingData<T>, StoringData<T> 
   BatchTLink<Iterator<Tuple<Integer, T>>, T> allGather();
 
   @Override
-  <K, V> BatchTupleTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T> mapToTupleFn);
+  <K, V> BatchTupleTSet<K, V> mapToTuple(MapFunc<T, Tuple<K, V>> mapToTupleFn);
 
   @Override
   BatchTLink<Iterator<T>, T> replicate(int replications);

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/tset/sets/streaming/StreamingTSet.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/tset/sets/streaming/StreamingTSet.java
@@ -56,7 +56,7 @@ public interface StreamingTSet<T> extends TSet<T> {
   StreamingTLink<Iterator<Tuple<Integer, T>>, T> allGather();
 
   @Override
-  <K, V> StreamingTupleTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T> mapToTupleFn);
+  <K, V> StreamingTupleTSet<K, V> mapToTuple(MapFunc<T, Tuple<K, V>> mapToTupleFn);
 
   @Override
   StreamingTLink<T, T> replicate(int replications);

--- a/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/batch/AssignWindowTranslatorBatch.java
+++ b/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/batch/AssignWindowTranslatorBatch.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.runners.twister2.translators.batch;
 
-import java.util.Iterator;
-
 import org.apache.beam.runners.twister2.Twister2BatchTranslationContext;
 import org.apache.beam.runners.twister2.translators.BatchTransformTranslator;
 import org.apache.beam.runners.twister2.translators.functions.AssignWindowsFunction;
@@ -44,7 +42,7 @@ public class AssignWindowTranslatorBatch<T> implements BatchTransformTranslator<
         (WindowingStrategy<T, BoundedWindow>) context.getOutput(transform).getWindowingStrategy();
 
     WindowFn<T, BoundedWindow> windowFn = windowingStrategy.getWindowFn();
-    ComputeTSet<WindowedValue<T>, Iterator<WindowedValue<T>>> outputTSet =
+    ComputeTSet<WindowedValue<T>> outputTSet =
         inputTTSet.direct().compute(new AssignWindowsFunction(windowFn));
     context.setOutputDataSet(context.getOutput(transform), outputTSet);
   }

--- a/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/batch/GroupByKeyTranslatorBatch.java
+++ b/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/batch/GroupByKeyTranslatorBatch.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.runners.twister2.translators.batch;
 
-import java.util.Iterator;
-
 import org.apache.beam.runners.core.SystemReduceFn;
 import org.apache.beam.runners.twister2.Twister2BatchTranslationContext;
 import org.apache.beam.runners.twister2.translators.BatchTransformTranslator;
@@ -35,7 +33,6 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.WindowingStrategy;
 
-import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.tset.sets.batch.BatchTSetImpl;
 import edu.iu.dsc.tws.tset.sets.batch.ComputeTSet;
 import edu.iu.dsc.tws.tset.sets.batch.KeyedTSet;
@@ -61,12 +58,12 @@ public class GroupByKeyTranslatorBatch<K, V> implements BatchTransformTranslator
 
     // todo add support for a partition function to be specified, this would use
     // todo keyedPartition function instead of KeyedGather
-    ComputeTSet<KV<K, Iterable<WindowedValue<V>>>, Iterator<Tuple<byte[], Iterator<byte[]>>>>
+    ComputeTSet<KV<K, Iterable<WindowedValue<V>>>>
         groupedbyKeyTset =
         keyedTSet.keyedGather().map(new ByteToWindowFunction(inputKeyCoder, wvCoder));
 
     // --- now group also by window.
-    ComputeTSet<WindowedValue<KV<K, Iterable<V>>>, Iterable<KV<K, Iterator<WindowedValue<V>>>>>
+    ComputeTSet<WindowedValue<KV<K, Iterable<V>>>>
         outputTset =
         groupedbyKeyTset
             .direct()

--- a/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/batch/ParDoMultiOutputTranslatorBatch.java
+++ b/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/batch/ParDoMultiOutputTranslatorBatch.java
@@ -18,7 +18,11 @@
 package org.apache.beam.runners.twister2.translators.batch;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.beam.runners.core.construction.ParDoTranslation;
 import org.apache.beam.runners.twister2.Twister2BatchTranslationContext;
@@ -92,7 +96,7 @@ public class ParDoMultiOutputTranslatorBatch<IT, OT>
       }
     }
 
-    ComputeTSet<RawUnionValue, Iterator<WindowedValue<IT>>> outputTSet =
+    ComputeTSet<RawUnionValue> outputTSet =
         inputTTSet
             .direct()
             .<RawUnionValue>compute(
@@ -109,8 +113,8 @@ public class ParDoMultiOutputTranslatorBatch<IT, OT>
                     outputMap));
 
     for (Map.Entry<TupleTag<?>, PValue> output : outputs.entrySet()) {
-      ComputeTSet<WindowedValue<OT>, Iterator<RawUnionValue>> tempTSet =
-          outputTSet.direct().compute(new OutputTagFilter(outputMap.get(output.getKey())));
+      ComputeTSet<WindowedValue<OT>> tempTSet =
+          outputTSet.direct().compute(new OutputTagFilter<>(outputMap.get(output.getKey())));
       context.setOutputDataSet((PCollection) output.getValue(), tempTSet);
     }
   }

--- a/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/functions/AssignWindowsFunction.java
+++ b/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/functions/AssignWindowsFunction.java
@@ -34,7 +34,7 @@ import edu.iu.dsc.tws.api.tset.fn.RecordCollector;
  * Assign Windows function.
  */
 public class AssignWindowsFunction<T>
-    implements ComputeCollectorFunc<WindowedValue<T>, Iterator<WindowedValue<T>>> {
+    implements ComputeCollectorFunc<Iterator<WindowedValue<T>>, WindowedValue<T>> {
   private static final Logger LOG = Logger.getLogger(AssignWindowsFunction.class.getName());
 
   private final WindowFn<T, BoundedWindow> windowFn;

--- a/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/functions/ByteToWindowFunction.java
+++ b/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/functions/ByteToWindowFunction.java
@@ -39,7 +39,7 @@ import edu.iu.dsc.tws.api.tset.fn.MapFunc;
  * ByteToWindow function.
  */
 public class ByteToWindowFunction<K, V>
-    implements MapFunc<KV<K, Iterable<WindowedValue<V>>>, Tuple<byte[], Iterator<byte[]>>> {
+    implements MapFunc<Tuple<byte[], Iterator<byte[]>>, KV<K, Iterable<WindowedValue<V>>>> {
   private final Coder<K> keyCoder;
   private final WindowedValueCoder<V> wvCoder;
 

--- a/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/functions/DoFnFunction.java
+++ b/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/functions/DoFnFunction.java
@@ -49,7 +49,7 @@ import edu.iu.dsc.tws.api.tset.fn.RecordCollector;
  * DoFn function.
  */
 public class DoFnFunction<OT, IT>
-    implements ComputeCollectorFunc<RawUnionValue, Iterator<WindowedValue<IT>>> {
+    implements ComputeCollectorFunc<Iterator<WindowedValue<IT>>, RawUnionValue> {
 
   private final DoFn<IT, OT> doFn;
   private final transient PipelineOptions pipelineOptions;

--- a/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/functions/GroupByWindowFunction.java
+++ b/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/functions/GroupByWindowFunction.java
@@ -51,7 +51,7 @@ import edu.iu.dsc.tws.api.tset.fn.RecordCollector;
  * GroupBy window function.
  */
 public class GroupByWindowFunction<K, V, W extends BoundedWindow>
-    implements FlatMapFunc<WindowedValue<KV<K, Iterable<V>>>, KV<K, Iterable<WindowedValue<V>>>> {
+    implements FlatMapFunc<KV<K, Iterable<WindowedValue<V>>>, WindowedValue<KV<K, Iterable<V>>>> {
   private static final Logger LOG = Logger.getLogger(GroupByWindowFunction.class.getName());
   private final WindowingStrategy<?, W> windowingStrategy;
   private final SystemReduceFn<K, V, Iterable<V>, Iterable<V>, W> reduceFn;

--- a/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/functions/MapToTupleFunction.java
+++ b/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/functions/MapToTupleFunction.java
@@ -33,7 +33,7 @@ import edu.iu.dsc.tws.api.tset.fn.MapFunc;
  * Map to tuple function.
  */
 public class MapToTupleFunction<K, V>
-    implements MapFunc<Tuple<byte[], byte[]>, WindowedValue<KV<K, V>>> {
+    implements MapFunc<WindowedValue<KV<K, V>>, Tuple<byte[], byte[]>> {
 
   private final Coder<K> keyCoder;
   private final WindowedValue.WindowedValueCoder<V> wvCoder;

--- a/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/functions/OutputTagFilter.java
+++ b/twister2/compatibility/beam/src/main/java/org/apache/beam/runners/twister2/translators/functions/OutputTagFilter.java
@@ -29,7 +29,7 @@ import edu.iu.dsc.tws.api.tset.fn.RecordCollector;
  * Output tag filter.
  */
 public class OutputTagFilter<OT, IT>
-    implements ComputeCollectorFunc<WindowedValue<OT>, Iterator<RawUnionValue>> {
+    implements ComputeCollectorFunc<Iterator<RawUnionValue>, WindowedValue<OT>> {
 
   private final int tag;
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/arrow/ArrowTSetSourceExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/arrow/ArrowTSetSourceExample.java
@@ -70,7 +70,7 @@ public class ArrowTSetSourceExample implements Twister2Worker, Serializable {
         = env.createCSVSource(csvInputDirectory, dsize, parallel, "split");
     SinkTSet<Iterator<Integer>> sinkTSet = csvSource
         .direct()
-        .map((MapFunc<Integer, String[]>) input -> Integer.parseInt(input[0]))
+        .map((MapFunc<String[], Integer>) input -> Integer.parseInt(input[0]))
         .direct()
         .sink(new ArrowBasedSinkFunction<>(arrowInputDirectory, arrowFileName, schema.toJson()));
     env.run(sinkTSet);
@@ -80,7 +80,7 @@ public class ArrowTSetSourceExample implements Twister2Worker, Serializable {
         .direct()
         //At computetset users can give the exact output type. We don't have to carry object type
         .compute(
-            (ComputeFunc<List<Integer>, Iterator<Object>>) input -> {
+            (ComputeFunc<Iterator<Object>, List<Integer>>) input -> {
               List<Integer> integers = new ArrayList<>();
               input.forEachRemaining(i -> integers.add((Integer) i));
               return integers;

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/batch/csv/CSVTSetSourceExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/batch/csv/CSVTSetSourceExample.java
@@ -47,7 +47,7 @@ public class CSVTSetSourceExample implements Twister2Worker, Serializable {
     SourceTSet<String[]> pointSource = env.createCSVSource("/tmp/dinput", dsize,
         parallelism, "split");
     ComputeTSet<double[][], Iterator<String[]>> points = pointSource.direct().compute(
-        new ComputeFunc<double[][], Iterator<String[]>>() {
+        new ComputeFunc<Iterator<String[]>, double[][]>() {
           private double[][] localPoints = new double[dsize / parallelism][dimension];
           @Override
           public double[][] compute(Iterator<String[]> input) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/batch/csv/CSVTSetSourceExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/batch/csv/CSVTSetSourceExample.java
@@ -46,9 +46,10 @@ public class CSVTSetSourceExample implements Twister2Worker, Serializable {
     int dimension = 2;
     SourceTSet<String[]> pointSource = env.createCSVSource("/tmp/dinput", dsize,
         parallelism, "split");
-    ComputeTSet<double[][], Iterator<String[]>> points = pointSource.direct().compute(
+    ComputeTSet<double[][]> points = pointSource.direct().compute(
         new ComputeFunc<Iterator<String[]>, double[][]>() {
           private double[][] localPoints = new double[dsize / parallelism][dimension];
+
           @Override
           public double[][] compute(Iterator<String[]> input) {
             for (int i = 0; i < dsize / parallelism && input.hasNext(); i++) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/batch/kmeans/KMeansTsetJob.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/batch/kmeans/KMeansTsetJob.java
@@ -72,9 +72,10 @@ public class KMeansTsetJob implements Twister2Worker, Serializable {
 
     SourceTSet<String[]> pointSource = env.createCSVSource(dataDirectory, dsize, parallelism,
         "split");
-    ComputeTSet<double[][], Iterator<String[]>> points = pointSource.direct().compute(
+    ComputeTSet<double[][]> points = pointSource.direct().compute(
         new ComputeFunc<Iterator<String[]>, double[][]>() {
           private double[][] localPoints = new double[dsize / parallelism][dimension];
+
           @Override
           public double[][] compute(Iterator<String[]> input) {
             for (int i = 0; i < dsize / parallelism && input.hasNext(); i++) {
@@ -93,9 +94,10 @@ public class KMeansTsetJob implements Twister2Worker, Serializable {
 
     SourceTSet<String[]> centerSource = env.createCSVSource(centroidDirectory, csize, parallelism,
         "complete");
-    ComputeTSet<double[][], Iterator<String[]>> centers = centerSource.direct().compute(
+    ComputeTSet<double[][]> centers = centerSource.direct().compute(
         new ComputeFunc<Iterator<String[]>, double[][]>() {
           private double[][] localCenters = new double[csize][dimension];
+
           @Override
           public double[][] compute(Iterator<String[]> input) {
             for (int i = 0; i < csize && input.hasNext(); i++) {
@@ -111,8 +113,8 @@ public class KMeansTsetJob implements Twister2Worker, Serializable {
 
     long endTimeData = System.currentTimeMillis();
 
-    ComputeTSet<double[][], Iterator<double[][]>> kmeansTSet = points.direct().map(new KMeansMap());
-    ComputeTSet<double[][], double[][]> reduced = kmeansTSet.allReduce((ReduceFunc<double[][]>)
+    ComputeTSet<double[][]> kmeansTSet = points.direct().map(new KMeansMap());
+    ComputeTSet<double[][]> reduced = kmeansTSet.allReduce((ReduceFunc<double[][]>)
         (t1, t2) -> {
           double[][] newCentroids = new double[t1.length][t1[0].length];
           for (int j = 0; j < t1.length; j++) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/batch/kmeans/KMeansTsetJob.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/batch/kmeans/KMeansTsetJob.java
@@ -73,7 +73,7 @@ public class KMeansTsetJob implements Twister2Worker, Serializable {
     SourceTSet<String[]> pointSource = env.createCSVSource(dataDirectory, dsize, parallelism,
         "split");
     ComputeTSet<double[][], Iterator<String[]>> points = pointSource.direct().compute(
-        new ComputeFunc<double[][], Iterator<String[]>>() {
+        new ComputeFunc<Iterator<String[]>, double[][]>() {
           private double[][] localPoints = new double[dsize / parallelism][dimension];
           @Override
           public double[][] compute(Iterator<String[]> input) {
@@ -94,7 +94,7 @@ public class KMeansTsetJob implements Twister2Worker, Serializable {
     SourceTSet<String[]> centerSource = env.createCSVSource(centroidDirectory, csize, parallelism,
         "complete");
     ComputeTSet<double[][], Iterator<String[]>> centers = centerSource.direct().compute(
-        new ComputeFunc<double[][], Iterator<String[]>>() {
+        new ComputeFunc<Iterator<String[]>, double[][]>() {
           private double[][] localCenters = new double[csize][dimension];
           @Override
           public double[][] compute(Iterator<String[]> input) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/batch/wordcount/tset/FileBasedWordCount.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/batch/wordcount/tset/FileBasedWordCount.java
@@ -24,7 +24,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
@@ -76,7 +75,7 @@ public class FileBasedWordCount implements Twister2Worker, Serializable {
     SourceTSet<String> lines = env.createSource(new WordCountFileSource(), 1);
 
     // distribute the lines among the workers and performs a flatmap operation to extract words
-    ComputeTSet<String, Iterator<String>> words =
+    ComputeTSet<String> words =
         lines.partition(new HashingPartitioner<>(), sourcePar)
             .flatmap((FlatMapFunc<String, String>) (l, collector) -> {
               StringTokenizer itr = new StringTokenizer(l);

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/ml/svm/job/SvmSgdTsetRunner.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/ml/svm/job/SvmSgdTsetRunner.java
@@ -13,7 +13,6 @@ package edu.iu.dsc.tws.examples.ml.svm.job;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Iterator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.compute.graph.OperationMode;
@@ -142,7 +141,7 @@ public class SvmSgdTsetRunner implements Twister2Worker, Serializable {
     for (int i = 0; i < this.svmJobParameters.getIterations(); i++) {
       LOG.info(String.format("Iteration %d", i));
 
-      ComputeTSet<double[], Iterator<double[][]>> svmTrainTset =
+      ComputeTSet<double[]> svmTrainTset =
           trainingData.direct()
               .map(new SvmTrainMap(this.binaryBatchModel, this.svmJobParameters));
 
@@ -192,7 +191,7 @@ public class SvmSgdTsetRunner implements Twister2Worker, Serializable {
 
     this.binaryBatchModel.setW(this.trainedWeightVector.getData().get(0));
 
-    ComputeTSet<Double, Iterator<double[][]>> svmTestTset =
+    ComputeTSet<Double> svmTestTset =
         testingData.direct()
             .map(new SvmTestMap(this.binaryBatchModel, this.svmJobParameters));
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/ml/svm/tset/SvmTestMap.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/ml/svm/tset/SvmTestMap.java
@@ -21,7 +21,7 @@ import edu.iu.dsc.tws.examples.ml.svm.util.BinaryBatchModel;
 import edu.iu.dsc.tws.examples.ml.svm.util.DataUtils;
 import edu.iu.dsc.tws.examples.ml.svm.util.SVMJobParameters;
 
-public class SvmTestMap implements MapFunc<Double, double[][]> {
+public class SvmTestMap implements MapFunc<double[][], Double> {
 
   private static final Logger LOG = Logger.getLogger(SvmTestMap.class.getName());
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/ml/svm/tset/SvmTrainMap.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/ml/svm/tset/SvmTrainMap.java
@@ -24,8 +24,8 @@ import edu.iu.dsc.tws.examples.ml.svm.util.BinaryBatchModel;
 import edu.iu.dsc.tws.examples.ml.svm.util.DataUtils;
 import edu.iu.dsc.tws.examples.ml.svm.util.SVMJobParameters;
 
-public class SvmTrainMap extends BaseTFunction<double[], double[][]>
-    implements MapFunc<double[], double[][]> {
+public class SvmTrainMap extends BaseTFunction<double[][], double[]>
+    implements MapFunc<double[][], double[]> {
 
   private static final Logger LOG = Logger.getLogger(SvmTrainMap.class.getName());
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/HadoopTSet.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/HadoopTSet.java
@@ -61,7 +61,7 @@ public class HadoopTSet implements IWorker, Serializable {
     configuration.set(TextInputFormat.INPUT_DIR, "/input4");
     SourceTSet<String> source =
         tSetEnv.createHadoopSource(configuration, TextInputFormat.class, 4,
-            new MapFunc<String, Tuple<LongWritable, Text>>() {
+            new MapFunc<Tuple<LongWritable, Text>, String>() {
               @Override
               public String map(Tuple<LongWritable, Text> input) {
                 return input.getKey().toString() + " : " + input.getValue().toString();

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/HelloTSet.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/HelloTSet.java
@@ -14,7 +14,6 @@ package edu.iu.dsc.tws.examples.tset;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.logging.Logger;
 
 import org.apache.commons.cli.CommandLine;
@@ -69,7 +68,7 @@ public class HelloTSet implements Twister2Worker, Serializable {
 
     PartitionTLink<int[]> partitioned = source.partition(new LoadBalancePartitioner<>());
 
-    ComputeTSet<int[], Iterator<int[]>> mapedPartition = partitioned.map(
+    ComputeTSet<int[]> mapedPartition = partitioned.map(
         (MapFunc<int[], int[]>) input -> Arrays.stream(input).map(a -> a * 2).toArray()
     );
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/AddInputsExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/AddInputsExample.java
@@ -47,7 +47,7 @@ public class AddInputsExample extends BatchTsetExample {
     CachedTSet<Integer> baseSrcCache = baseSrc.direct().cache().setName("baseSrc");
 
     CachedTSet<Integer> out = baseSrcCache.direct().compute(
-        new BaseComputeCollectorFunc<Integer, Iterator<Integer>>() {
+        new BaseComputeCollectorFunc<Iterator<Integer>, Integer>() {
           @Override
           public void compute(Iterator<Integer> input, RecordCollector<Integer> collector) {
             DataPartitionConsumer<Integer> c1 = (DataPartitionConsumer<Integer>)

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/AllGatherExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/AllGatherExample.java
@@ -67,7 +67,7 @@ public class AllGatherExample extends BatchTsetExample {
 
     LOG.info("test computec");
     src.allGather()
-        .compute((ComputeCollectorFunc<String, Iterator<Tuple<Integer, Integer>>>)
+        .compute((ComputeCollectorFunc<Iterator<Tuple<Integer, Integer>>, String>)
             (input, output) -> {
               int sum = 0;
               while (input.hasNext()) {
@@ -80,7 +80,7 @@ public class AllGatherExample extends BatchTsetExample {
 
     LOG.info("test compute");
     src.allGather()
-        .compute((ComputeFunc<String, Iterator<Tuple<Integer, Integer>>>)
+        .compute((ComputeFunc<Iterator<Tuple<Integer, Integer>>, String>)
             input -> {
               int sum = 0;
               while (input.hasNext()) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/AllReduceExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/AllReduceExample.java
@@ -74,7 +74,7 @@ public class AllReduceExample extends BatchTsetExample {
 
     LOG.info("test computec");
     src.allReduce(Integer::sum)
-        .compute((ComputeCollectorFunc<String, Integer>)
+        .compute((ComputeCollectorFunc<Integer, String>)
             (input, output) -> output.collect("sum=" + input))
         .direct()
         .forEach(s -> LOG.info("computec: " + s));

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/BranchingExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/BranchingExample.java
@@ -13,12 +13,10 @@
 package edu.iu.dsc.tws.examples.tset.batch;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
 import edu.iu.dsc.tws.api.comms.CommunicationContext;
-import edu.iu.dsc.tws.api.comms.structs.JoinedTuple;
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.resource.WorkerEnvironment;
@@ -48,13 +46,13 @@ public class BranchingExample extends BatchTsetExample {
         CommunicationContext.JoinType.INNER, Integer::compareTo).setName("join");
 
 
-    ComputeTSet<String, Iterator<JoinedTuple<Integer, Integer, Integer>>> map
+    ComputeTSet<String> map
         = join.map(t -> "(" + t.getKey() + " " + t.getLeftValue() + " " + t.getRightValue() + ")")
         .setName("map***");
 
-    ComputeTSet<String, Iterator<String>> map1 = map.direct().map(s -> "###" + s).setName("map@@");
+    ComputeTSet<String> map1 = map.direct().map(s -> "###" + s).setName("map@@");
 
-    ComputeTSet<String, Iterator<String>> union = map.union(map1).setName("union");
+    ComputeTSet<String> union = map.union(map1).setName("union");
 
     union.direct().forEach(s -> LOG.info(s));
   }

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/BroadcastExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/BroadcastExample.java
@@ -55,7 +55,7 @@ public class BroadcastExample extends BatchTsetExample {
         .forEach(s -> LOG.info("flat:" + s));
 
     LOG.info("test compute");
-    replicate.compute((ComputeFunc<String, Iterator<Integer>>)
+    replicate.compute((ComputeFunc<Iterator<Integer>, String>)
         input -> {
           int sum = 0;
           while (input.hasNext()) {
@@ -67,7 +67,7 @@ public class BroadcastExample extends BatchTsetExample {
         .forEach(i -> LOG.info("comp: " + i));
 
     LOG.info("test computec");
-    replicate.compute((ComputeCollectorFunc<String, Iterator<Integer>>)
+    replicate.compute((ComputeCollectorFunc<Iterator<Integer>, String>)
         (input, output) -> {
           int sum = 0;
           while (input.hasNext()) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/CacheExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/CacheExample.java
@@ -91,7 +91,7 @@ public class CacheExample extends BatchTsetExample {
 
     LOG.info("test compute");
     cTset.direct()
-        .compute((ComputeFunc<String, Iterator<Integer>>) input -> {
+        .compute((ComputeFunc<Iterator<Integer>, String>) input -> {
           int sum = 0;
           while (input.hasNext()) {
             sum += input.next();
@@ -103,7 +103,7 @@ public class CacheExample extends BatchTsetExample {
 
     LOG.info("test computec");
     cTset.direct()
-        .compute((ComputeCollectorFunc<String, Iterator<Integer>>)
+        .compute((ComputeCollectorFunc<Iterator<Integer>, String>)
             (input, output) -> {
               int sum = 0;
               while (input.hasNext()) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ComputeCollectExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ComputeCollectExample.java
@@ -51,7 +51,7 @@ public class ComputeCollectExample extends BatchTsetExample {
     SourceTSet<Integer> src = dummySource(env, start, COUNT, PARALLELISM).setName("src");
 
     ComputeTSet<String, Iterator<Integer>> modify = src.direct().compute(
-        (ComputeCollectorFunc<String, Iterator<Integer>>) (input, collector) -> {
+        (ComputeCollectorFunc<Iterator<Integer>, String>) (input, collector) -> {
           while (input.hasNext()) {
             collector.collect(input.next() + "##");
           }

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ComputeCollectExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ComputeCollectExample.java
@@ -50,7 +50,7 @@ public class ComputeCollectExample extends BatchTsetExample {
     int start = env.getWorkerID() * 100;
     SourceTSet<Integer> src = dummySource(env, start, COUNT, PARALLELISM).setName("src");
 
-    ComputeTSet<String, Iterator<Integer>> modify = src.direct().compute(
+    ComputeTSet<String> modify = src.direct().compute(
         (ComputeCollectorFunc<Iterator<Integer>, String>) (input, collector) -> {
           while (input.hasNext()) {
             collector.collect(input.next() + "##");

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ComputeExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ComputeExample.java
@@ -53,7 +53,7 @@ public class ComputeExample extends BatchTsetExample {
         .setName("src")
         .withSchema(PrimitiveSchemas.INTEGER);
 
-    ComputeTSet<Integer, Iterator<Integer>> sum = src.direct().compute(
+    ComputeTSet<Integer> sum = src.direct().compute(
         (ComputeFunc<Iterator<Integer>, Integer>) input -> {
           int s = 0;
           while (input.hasNext()) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ComputeExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ComputeExample.java
@@ -54,7 +54,7 @@ public class ComputeExample extends BatchTsetExample {
         .withSchema(PrimitiveSchemas.INTEGER);
 
     ComputeTSet<Integer, Iterator<Integer>> sum = src.direct().compute(
-        (ComputeFunc<Integer, Iterator<Integer>>) input -> {
+        (ComputeFunc<Iterator<Integer>, Integer>) input -> {
           int s = 0;
           while (input.hasNext()) {
             s += input.next();

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/DirectExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/DirectExample.java
@@ -75,7 +75,7 @@ public class DirectExample extends BatchTsetExample {
         .forEach(s -> LOG.info("flat:" + s));
 
     LOG.info("test compute");
-    direct.compute((ComputeFunc<String, Iterator<Integer>>) input -> {
+    direct.compute((ComputeFunc<Iterator<Integer>, String>) input -> {
       int sum = 0;
       while (input.hasNext()) {
         sum += input.next();
@@ -87,7 +87,7 @@ public class DirectExample extends BatchTsetExample {
         .forEach(i -> LOG.info("comp: " + i));
 
     LOG.info("test computec");
-    direct.compute((ComputeCollectorFunc<String, Iterator<Integer>>)
+    direct.compute((ComputeCollectorFunc<Iterator<Integer>, String>)
         (input, output) -> {
           int sum = 0;
           while (input.hasNext()) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/DirectIterExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/DirectIterExample.java
@@ -13,7 +13,6 @@
 package edu.iu.dsc.tws.examples.tset.batch;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
@@ -40,7 +39,7 @@ public class DirectIterExample extends BatchTsetExample {
     CachedTSet<Integer> cachedInput = src.direct().cache();
 
     LOG.info("test direct iteration");
-    ComputeTSet<Object, Iterator<Integer>> lazyForEach = cachedInput.direct().lazyForEach(
+    ComputeTSet<Object> lazyForEach = cachedInput.direct().lazyForEach(
         input -> {
           LOG.info("##" + input.toString());
         });

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/EvaluateExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/EvaluateExample.java
@@ -14,7 +14,6 @@
 package edu.iu.dsc.tws.examples.tset.batch;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
@@ -42,11 +41,11 @@ public class EvaluateExample extends BatchTsetExample {
     DirectTLink<Integer> direct = src.direct().setName("direct");
 
     LOG.info("test foreach");
-    ComputeTSet<Object, Iterator<Integer>> tset1 =
+    ComputeTSet<Object> tset1 =
         direct.lazyForEach(i -> LOG.info("foreach: " + i));
 
     LOG.info("test map");
-    ComputeTSet<Object, Iterator<String>> tset2 =
+    ComputeTSet<Object> tset2 =
         direct.map(i -> i.toString() + "$$").setName("map")
             .direct()
             .lazyForEach(s -> LOG.info("map: " + s));

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/FullGraphRunExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/FullGraphRunExample.java
@@ -47,11 +47,11 @@ public class FullGraphRunExample extends BatchTsetExample {
     SourceTSet<Integer> src = dummySource(env, COUNT, PARALLELISM);
 
     src.direct()
-        .flatmap((FlatMapFunc<Object, Integer>)
+        .flatmap((FlatMapFunc<Integer, Object>)
             (integer, collector) -> LOG.info("dir= " + integer));
 
     src.reduce(Integer::sum)
-        .flatmap((FlatMapFunc<Object, Integer>)
+        .flatmap((FlatMapFunc<Integer, Object>)
             (integer, collector) -> LOG.info("red= " + integer));
 
 //    env.run();

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/GatherExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/GatherExample.java
@@ -64,7 +64,7 @@ public class GatherExample extends BatchTsetExample {
         .forEach(s -> LOG.info("map: " + s));
 
     LOG.info("test compute");
-    gather.compute((ComputeFunc<String, Iterator<Tuple<Integer, Integer>>>) input -> {
+    gather.compute((ComputeFunc<Iterator<Tuple<Integer, Integer>>, String>) input -> {
       int sum = 0;
       while (input.hasNext()) {
         sum += input.next().getValue();
@@ -76,7 +76,7 @@ public class GatherExample extends BatchTsetExample {
         .forEach(s -> LOG.info("compute: " + s));
 
     LOG.info("test computec");
-    gather.compute((ComputeCollectorFunc<String, Iterator<Tuple<Integer, Integer>>>)
+    gather.compute((ComputeCollectorFunc<Iterator<Tuple<Integer, Integer>>, String>)
         (input, output) -> {
           int sum = 0;
           while (input.hasNext()) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/KGatherExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/KGatherExample.java
@@ -57,7 +57,7 @@ public class KGatherExample extends BatchTsetExample {
     );
 
     LOG.info("test map");
-    klink.map((MapFunc<String, Tuple<Integer, Iterator<Integer>>>)
+    klink.map((MapFunc<Tuple<Integer, Iterator<Integer>>, String>)
         input -> {
           int s = 0;
           while (input.getValue().hasNext()) {
@@ -69,7 +69,7 @@ public class KGatherExample extends BatchTsetExample {
         .forEach(s -> LOG.info("map: " + s));
 
     LOG.info("test compute");
-    klink.compute((ComputeFunc<String, Iterator<Tuple<Integer, Iterator<Integer>>>>)
+    klink.compute((ComputeFunc<Iterator<Tuple<Integer, Iterator<Integer>>>, String>)
         input -> {
           StringBuilder s = new StringBuilder();
           while (input.hasNext()) {
@@ -83,7 +83,7 @@ public class KGatherExample extends BatchTsetExample {
         .forEach(s -> LOG.info("compute: concat " + s));
 
     LOG.info("test computec");
-    klink.compute((ComputeCollectorFunc<String, Iterator<Tuple<Integer, Iterator<Integer>>>>)
+    klink.compute((ComputeCollectorFunc<Iterator<Tuple<Integer, Iterator<Integer>>>, String>)
         (input, output) -> {
           while (input.hasNext()) {
             Tuple<Integer, Iterator<Integer>> next = input.next();

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/KGatherUngroupedExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/KGatherUngroupedExample.java
@@ -48,13 +48,13 @@ public class KGatherUngroupedExample extends BatchTsetExample {
     );
 
     LOG.info("test map");
-    klink.map((MapFunc<String, Tuple<Integer, Integer>>)
+    klink.map((MapFunc<Tuple<Integer, Integer>, String>)
         input -> input.getKey() + " -> " + input.getValue())
         .direct()
         .forEach(s -> LOG.info("map: " + s));
 
     LOG.info("test compute");
-    klink.compute((ComputeFunc<String, Iterator<Tuple<Integer, Integer>>>)
+    klink.compute((ComputeFunc<Iterator<Tuple<Integer, Integer>>, String>)
         input -> {
           StringBuilder sb = new StringBuilder();
           while (input.hasNext()) {
@@ -67,7 +67,7 @@ public class KGatherUngroupedExample extends BatchTsetExample {
         .forEach(s -> LOG.info("compute: " + s));
 
     LOG.info("test computec");
-    klink.compute((ComputeCollectorFunc<String, Iterator<Tuple<Integer, Integer>>>)
+    klink.compute((ComputeCollectorFunc<Iterator<Tuple<Integer, Integer>>, String>)
         (input, output) -> {
           while (input.hasNext()) {
             Tuple<Integer, Integer> next = input.next();

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/KPartitionExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/KPartitionExample.java
@@ -64,7 +64,7 @@ public class KPartitionExample extends BatchTsetExample {
 
     LOG.info("test compute");
     klink.compute(
-        (ComputeFunc<String, Iterator<Tuple<Integer, Integer>>>) input -> {
+        (ComputeFunc<Iterator<Tuple<Integer, Integer>>, String>) input -> {
           StringBuilder s = new StringBuilder();
           while (input.hasNext()) {
             s.append(input.next().toString()).append(" ");
@@ -75,7 +75,7 @@ public class KPartitionExample extends BatchTsetExample {
         .forEach(s -> LOG.info("compute: concat " + s));
 
     LOG.info("test computec");
-    klink.compute((ComputeCollectorFunc<String, Iterator<Tuple<Integer, Integer>>>)
+    klink.compute((ComputeCollectorFunc<Iterator<Tuple<Integer, Integer>>, String>)
         (input, output) -> {
           while (input.hasNext()) {
             output.collect(input.next().toString());

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/KReduceExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/KReduceExample.java
@@ -63,7 +63,7 @@ public class KReduceExample extends BatchTsetExample {
 
     LOG.info("test compute");
     kreduce.compute(
-        (ComputeFunc<String, Iterator<Tuple<Integer, Integer>>>) input -> {
+        (ComputeFunc<Iterator<Tuple<Integer, Integer>>, String>) input -> {
           StringBuilder s = new StringBuilder();
           while (input.hasNext()) {
             s.append(input.next().toString()).append(" ");
@@ -74,7 +74,7 @@ public class KReduceExample extends BatchTsetExample {
         .forEach(s -> LOG.info("compute: concat " + s));
 
     LOG.info("test computec");
-    kreduce.compute((ComputeCollectorFunc<String, Iterator<Tuple<Integer, Integer>>>)
+    kreduce.compute((ComputeCollectorFunc<Iterator<Tuple<Integer, Integer>>, String>)
         (input, output) -> {
           while (input.hasNext()) {
             output.collect(input.next().toString());

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/KeyedAddInputsExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/KeyedAddInputsExample.java
@@ -59,33 +59,34 @@ public class KeyedAddInputsExample extends BatchTsetExample {
     KeyedCachedTSet<String, Integer> cache1 = src1.cache();
 
     ComputeTSet<String, Iterator<Tuple<String, Integer>>> comp =
-        cache0.keyedDirect().compute(new BaseComputeCollectorFunc<Iterator<Tuple<String, Integer>>, String
-            >() {
-          private Map<String, Integer> input1 = new HashMap<>();
+        cache0.keyedDirect().compute(
+            new BaseComputeCollectorFunc<Iterator<Tuple<String, Integer>>, String>() {
+              private Map<String, Integer> input1 = new HashMap<>();
 
-          @Override
-          public void prepare(TSetContext ctx) {
-            super.prepare(ctx);
+              @Override
+              public void prepare(TSetContext ctx) {
+                super.prepare(ctx);
 
-            // populate the hashmap with values from the input
-            DataPartitionConsumer<Tuple<String, Integer>> part =
-                (DataPartitionConsumer<Tuple<String, Integer>>) getInput("input").getConsumer();
-            while (part.hasNext()) {
-              Tuple<String, Integer> next = part.next();
-              input1.put(next.getKey(), next.getValue());
-            }
-          }
+                // populate the hashmap with values from the input
+                DataPartitionConsumer<Tuple<String, Integer>> part =
+                    (DataPartitionConsumer<Tuple<String, Integer>>) getInput("input")
+                        .getConsumer();
+                while (part.hasNext()) {
+                  Tuple<String, Integer> next = part.next();
+                  input1.put(next.getKey(), next.getValue());
+                }
+              }
 
-          @Override
-          public void compute(Iterator<Tuple<String, Integer>> input,
-                              RecordCollector<String> output) {
-            while (input.hasNext()) {
-              Tuple<String, Integer> next = input.next();
-              output.collect(next.getKey() + " -> " + next.getValue() + ", "
-                  + input1.get(next.getKey()));
-            }
-          }
-        }).addInput("input", cache1);
+              @Override
+              public void compute(Iterator<Tuple<String, Integer>> input,
+                                  RecordCollector<String> output) {
+                while (input.hasNext()) {
+                  Tuple<String, Integer> next = input.next();
+                  output.collect(next.getKey() + " -> " + next.getValue() + ", "
+                      + input1.get(next.getKey()));
+                }
+              }
+            }).addInput("input", cache1);
 
     comp.direct().forEach(i -> LOG.info("comp: " + i));
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/KeyedAddInputsExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/KeyedAddInputsExample.java
@@ -59,8 +59,8 @@ public class KeyedAddInputsExample extends BatchTsetExample {
     KeyedCachedTSet<String, Integer> cache1 = src1.cache();
 
     ComputeTSet<String, Iterator<Tuple<String, Integer>>> comp =
-        cache0.keyedDirect().compute(new BaseComputeCollectorFunc<String,
-            Iterator<Tuple<String, Integer>>>() {
+        cache0.keyedDirect().compute(new BaseComputeCollectorFunc<Iterator<Tuple<String, Integer>>, String
+            >() {
           private Map<String, Integer> input1 = new HashMap<>();
 
           @Override

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/KeyedAddInputsExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/KeyedAddInputsExample.java
@@ -58,7 +58,7 @@ public class KeyedAddInputsExample extends BatchTsetExample {
     KeyedCachedTSet<String, Integer> cache0 = src0.cache();
     KeyedCachedTSet<String, Integer> cache1 = src1.cache();
 
-    ComputeTSet<String, Iterator<Tuple<String, Integer>>> comp =
+    ComputeTSet<String> comp =
         cache0.keyedDirect().compute(
             new BaseComputeCollectorFunc<Iterator<Tuple<String, Integer>>, String>() {
               private Map<String, Integer> input1 = new HashMap<>();
@@ -92,7 +92,7 @@ public class KeyedAddInputsExample extends BatchTsetExample {
 
     LOG.info("Test lazy cache!");
 
-    ComputeTSet<Object, Iterator<String>> forEach = comp.direct()
+    ComputeTSet<Object> forEach = comp.direct()
         .lazyForEach(i -> LOG.info("comp-lazy: " + i));
 
     for (int i = 0; i < 4; i++) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/PartitionExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/PartitionExample.java
@@ -67,7 +67,7 @@ public class PartitionExample extends BatchTsetExample {
 
     LOG.info("test compute");
     src.partition(new LoadBalancePartitioner<>())
-        .compute((ComputeFunc<Integer, Iterator<Integer>>) input -> {
+        .compute((ComputeFunc<Iterator<Integer>, Integer>) input -> {
           int sum = 0;
           while (input.hasNext()) {
             sum += input.next();
@@ -79,7 +79,7 @@ public class PartitionExample extends BatchTsetExample {
 
     LOG.info("test computec");
     src.partition(new LoadBalancePartitioner<>())
-        .compute((ComputeCollectorFunc<String, Iterator<Integer>>)
+        .compute((ComputeCollectorFunc<Iterator<Integer>, String>)
             (input, output) -> {
               int sum = 0;
               while (input.hasNext()) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/PartitionMtoNExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/PartitionMtoNExample.java
@@ -64,7 +64,7 @@ public class PartitionMtoNExample extends BatchTsetExample {
 
     LOG.info("test compute");
     src.partition(new LoadBalancePartitioner<>(), n)
-        .compute((ComputeFunc<Integer, Iterator<Integer>>) input -> {
+        .compute((ComputeFunc<Iterator<Integer>, Integer>) input -> {
           int sum = 0;
           while (input.hasNext()) {
             sum += input.next();
@@ -76,7 +76,7 @@ public class PartitionMtoNExample extends BatchTsetExample {
 
     LOG.info("test computec");
     src.partition(new LoadBalancePartitioner<>(), n)
-        .compute((ComputeCollectorFunc<String, Iterator<Integer>>)
+        .compute((ComputeCollectorFunc<Iterator<Integer>, String>)
             (input, output) -> {
               int sum = 0;
               while (input.hasNext()) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/PersistExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/PersistExample.java
@@ -79,7 +79,7 @@ public class PersistExample extends BatchTsetExample {
 
     LOG.info("test compute");
     cTset.direct()
-        .compute((ComputeFunc<String, Iterator<Integer>>) input -> {
+        .compute((ComputeFunc<Iterator<Integer>, String>) input -> {
           int sum = 0;
           while (input.hasNext()) {
             sum += input.next();
@@ -91,7 +91,7 @@ public class PersistExample extends BatchTsetExample {
 
     LOG.info("test computec");
     cTset.direct()
-        .compute((ComputeCollectorFunc<String, Iterator<Integer>>)
+        .compute((ComputeCollectorFunc<Iterator<Integer>, String>)
             (input, output) -> {
               int sum = 0;
               while (input.hasNext()) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/PipeExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/PipeExample.java
@@ -41,7 +41,7 @@ public class PipeExample extends BatchTsetExample {
     CachedTSet<Integer> cachedInput = src.pipe().cache();
 
     LOG.info("test direct iteration");
-    ComputeTSet<Object, Integer> lazyForEach = cachedInput.pipe().lazyForEach(
+    ComputeTSet<Object> lazyForEach = cachedInput.pipe().lazyForEach(
         input -> {
           LOG.info("##" + input.toString());
         });

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ReduceExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/ReduceExample.java
@@ -74,14 +74,14 @@ public class ReduceExample extends BatchTsetExample {
 
     LOG.info("test compute");
     reduce
-        .compute((ComputeFunc<String, Integer>) input -> "sum=" + input)
+        .compute((ComputeFunc<Integer, String>) input -> "sum=" + input)
         .withSchema(PrimitiveSchemas.STRING)
         .direct()
         .forEach(s -> LOG.info("compute: " + s));
 
     LOG.info("test computec");
     reduce
-        .compute((ComputeCollectorFunc<String, Integer>)
+        .compute((ComputeCollectorFunc<Integer, String>)
             (input, output) -> output.collect("sum=" + input))
         .withSchema(PrimitiveSchemas.STRING)
         .direct()

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/SetSchemaExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/SetSchemaExample.java
@@ -67,7 +67,7 @@ public class SetSchemaExample implements Twister2Worker, Serializable {
     src.withSchema(PrimitiveSchemas.INTEGER).direct().forEach(ii -> LOG.info("out1: " + ii));
 
     ComputeTSet<String, Integer> map = src.allReduce(Integer::sum).map(
-        new BaseMapFunc<String, Integer>() {
+        new BaseMapFunc<Integer, String>() {
           @Override
           public void prepare(TSetContext ctx) {
             super.prepare(ctx);
@@ -86,7 +86,7 @@ public class SetSchemaExample implements Twister2Worker, Serializable {
     map.withSchema(PrimitiveSchemas.STRING).direct().forEach(ii -> LOG.info("out3: " + ii));
 
     KeyedTSet<String, Integer> keyed = map.mapToTuple(
-        new BaseMapFunc<Tuple<String, Integer>, String>() {
+        new BaseMapFunc<String, Tuple<String, Integer>>() {
           @Override
           public void prepare(TSetContext ctx) {
             super.prepare(ctx);

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/SetSchemaExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/SetSchemaExample.java
@@ -66,7 +66,7 @@ public class SetSchemaExample implements Twister2Worker, Serializable {
 
     src.withSchema(PrimitiveSchemas.INTEGER).direct().forEach(ii -> LOG.info("out1: " + ii));
 
-    ComputeTSet<String, Integer> map = src.allReduce(Integer::sum).map(
+    ComputeTSet<String> map = src.allReduce(Integer::sum).map(
         new BaseMapFunc<Integer, String>() {
           @Override
           public void prepare(TSetContext ctx) {

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/UnionExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/UnionExample.java
@@ -12,7 +12,6 @@
 package edu.iu.dsc.tws.examples.tset.batch;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
@@ -35,7 +34,7 @@ public class UnionExample extends BatchTsetExample {
     SourceTSet<Integer> src1 = dummySource(env, start, COUNT, PARALLELISM).setName("src1");
     SourceTSet<Integer> src2 = dummySourceOther(env, COUNT, PARALLELISM).setName("src2");
 
-    ComputeTSet<Integer, Iterator<Integer>> unionTSet = src1.union(src2);
+    ComputeTSet<Integer> unionTSet = src1.union(src2);
     LOG.info("test source union");
     unionTSet.direct().forEach(s -> LOG.info("map: " + s));
   }

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/UnionExample2.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/batch/UnionExample2.java
@@ -13,7 +13,6 @@
 package edu.iu.dsc.tws.examples.tset.batch;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
@@ -39,8 +38,8 @@ public class UnionExample2 extends BatchTsetExample {
     int start = env.getWorkerID() * 100;
     SourceTSet<Integer> src1 = dummySource(env, start, COUNT, PARALLELISM).setName("src1");
 
-    ComputeTSet<Integer, Iterator<Integer>> map = src1.direct().map(i -> i + 50);
-    ComputeTSet<Integer, Iterator<Integer>> unionTSet = src1.union(map);
+    ComputeTSet<Integer> map = src1.direct().map(i -> i + 50);
+    ComputeTSet<Integer> unionTSet = src1.union(map);
 
     LOG.info("test source union");
     unionTSet.direct().forEach(s -> LOG.info("union: " + s));

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/checkpointing/CheckpointingExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/checkpointing/CheckpointingExample.java
@@ -64,7 +64,7 @@ public class CheckpointingExample implements Twister2Worker, Serializable {
 
     SourceTSet<Integer> src1 = dummySource(env, count, 100 * env.getWorkerID() + 10);
     src1.direct().compute(
-        new BaseComputeFunc<String, Iterator<Integer>>() {
+        new BaseComputeFunc<Iterator<Integer>, String>() {
           private DataPartitionConsumer<Integer> in;
 
           @Override

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/checkpointing/KeyedCheckpointingExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/checkpointing/KeyedCheckpointingExample.java
@@ -68,7 +68,7 @@ public class KeyedCheckpointingExample implements Twister2Worker, Serializable {
 
     KeyedSourceTSet<String, Integer> src1 = dummySource(env, count, 10);
     src1.keyedDirect().compute(
-        new BaseComputeFunc<String, Iterator<Tuple<String, Integer>>>() {
+        new BaseComputeFunc<Iterator<Tuple<String, Integer>>, String>() {
           private DataPartitionConsumer<Tuple<String, Integer>> in;
 
           @Override

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/streaming/SReduceWindowExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/streaming/SReduceWindowExample.java
@@ -81,10 +81,10 @@ public class SReduceWindowExample extends StreamingTsetExample {
 
       if (REDUCE_WINDOW) {
 
-        WindowComputeTSet<Integer, Iterator<Integer>> winTSet
+        WindowComputeTSet<Iterator<Integer>, Integer> winTSet
             = link.countWindow(2);
 
-        WindowComputeTSet<Integer, Iterator<Integer>> localReducedTSet = winTSet
+        WindowComputeTSet<Iterator<Integer>, Integer> localReducedTSet = winTSet
             .aggregate((AggregateFunc<Integer>) Integer::sum);
 
         localReducedTSet.direct().forEach(System.out::println);
@@ -119,10 +119,10 @@ public class SReduceWindowExample extends StreamingTsetExample {
 
       if (REDUCE_WINDOW) {
 
-        WindowComputeTSet<Integer, Iterator<Integer>> winTSet
+        WindowComputeTSet<Iterator<Integer>, Integer> winTSet
             = link.timeWindow(2, TimeUnit.MILLISECONDS);
 
-        WindowComputeTSet<Integer, Iterator<Integer>> localReducedTSet = winTSet
+        WindowComputeTSet<Iterator<Integer>, Integer> localReducedTSet = winTSet
             .aggregate((AggregateFunc<Integer>) Integer::sum);
 
         localReducedTSet.direct().forEach(System.out::println);

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/streaming/SUnionExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/streaming/SUnionExample.java
@@ -36,7 +36,7 @@ public class SUnionExample extends StreamingTsetExample {
     SSourceTSet<Integer> src1 = dummySource(env, COUNT, PARALLELISM).setName("src1");
     SSourceTSet<Integer> src2 = dummySourceOther(env, COUNT, PARALLELISM).setName("src2");
 //    src.direct().forEach(s -> LOG.info("map sssss: " + s));
-    SComputeTSet<Integer, Integer> unionTSet = src1.union(src2);
+    SComputeTSet<Integer> unionTSet = src1.union(src2);
     LOG.info("test source union");
     unionTSet.direct().forEach(s -> LOG.info("map: " + s));
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/tutorial/intermediate/caching/TSetCachingExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/tutorial/intermediate/caching/TSetCachingExample.java
@@ -100,7 +100,7 @@ public class TSetCachingExample implements Twister2Worker, Serializable {
     }, 4);
 
     ComputeTSet<Integer, Iterator<Integer>> calc = sourceZ.direct().compute(
-        new ComputeCollectorFunc<Integer, Iterator<Integer>>() {
+        new ComputeCollectorFunc<Iterator<Integer>, Integer>() {
 
           private DataPartitionConsumer<Integer> xValues;
 

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/tutorial/intermediate/caching/TSetCachingExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/tutorial/intermediate/caching/TSetCachingExample.java
@@ -70,7 +70,7 @@ public class TSetCachingExample implements Twister2Worker, Serializable {
       }
     }, 4);
 
-    ComputeTSet<Object, Iterator<Object>> twoComputes = sourceX.direct().compute((itr, c) -> {
+    ComputeTSet<Object> twoComputes = sourceX.direct().compute((itr, c) -> {
       itr.forEachRemaining(i -> {
         c.collect(i * 5);
       });
@@ -99,7 +99,7 @@ public class TSetCachingExample implements Twister2Worker, Serializable {
       }
     }, 4);
 
-    ComputeTSet<Integer, Iterator<Integer>> calc = sourceZ.direct().compute(
+    ComputeTSet<Integer> calc = sourceZ.direct().compute(
         new ComputeCollectorFunc<Iterator<Integer>, Integer>() {
 
           private DataPartitionConsumer<Integer> xValues;

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/tutorial/intermediate/checkpoint/TSetCheckptExample.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/tset/tutorial/intermediate/checkpoint/TSetCheckptExample.java
@@ -13,7 +13,6 @@
 package edu.iu.dsc.tws.examples.tset.tutorial.intermediate.checkpoint;
 
 import java.io.Serializable;
-import java.util.Iterator;
 import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.JobConfig;
@@ -68,7 +67,7 @@ public class TSetCheckptExample implements Twister2Worker, Serializable {
     }, 4);
 
     long t1 = System.currentTimeMillis();
-    ComputeTSet<Object, Iterator<Object>> twoComputes = sourceX.direct().compute((itr, c) -> {
+    ComputeTSet<Object> twoComputes = sourceX.direct().compute((itr, c) -> {
       itr.forEachRemaining(i -> {
         c.collect(i * 5);
       });

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/env/BatchEnvironment.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/env/BatchEnvironment.java
@@ -148,7 +148,7 @@ public class BatchEnvironment extends TSetEnvironment {
 
   public <K, V, F extends InputFormat<K, V>, I> SourceTSet<I> createHadoopSource(
       Configuration configuration, Class<F> inputFormat, int parallel,
-      MapFunc<I, Tuple<K, V>> mapFunc) {
+      MapFunc<Tuple<K, V>, I> mapFunc) {
     SourceTSet<I> sourceT = new SourceTSet<>(this,
         new HadoopSourceWithMap<>(configuration, inputFormat, mapFunc), parallel);
     getGraph().addSourceTSet(sourceT);
@@ -159,7 +159,7 @@ public class BatchEnvironment extends TSetEnvironment {
   public <K, V,
       F extends InputFormat<K, V>, K2, V2> KeyedSourceTSet<K2, V2> createKeyedHadoopSource(
       Configuration configuration, Class<F> inputFormat, int parallel,
-      MapFunc<Tuple<K2, V2>, Tuple<K, V>> mapFunc) {
+      MapFunc<Tuple<K, V>, Tuple<K2, V2>> mapFunc) {
     KeyedSourceTSet<K2, V2> sourceT = new KeyedSourceTSet<>(this,
         new HadoopSourceWithMap<>(configuration, inputFormat, mapFunc), parallel);
     getGraph().addSourceTSet(sourceT);

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/FlatMapCompute.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/FlatMapCompute.java
@@ -30,10 +30,10 @@ import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.FlatMapFunc;
 import edu.iu.dsc.tws.api.tset.fn.RecordCollector;
 
-public class FlatMapCompute<O, I> implements ComputeCollectorFunc<O, I> {
-  private FlatMapFunc<O, I> mapFn;
+public class FlatMapCompute<I, O> implements ComputeCollectorFunc<I, O> {
+  private final FlatMapFunc<I, O> mapFn;
 
-  public FlatMapCompute(FlatMapFunc<O, I> mapFunction) {
+  public FlatMapCompute(FlatMapFunc<I, O> mapFunction) {
     this.mapFn = mapFunction;
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/FlatMapIterCompute.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/FlatMapIterCompute.java
@@ -19,14 +19,14 @@ import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.FlatMapFunc;
 import edu.iu.dsc.tws.api.tset.fn.RecordCollector;
 
-public class FlatMapIterCompute<O, I> implements ComputeCollectorFunc<O, Iterator<I>> {
-  private FlatMapFunc<O, I> mapFn;
+public class FlatMapIterCompute<I, O> implements ComputeCollectorFunc<Iterator<I>, O> {
+  private FlatMapFunc<I, O> mapFn;
 
   public FlatMapIterCompute() {
     //no args constructor for kryo
   }
 
-  public FlatMapIterCompute(FlatMapFunc<O, I> mapFunction) {
+  public FlatMapIterCompute(FlatMapFunc<I, O> mapFunction) {
     this.mapFn = mapFunction;
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/ForEachCompute.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/ForEachCompute.java
@@ -17,7 +17,7 @@ import edu.iu.dsc.tws.api.tset.TSetContext;
 import edu.iu.dsc.tws.api.tset.fn.ApplyFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 
-public class ForEachCompute<T> implements ComputeFunc<Object, T> {
+public class ForEachCompute<T> implements ComputeFunc<T, Object> {
   private ApplyFunc<T> applyFn;
 
   public ForEachCompute(ApplyFunc<T> applyFunction) {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/ForEachIterCompute.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/ForEachIterCompute.java
@@ -18,7 +18,7 @@ import edu.iu.dsc.tws.api.tset.TSetContext;
 import edu.iu.dsc.tws.api.tset.fn.ApplyFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 
-public class ForEachIterCompute<T> implements ComputeFunc<Object, Iterator<T>> {
+public class ForEachIterCompute<T> implements ComputeFunc<Iterator<T>, Object> {
   private ApplyFunc<T> applyFn;
 
   public ForEachIterCompute() {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/GatherFlatMapCompute.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/GatherFlatMapCompute.java
@@ -20,11 +20,11 @@ import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.FlatMapFunc;
 import edu.iu.dsc.tws.api.tset.fn.RecordCollector;
 
-public class GatherFlatMapCompute<O, I> implements
-    ComputeCollectorFunc<O, Iterator<Tuple<Integer, I>>> {
-  private FlatMapFunc<O, I> mapFn;
+public class GatherFlatMapCompute<I, O> implements
+    ComputeCollectorFunc<Iterator<Tuple<Integer, I>>, O> {
+  private FlatMapFunc<I, O> mapFn;
 
-  public GatherFlatMapCompute(FlatMapFunc<O, I> mapFunction) {
+  public GatherFlatMapCompute(FlatMapFunc<I, O> mapFunction) {
     this.mapFn = mapFunction;
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/GatherForEachCompute.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/GatherForEachCompute.java
@@ -19,7 +19,7 @@ import edu.iu.dsc.tws.api.tset.TSetContext;
 import edu.iu.dsc.tws.api.tset.fn.ApplyFunc;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 
-public class GatherForEachCompute<T> implements ComputeFunc<Object, Iterator<Tuple<Integer, T>>> {
+public class GatherForEachCompute<T> implements ComputeFunc<Iterator<Tuple<Integer, T>>, Object> {
   private ApplyFunc<T> applyFn;
 
   public GatherForEachCompute(ApplyFunc<T> applyFunction) {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/GatherMapCompute.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/GatherMapCompute.java
@@ -20,16 +20,16 @@ import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.MapFunc;
 import edu.iu.dsc.tws.api.tset.fn.RecordCollector;
 
-public class GatherMapCompute<O, I> implements
-    ComputeCollectorFunc<O, Iterator<Tuple<Integer, I>>> {
+public class GatherMapCompute<I, O> implements
+    ComputeCollectorFunc<Iterator<Tuple<Integer, I>>, O> {
 
-  private MapFunc<O, I> mapFn;
+  private MapFunc<I, O> mapFn;
 
   private GatherMapCompute() {
     //non arg constructor for kryp
   }
 
-  public GatherMapCompute(MapFunc<O, I> mapFunction) {
+  public GatherMapCompute(MapFunc<I, O> mapFunction) {
     this.mapFn = mapFunction;
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/MapCompute.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/MapCompute.java
@@ -16,10 +16,10 @@ import edu.iu.dsc.tws.api.tset.TSetContext;
 import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 import edu.iu.dsc.tws.api.tset.fn.MapFunc;
 
-public class MapCompute<O, I> implements ComputeFunc<O, I> {
-  private MapFunc<O, I> mapFn;
+public class MapCompute<I, O> implements ComputeFunc<I, O> {
+  private MapFunc<I, O> mapFn;
 
-  public MapCompute(MapFunc<O, I> mapFunction) {
+  public MapCompute(MapFunc<I, O> mapFunction) {
     this.mapFn = mapFunction;
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/MapIterCompute.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/MapIterCompute.java
@@ -19,14 +19,14 @@ import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.MapFunc;
 import edu.iu.dsc.tws.api.tset.fn.RecordCollector;
 
-public class MapIterCompute<O, I> implements ComputeCollectorFunc<O, Iterator<I>> {
-  private MapFunc<O, I> mapFn;
+public class MapIterCompute<I, O> implements ComputeCollectorFunc<Iterator<I>, O> {
+  private MapFunc<I, O> mapFn;
 
   private MapIterCompute() {
     //non arg constructor for kryp
   }
 
-  public MapIterCompute(MapFunc<O, I> mapFunction) {
+  public MapIterCompute(MapFunc<I, O> mapFunction) {
     this.mapFn = mapFunction;
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/ProcessWindowCompute.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/ProcessWindowCompute.java
@@ -16,11 +16,11 @@ import java.util.Iterator;
 import edu.iu.dsc.tws.api.tset.TSetContext;
 import edu.iu.dsc.tws.api.tset.fn.MapFunc;
 
-public class ProcessWindowCompute<O, I> implements WindowComputeFunc<O, Iterator<I>> {
+public class ProcessWindowCompute<I, O> implements WindowComputeFunc<Iterator<I>, O> {
 
-  private MapFunc<O, Iterator<I>> processFn;
+  private MapFunc<Iterator<I>, O> processFn;
 
-  public ProcessWindowCompute(MapFunc<O, Iterator<I>> procFn) {
+  public ProcessWindowCompute(MapFunc<Iterator<I>, O> procFn) {
     this.processFn = procFn;
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/WindowComputeFunc.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/WindowComputeFunc.java
@@ -19,7 +19,7 @@ import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
  * @param <O> TSet Window Output
  * @param <I> TSet Window Input
  */
-public interface WindowComputeFunc<O, I> extends ComputeFunc<O, I> {
+public interface WindowComputeFunc<I, O> extends ComputeFunc<I, O> {
 
 
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/row/RowFlatMapCompute.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/row/RowFlatMapCompute.java
@@ -19,7 +19,7 @@ import edu.iu.dsc.tws.api.tset.fn.FlatMapFunc;
 import edu.iu.dsc.tws.api.tset.fn.RecordCollector;
 import edu.iu.dsc.tws.common.table.Row;
 
-public class RowFlatMapCompute implements ComputeCollectorFunc<Row, Iterator<Row>> {
+public class RowFlatMapCompute implements ComputeCollectorFunc<Iterator<Row>, Row> {
   private FlatMapFunc<Row, Row> mapFn;
 
   public RowFlatMapCompute(FlatMapFunc<Row, Row> mapFn) {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/row/RowForEachCompute.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/row/RowForEachCompute.java
@@ -20,7 +20,7 @@ import edu.iu.dsc.tws.api.tset.fn.ComputeCollectorFunc;
 import edu.iu.dsc.tws.api.tset.fn.RecordCollector;
 import edu.iu.dsc.tws.common.table.Row;
 
-public class RowForEachCompute implements ComputeCollectorFunc<Row, Iterator<Row>> {
+public class RowForEachCompute implements ComputeCollectorFunc<Iterator<Row>, Row> {
   private static final Logger LOG = Logger.getLogger(RowForEachCompute.class.getName());
 
   private ApplyFunc<Row> applyFn;

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/row/RowMapCompute.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/fn/row/RowMapCompute.java
@@ -19,7 +19,7 @@ import edu.iu.dsc.tws.api.tset.fn.MapFunc;
 import edu.iu.dsc.tws.api.tset.fn.RecordCollector;
 import edu.iu.dsc.tws.common.table.Row;
 
-public class RowMapCompute implements ComputeCollectorFunc<Row, Iterator<Row>> {
+public class RowMapCompute implements ComputeCollectorFunc<Iterator<Row>, Row> {
   private MapFunc<Row, Row> mapFn;
 
   public RowMapCompute(MapFunc<Row, Row> mapFn) {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchGatherLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchGatherLink.java
@@ -54,13 +54,13 @@ public abstract class BatchGatherLink<T> extends BatchTLinkImpl<Iterator<Tuple<I
   }
 
   @Override
-  public <O> ComputeTSet<O, Iterator<Tuple<Integer, T>>> map(MapFunc<T, O> mapFn) {
+  public <O> ComputeTSet<O> map(MapFunc<T, O> mapFn) {
     GatherMapCompute<T, O> comp = new GatherMapCompute<>(mapFn);
     return compute("map", comp);
   }
 
   @Override
-  public <O> ComputeTSet<O, Iterator<Tuple<Integer, T>>> flatmap(FlatMapFunc<T, O> mapFn) {
+  public <O> ComputeTSet<O> flatmap(FlatMapFunc<T, O> mapFn) {
     GatherFlatMapCompute<T, O> comp = new GatherFlatMapCompute<>(mapFn);
     return compute("map", comp);
   }
@@ -77,12 +77,12 @@ public abstract class BatchGatherLink<T> extends BatchTLinkImpl<Iterator<Tuple<I
 
   @Override
   public void forEach(ApplyFunc<T> applyFunction) {
-    ComputeTSet<Object, Iterator<Tuple<Integer, T>>> set = lazyForEach(applyFunction);
+    ComputeTSet<Object> set = lazyForEach(applyFunction);
     getTSetEnv().run(set);
   }
 
   @Override
-  public ComputeTSet<Object, Iterator<Tuple<Integer, T>>> lazyForEach(ApplyFunc<T> applyFunction) {
+  public ComputeTSet<Object> lazyForEach(ApplyFunc<T> applyFunction) {
     GatherForEachCompute<T> comp = new GatherForEachCompute<>(applyFunction);
     return compute("foreach", comp);
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchGatherLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchGatherLink.java
@@ -54,19 +54,19 @@ public abstract class BatchGatherLink<T> extends BatchTLinkImpl<Iterator<Tuple<I
   }
 
   @Override
-  public <O> ComputeTSet<O, Iterator<Tuple<Integer, T>>> map(MapFunc<O, T> mapFn) {
-    GatherMapCompute<O, T> comp = new GatherMapCompute<>(mapFn);
+  public <O> ComputeTSet<O, Iterator<Tuple<Integer, T>>> map(MapFunc<T, O> mapFn) {
+    GatherMapCompute<T, O> comp = new GatherMapCompute<>(mapFn);
     return compute("map", comp);
   }
 
   @Override
-  public <O> ComputeTSet<O, Iterator<Tuple<Integer, T>>> flatmap(FlatMapFunc<O, T> mapFn) {
-    GatherFlatMapCompute<O, T> comp = new GatherFlatMapCompute<>(mapFn);
+  public <O> ComputeTSet<O, Iterator<Tuple<Integer, T>>> flatmap(FlatMapFunc<T, O> mapFn) {
+    GatherFlatMapCompute<T, O> comp = new GatherFlatMapCompute<>(mapFn);
     return compute("map", comp);
   }
 
   @Override
-  public <K, V> KeyedTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T> genTupleFn) {
+  public <K, V> KeyedTSet<K, V> mapToTuple(MapFunc<T, Tuple<K, V>> genTupleFn) {
     KeyedTSet<K, V> set = new KeyedTSet<>(getTSetEnv(), new GatherMapCompute<>(genTupleFn),
         getTargetParallelism(), getSchema());
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchIteratorLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchIteratorLink.java
@@ -42,17 +42,17 @@ public abstract class BatchIteratorLink<T> extends BatchTLinkImpl<Iterator<T>, T
   }
 
   @Override
-  public <P> ComputeTSet<P, Iterator<T>> map(MapFunc<P, T> mapFn) {
+  public <P> ComputeTSet<P, Iterator<T>> map(MapFunc<T, P> mapFn) {
     return compute("map", new MapIterCompute<>(mapFn));
   }
 
   @Override
-  public <P> ComputeTSet<P, Iterator<T>> flatmap(FlatMapFunc<P, T> mapFn) {
+  public <P> ComputeTSet<P, Iterator<T>> flatmap(FlatMapFunc<T, P> mapFn) {
     return compute("flatmap", new FlatMapIterCompute<>(mapFn));
   }
 
   @Override
-  public <K, V> KeyedTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T> mapToTupFn) {
+  public <K, V> KeyedTSet<K, V> mapToTuple(MapFunc<T, Tuple<K, V>> mapToTupFn) {
     KeyedTSet<K, V> set = new KeyedTSet<>(getTSetEnv(), new MapIterCompute<>(mapToTupFn),
         getTargetParallelism(), getSchema());
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchIteratorLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchIteratorLink.java
@@ -42,12 +42,12 @@ public abstract class BatchIteratorLink<T> extends BatchTLinkImpl<Iterator<T>, T
   }
 
   @Override
-  public <P> ComputeTSet<P, Iterator<T>> map(MapFunc<T, P> mapFn) {
+  public <P> ComputeTSet<P> map(MapFunc<T, P> mapFn) {
     return compute("map", new MapIterCompute<>(mapFn));
   }
 
   @Override
-  public <P> ComputeTSet<P, Iterator<T>> flatmap(FlatMapFunc<T, P> mapFn) {
+  public <P> ComputeTSet<P> flatmap(FlatMapFunc<T, P> mapFn) {
     return compute("flatmap", new FlatMapIterCompute<>(mapFn));
   }
 
@@ -62,13 +62,13 @@ public abstract class BatchIteratorLink<T> extends BatchTLinkImpl<Iterator<T>, T
   }
 
   @Override
-  public ComputeTSet<Object, Iterator<T>> lazyForEach(ApplyFunc<T> applyFunction) {
+  public ComputeTSet<Object> lazyForEach(ApplyFunc<T> applyFunction) {
     return compute("foreach", new ForEachIterCompute<>(applyFunction));
   }
 
   @Override
   public void forEach(ApplyFunc<T> applyFunction) {
-    ComputeTSet<Object, Iterator<T>> set = lazyForEach(applyFunction);
+    ComputeTSet<Object> set = lazyForEach(applyFunction);
 
     getTSetEnv().run(set);
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchSingleLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchSingleLink.java
@@ -40,12 +40,12 @@ public abstract class BatchSingleLink<T> extends BatchTLinkImpl<T, T> {
   }
 
   @Override
-  public <P> ComputeTSet<P, T> map(MapFunc<P, T> mapFn) {
+  public <P> ComputeTSet<P, T> map(MapFunc<T, P> mapFn) {
     return compute("map", new MapCompute<>(mapFn));
   }
 
   @Override
-  public <P> ComputeTSet<P, T> flatmap(FlatMapFunc<P, T> mapFn) {
+  public <P> ComputeTSet<P, T> flatmap(FlatMapFunc<T, P> mapFn) {
     return compute("flatmap", new FlatMapCompute<>(mapFn));
   }
 
@@ -62,7 +62,7 @@ public abstract class BatchSingleLink<T> extends BatchTLinkImpl<T, T> {
   }
 
   @Override
-  public <K, O> KeyedTSet<K, O> mapToTuple(MapFunc<Tuple<K, O>, T> genTupleFn) {
+  public <K, O> KeyedTSet<K, O> mapToTuple(MapFunc<T, Tuple<K, O>> genTupleFn) {
     KeyedTSet<K, O> set = new KeyedTSet<>(getTSetEnv(), new MapCompute<>(genTupleFn),
         getTargetParallelism(), getSchema());
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchSingleLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchSingleLink.java
@@ -40,24 +40,24 @@ public abstract class BatchSingleLink<T> extends BatchTLinkImpl<T, T> {
   }
 
   @Override
-  public <P> ComputeTSet<P, T> map(MapFunc<T, P> mapFn) {
+  public <P> ComputeTSet<P> map(MapFunc<T, P> mapFn) {
     return compute("map", new MapCompute<>(mapFn));
   }
 
   @Override
-  public <P> ComputeTSet<P, T> flatmap(FlatMapFunc<T, P> mapFn) {
+  public <P> ComputeTSet<P> flatmap(FlatMapFunc<T, P> mapFn) {
     return compute("flatmap", new FlatMapCompute<>(mapFn));
   }
 
   @Override
   public void forEach(ApplyFunc<T> applyFunction) {
-    ComputeTSet<Object, T> set = lazyForEach(applyFunction);
+    ComputeTSet<Object> set = lazyForEach(applyFunction);
 
     getTSetEnv().run(set);
   }
 
   @Override
-  public ComputeTSet<Object, T> lazyForEach(ApplyFunc<T> applyFunction) {
+  public ComputeTSet<Object> lazyForEach(ApplyFunc<T> applyFunction) {
     return compute("foreach", new ForEachCompute<>(applyFunction));
   }
 
@@ -81,7 +81,7 @@ public abstract class BatchSingleLink<T> extends BatchTLinkImpl<T, T> {
 
   @Override
   public StorableTBase<T> cache() {
-    return (CachedTSet<T>) super.cache();
+    return super.cache();
   }
 
   @Override
@@ -97,6 +97,6 @@ public abstract class BatchSingleLink<T> extends BatchTLinkImpl<T, T> {
 
   @Override
   public StorableTBase<T> persist() {
-    return (PersistedTSet<T>) super.persist();
+    return super.persist();
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchTLinkImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchTLinkImpl.java
@@ -42,7 +42,7 @@ public abstract class BatchTLinkImpl<T1, T0> extends BaseTLinkWithSchema<T1, T0>
     return (BatchEnvironment) super.getTSetEnv();
   }
 
-  public <P> ComputeTSet<P, T1> compute(String n, ComputeFunc<P, T1> computeFunction) {
+  public <P> ComputeTSet<P, T1> compute(String n, ComputeFunc<T1, P> computeFunction) {
     ComputeTSet<P, T1> set;
     if (n != null && !n.isEmpty()) {
       set = new ComputeTSet<>(getTSetEnv(), n, computeFunction, getTargetParallelism(),
@@ -55,7 +55,7 @@ public abstract class BatchTLinkImpl<T1, T0> extends BaseTLinkWithSchema<T1, T0>
     return set;
   }
 
-  public <P> ComputeTSet<P, T1> compute(String n, ComputeCollectorFunc<P, T1> computeFunction) {
+  public <P> ComputeTSet<P, T1> compute(String n, ComputeCollectorFunc<T1, P> computeFunction) {
     ComputeTSet<P, T1> set;
     if (n != null && !n.isEmpty()) {
       set = new ComputeTSet<>(getTSetEnv(), n, computeFunction, getTargetParallelism(),
@@ -69,12 +69,12 @@ public abstract class BatchTLinkImpl<T1, T0> extends BaseTLinkWithSchema<T1, T0>
   }
 
   @Override
-  public <P> ComputeTSet<P, T1> compute(ComputeFunc<P, T1> computeFunction) {
+  public <P> ComputeTSet<P, T1> compute(ComputeFunc<T1, P> computeFunction) {
     return compute(null, computeFunction);
   }
 
   @Override
-  public <P> ComputeTSet<P, T1> compute(ComputeCollectorFunc<P, T1> computeFunction) {
+  public <P> ComputeTSet<P, T1> compute(ComputeCollectorFunc<T1, P> computeFunction) {
     return compute(null, computeFunction);
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchTLinkImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/BatchTLinkImpl.java
@@ -42,8 +42,8 @@ public abstract class BatchTLinkImpl<T1, T0> extends BaseTLinkWithSchema<T1, T0>
     return (BatchEnvironment) super.getTSetEnv();
   }
 
-  public <P> ComputeTSet<P, T1> compute(String n, ComputeFunc<T1, P> computeFunction) {
-    ComputeTSet<P, T1> set;
+  public <P> ComputeTSet<P> compute(String n, ComputeFunc<T1, P> computeFunction) {
+    ComputeTSet<P> set;
     if (n != null && !n.isEmpty()) {
       set = new ComputeTSet<>(getTSetEnv(), n, computeFunction, getTargetParallelism(),
           getSchema());
@@ -55,8 +55,8 @@ public abstract class BatchTLinkImpl<T1, T0> extends BaseTLinkWithSchema<T1, T0>
     return set;
   }
 
-  public <P> ComputeTSet<P, T1> compute(String n, ComputeCollectorFunc<T1, P> computeFunction) {
-    ComputeTSet<P, T1> set;
+  public <P> ComputeTSet<P> compute(String n, ComputeCollectorFunc<T1, P> computeFunction) {
+    ComputeTSet<P> set;
     if (n != null && !n.isEmpty()) {
       set = new ComputeTSet<>(getTSetEnv(), n, computeFunction, getTargetParallelism(),
           getSchema());
@@ -69,12 +69,12 @@ public abstract class BatchTLinkImpl<T1, T0> extends BaseTLinkWithSchema<T1, T0>
   }
 
   @Override
-  public <P> ComputeTSet<P, T1> compute(ComputeFunc<T1, P> computeFunction) {
+  public <P> ComputeTSet<P> compute(ComputeFunc<T1, P> computeFunction) {
     return compute(null, computeFunction);
   }
 
   @Override
-  public <P> ComputeTSet<P, T1> compute(ComputeCollectorFunc<T1, P> computeFunction) {
+  public <P> ComputeTSet<P> compute(ComputeCollectorFunc<T1, P> computeFunction) {
     return compute(null, computeFunction);
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/PipeTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/PipeTLink.java
@@ -52,12 +52,12 @@ public class PipeTLink<T> extends BatchTLinkImpl<T, T> {
 
   @Override
   public void forEach(ApplyFunc<T> applyFunction) {
-    ComputeTSet<Object, T> set = lazyForEach(applyFunction);
+    ComputeTSet<Object> set = lazyForEach(applyFunction);
     getTSetEnv().run(set);
   }
 
   @Override
-  public ComputeTSet<Object, T> lazyForEach(ApplyFunc<T> applyFunction) {
+  public ComputeTSet<Object> lazyForEach(ApplyFunc<T> applyFunction) {
     ForEachCompute<T> compute = new ForEachCompute<>(applyFunction);
     return compute("foreach", compute);
   }
@@ -73,13 +73,13 @@ public class PipeTLink<T> extends BatchTLinkImpl<T, T> {
   }
 
   @Override
-  public <O> ComputeTSet<O, T> flatmap(FlatMapFunc<T, O> mapFn) {
+  public <O> ComputeTSet<O> flatmap(FlatMapFunc<T, O> mapFn) {
     FlatMapCompute<T, O> comp = new FlatMapCompute<>(mapFn);
     return compute("flatmap", comp);
   }
 
   @Override
-  public <O> ComputeTSet<O, T> map(MapFunc<T, O> mapFn) {
+  public <O> ComputeTSet<O> map(MapFunc<T, O> mapFn) {
     MapCompute<T, O> comp = new MapCompute<>(mapFn);
     return compute("map", comp);
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/PipeTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/PipeTLink.java
@@ -63,7 +63,7 @@ public class PipeTLink<T> extends BatchTLinkImpl<T, T> {
   }
 
   @Override
-  public <K, V> KeyedTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T> genTupleFn) {
+  public <K, V> KeyedTSet<K, V> mapToTuple(MapFunc<T, Tuple<K, V>> genTupleFn) {
     KeyedTSet<K, V> set = new KeyedTSet<>(getTSetEnv(), new MapCompute<>(genTupleFn),
         getTargetParallelism(), getSchema());
 
@@ -73,14 +73,14 @@ public class PipeTLink<T> extends BatchTLinkImpl<T, T> {
   }
 
   @Override
-  public <O> ComputeTSet<O, T> flatmap(FlatMapFunc<O, T> mapFn) {
-    FlatMapCompute<O, T> comp = new FlatMapCompute<>(mapFn);
+  public <O> ComputeTSet<O, T> flatmap(FlatMapFunc<T, O> mapFn) {
+    FlatMapCompute<T, O> comp = new FlatMapCompute<>(mapFn);
     return compute("flatmap", comp);
   }
 
   @Override
-  public <O> ComputeTSet<O, T> map(MapFunc<O, T> mapFn) {
-    MapCompute<O, T> comp = new MapCompute<>(mapFn);
+  public <O> ComputeTSet<O, T> map(MapFunc<T, O> mapFn) {
+    MapCompute<T, O> comp = new MapCompute<>(mapFn);
     return compute("map", comp);
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/row/RowBatchTLinkImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/row/RowBatchTLinkImpl.java
@@ -59,7 +59,7 @@ public abstract class RowBatchTLinkImpl extends BaseTLinkWithSchema<Row, Row>
   }
 
   protected RowComputeTSet compute(String n,
-                                ComputeCollectorFunc<Row, Iterator<Row>> computeFunction) {
+                                ComputeCollectorFunc<Iterator<Row>, Row> computeFunction) {
     RowComputeTSet set;
     if (n != null && !n.isEmpty()) {
       set = new RowComputeTSet(getTSetEnv(), n, computeFunction, getTargetParallelism(),
@@ -74,7 +74,7 @@ public abstract class RowBatchTLinkImpl extends BaseTLinkWithSchema<Row, Row>
   }
 
   @Override
-  public RowComputeTSet compute(ComputeCollectorFunc<Row, Iterator<Row>> computeFunction) {
+  public RowComputeTSet compute(ComputeCollectorFunc<Iterator<Row>, Row> computeFunction) {
     return compute(null, computeFunction);
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/row/RowPartitionTLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/batch/row/RowPartitionTLink.java
@@ -48,7 +48,7 @@ public class RowPartitionTLink extends RowBatchTLinkImpl {
   }
 
   protected RowComputeTSet compute(String n,
-                                ComputeCollectorFunc<Row, Iterator<Row>> computeFunction) {
+                                ComputeCollectorFunc<Iterator<Row>, Row> computeFunction) {
     RowComputeTSet set;
     if (n != null && !n.isEmpty()) {
       set = new RowComputeTSet(getTSetEnv(), n, computeFunction, getTargetParallelism(),

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingGatherLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingGatherLink.java
@@ -60,19 +60,19 @@ computeWithoutKey(Compute<P, Iterator<T>> computeFunction) {
   }*/
 
   @Override
-  public <O> SComputeTSet<O, Iterator<Tuple<Integer, T>>> map(MapFunc<O, T> mapFn) {
-    GatherMapCompute<O, T> comp = new GatherMapCompute<>(mapFn);
+  public <O> SComputeTSet<O, Iterator<Tuple<Integer, T>>> map(MapFunc<T, O> mapFn) {
+    GatherMapCompute<T, O> comp = new GatherMapCompute<>(mapFn);
     return compute("smap", comp);
   }
 
   @Override
-  public <O> SComputeTSet<O, Iterator<Tuple<Integer, T>>> flatmap(FlatMapFunc<O, T> mapFn) {
-    GatherFlatMapCompute<O, T> comp = new GatherFlatMapCompute<>(mapFn);
+  public <O> SComputeTSet<O, Iterator<Tuple<Integer, T>>> flatmap(FlatMapFunc<T, O> mapFn) {
+    GatherFlatMapCompute<T, O> comp = new GatherFlatMapCompute<>(mapFn);
     return compute("smap", comp);
   }
 
   @Override
-  public <K, V> SKeyedTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T> genTupleFn) {
+  public <K, V> SKeyedTSet<K, V> mapToTuple(MapFunc<T, Tuple<K, V>> genTupleFn) {
     SKeyedTSet<K, V> set = new SKeyedTSet<>(getTSetEnv(), new GatherMapCompute<>(genTupleFn),
         getTargetParallelism(), getSchema());
     addChildToGraph(set);

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingGatherLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingGatherLink.java
@@ -60,13 +60,13 @@ computeWithoutKey(Compute<P, Iterator<T>> computeFunction) {
   }*/
 
   @Override
-  public <O> SComputeTSet<O, Iterator<Tuple<Integer, T>>> map(MapFunc<T, O> mapFn) {
+  public <O> SComputeTSet<O> map(MapFunc<T, O> mapFn) {
     GatherMapCompute<T, O> comp = new GatherMapCompute<>(mapFn);
     return compute("smap", comp);
   }
 
   @Override
-  public <O> SComputeTSet<O, Iterator<Tuple<Integer, T>>> flatmap(FlatMapFunc<T, O> mapFn) {
+  public <O> SComputeTSet<O> flatmap(FlatMapFunc<T, O> mapFn) {
     GatherFlatMapCompute<T, O> comp = new GatherFlatMapCompute<>(mapFn);
     return compute("smap", comp);
   }
@@ -82,7 +82,7 @@ computeWithoutKey(Compute<P, Iterator<T>> computeFunction) {
   @Override
   public void forEach(ApplyFunc<T> applyFunction) {
     GatherForEachCompute<T> comp = new GatherForEachCompute<>(applyFunction);
-    SComputeTSet<Object, Iterator<Tuple<Integer, T>>> foreach =
+    SComputeTSet<Object> foreach =
         compute("sforeach", comp);
     addChildToGraph(foreach);
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingIteratorLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingIteratorLink.java
@@ -39,18 +39,18 @@ public abstract class StreamingIteratorLink<T> extends StreamingTLinkImpl<Iterat
   }
 
   @Override
-  public <P> SComputeTSet<P, Iterator<T>> map(MapFunc<T, P> mapFn) {
+  public <P> SComputeTSet<P> map(MapFunc<T, P> mapFn) {
     return compute("smap", new MapIterCompute<>(mapFn));
   }
 
   @Override
-  public <P> SComputeTSet<P, Iterator<T>> flatmap(FlatMapFunc<T, P> mapFn) {
+  public <P> SComputeTSet<P> flatmap(FlatMapFunc<T, P> mapFn) {
     return compute("sflatmap", new FlatMapIterCompute<>(mapFn));
   }
 
   @Override
   public void forEach(ApplyFunc<T> applyFunction) {
-    SComputeTSet<Object, Iterator<T>> set = compute("sforeach",
+    SComputeTSet<Object> set = compute("sforeach",
         new ForEachIterCompute<>(applyFunction)
     );
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingIteratorLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingIteratorLink.java
@@ -39,12 +39,12 @@ public abstract class StreamingIteratorLink<T> extends StreamingTLinkImpl<Iterat
   }
 
   @Override
-  public <P> SComputeTSet<P, Iterator<T>> map(MapFunc<P, T> mapFn) {
+  public <P> SComputeTSet<P, Iterator<T>> map(MapFunc<T, P> mapFn) {
     return compute("smap", new MapIterCompute<>(mapFn));
   }
 
   @Override
-  public <P> SComputeTSet<P, Iterator<T>> flatmap(FlatMapFunc<P, T> mapFn) {
+  public <P> SComputeTSet<P, Iterator<T>> flatmap(FlatMapFunc<T, P> mapFn) {
     return compute("sflatmap", new FlatMapIterCompute<>(mapFn));
   }
 
@@ -56,7 +56,7 @@ public abstract class StreamingIteratorLink<T> extends StreamingTLinkImpl<Iterat
   }
 
   @Override
-  public <K, V> SKeyedTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T> mapToTupFn) {
+  public <K, V> SKeyedTSet<K, V> mapToTuple(MapFunc<T, Tuple<K, V>> mapToTupFn) {
     SKeyedTSet<K, V> set = new SKeyedTSet<>(getTSetEnv(), new MapIterCompute<>(mapToTupFn),
         getTargetParallelism(), getSchema());
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingSingleLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingSingleLink.java
@@ -37,18 +37,18 @@ public abstract class StreamingSingleLink<T> extends StreamingTLinkImpl<T, T> {
   }
 
   @Override
-  public <P> SComputeTSet<P, T> map(MapFunc<T, P> mapFn) {
+  public <P> SComputeTSet<P> map(MapFunc<T, P> mapFn) {
     return compute("smap", new MapCompute<>(mapFn));
   }
 
   @Override
-  public <P> SComputeTSet<P, T> flatmap(FlatMapFunc<T, P> mapFn) {
+  public <P> SComputeTSet<P> flatmap(FlatMapFunc<T, P> mapFn) {
     return compute("sflatmap", new FlatMapCompute<>(mapFn));
   }
 
   @Override
   public void forEach(ApplyFunc<T> applyFunction) {
-    SComputeTSet<Object, T> set = compute("sforeach", new ForEachCompute<>(applyFunction));
+    SComputeTSet<Object> set = compute("sforeach", new ForEachCompute<>(applyFunction));
   }
 
   @Override

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingSingleLink.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingSingleLink.java
@@ -37,12 +37,12 @@ public abstract class StreamingSingleLink<T> extends StreamingTLinkImpl<T, T> {
   }
 
   @Override
-  public <P> SComputeTSet<P, T> map(MapFunc<P, T> mapFn) {
+  public <P> SComputeTSet<P, T> map(MapFunc<T, P> mapFn) {
     return compute("smap", new MapCompute<>(mapFn));
   }
 
   @Override
-  public <P> SComputeTSet<P, T> flatmap(FlatMapFunc<P, T> mapFn) {
+  public <P> SComputeTSet<P, T> flatmap(FlatMapFunc<T, P> mapFn) {
     return compute("sflatmap", new FlatMapCompute<>(mapFn));
   }
 
@@ -52,7 +52,7 @@ public abstract class StreamingSingleLink<T> extends StreamingTLinkImpl<T, T> {
   }
 
   @Override
-  public <K, O> SKeyedTSet<K, O> mapToTuple(MapFunc<Tuple<K, O>, T> genTupleFn) {
+  public <K, O> SKeyedTSet<K, O> mapToTuple(MapFunc<T, Tuple<K, O>> genTupleFn) {
     SKeyedTSet<K, O> set = new SKeyedTSet<>(getTSetEnv(), new MapCompute<>(genTupleFn),
         getTargetParallelism(), getSchema());
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingTLinkImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingTLinkImpl.java
@@ -43,8 +43,8 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLinkWithSchema<T1,
     return (StreamingEnvironment) super.getTSetEnv();
   }
 
-  public <P> SComputeTSet<P, T1> compute(String n, ComputeFunc<T1, P> computeFunction) {
-    SComputeTSet<P, T1> set;
+  public <P> SComputeTSet<P> compute(String n, ComputeFunc<T1, P> computeFunction) {
+    SComputeTSet<P> set;
     if (n != null && !n.isEmpty()) {
       set = new SComputeTSet<>(getTSetEnv(), n, computeFunction, getTargetParallelism(),
           getSchema());
@@ -70,8 +70,8 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLinkWithSchema<T1,
     return set;
   }
 
-  public <P> SComputeTSet<P, T1> compute(String n, ComputeCollectorFunc<T1, P> computeFunction) {
-    SComputeTSet<P, T1> set;
+  public <P> SComputeTSet<P> compute(String n, ComputeCollectorFunc<T1, P> computeFunction) {
+    SComputeTSet<P> set;
     if (n != null && !n.isEmpty()) {
       set = new SComputeTSet<>(getTSetEnv(), n, computeFunction, getTargetParallelism(),
           getSchema());
@@ -84,12 +84,12 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLinkWithSchema<T1,
   }
 
   @Override
-  public <P> SComputeTSet<P, T1> compute(ComputeFunc<T1, P> computeFunction) {
+  public <P> SComputeTSet<P> compute(ComputeFunc<T1, P> computeFunction) {
     return compute(null, computeFunction);
   }
 
   @Override
-  public <P> SComputeTSet<P, T1> compute(ComputeCollectorFunc<T1, P> computeFunction) {
+  public <P> SComputeTSet<P> compute(ComputeCollectorFunc<T1, P> computeFunction) {
     return compute(null, computeFunction);
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingTLinkImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/links/streaming/StreamingTLinkImpl.java
@@ -43,7 +43,7 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLinkWithSchema<T1,
     return (StreamingEnvironment) super.getTSetEnv();
   }
 
-  public <P> SComputeTSet<P, T1> compute(String n, ComputeFunc<P, T1> computeFunction) {
+  public <P> SComputeTSet<P, T1> compute(String n, ComputeFunc<T1, P> computeFunction) {
     SComputeTSet<P, T1> set;
     if (n != null && !n.isEmpty()) {
       set = new SComputeTSet<>(getTSetEnv(), n, computeFunction, getTargetParallelism(),
@@ -56,8 +56,8 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLinkWithSchema<T1,
     return set;
   }
 
-  private <P> WindowComputeTSet<P, Iterator<T1>> window(String n) {
-    WindowComputeTSet<P, Iterator<T1>> set;
+  private <P> WindowComputeTSet<Iterator<T1>, P> window(String n) {
+    WindowComputeTSet<Iterator<T1>, P> set;
     if (n != null && !n.isEmpty()) {
       set = new WindowComputeTSet<>(getTSetEnv(), n, getTargetParallelism(),
           this.windowParameter, getSchema());
@@ -70,7 +70,7 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLinkWithSchema<T1,
     return set;
   }
 
-  public <P> SComputeTSet<P, T1> compute(String n, ComputeCollectorFunc<P, T1> computeFunction) {
+  public <P> SComputeTSet<P, T1> compute(String n, ComputeCollectorFunc<T1, P> computeFunction) {
     SComputeTSet<P, T1> set;
     if (n != null && !n.isEmpty()) {
       set = new SComputeTSet<>(getTSetEnv(), n, computeFunction, getTargetParallelism(),
@@ -84,12 +84,12 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLinkWithSchema<T1,
   }
 
   @Override
-  public <P> SComputeTSet<P, T1> compute(ComputeFunc<P, T1> computeFunction) {
+  public <P> SComputeTSet<P, T1> compute(ComputeFunc<T1, P> computeFunction) {
     return compute(null, computeFunction);
   }
 
   @Override
-  public <P> SComputeTSet<P, T1> compute(ComputeCollectorFunc<P, T1> computeFunction) {
+  public <P> SComputeTSet<P, T1> compute(ComputeCollectorFunc<T1, P> computeFunction) {
     return compute(null, computeFunction);
   }
 
@@ -101,26 +101,26 @@ public abstract class StreamingTLinkImpl<T1, T0> extends BaseTLinkWithSchema<T1,
     return sinkTSet;
   }
 
-  public <P> WindowComputeTSet<P, Iterator<T1>> countWindow(long windowLen) {
+  public <P> WindowComputeTSet<Iterator<T1>, P> countWindow(long windowLen) {
     this.windowParameter = new WindowParameter();
     this.windowParameter.withTumblingCountWindow(windowLen);
     return window("w-count-tumbling-compute-prev");
   }
 
-  public <P> WindowComputeTSet<P, Iterator<T1>> countWindow(long windowLen, long slidingLen) {
+  public <P> WindowComputeTSet<Iterator<T1>, P> countWindow(long windowLen, long slidingLen) {
     this.windowParameter = new WindowParameter();
     this.windowParameter.withSlidingingCountWindow(windowLen, slidingLen);
     return window("w-count-sliding-compute-prev");
   }
 
-  public <P> WindowComputeTSet<P, Iterator<T1>> timeWindow(long windowLen,
+  public <P> WindowComputeTSet<Iterator<T1>, P> timeWindow(long windowLen,
                                                            TimeUnit windowLenTimeUnit) {
     this.windowParameter = new WindowParameter();
     this.windowParameter.withTumblingDurationWindow(windowLen, windowLenTimeUnit);
     return window("w-duration-tumbling-compute-prev");
   }
 
-  public <P> WindowComputeTSet<P, Iterator<T1>> timeWindow(long windowLen,
+  public <P> WindowComputeTSet<Iterator<T1>, P> timeWindow(long windowLen,
                                                            TimeUnit windowLenTimeUnit,
                                                            long slidingLen,
                                                            TimeUnit slidingWindowTimeUnit) {

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/ops/ComputeCollectorOp.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/ops/ComputeCollectorOp.java
@@ -29,15 +29,15 @@ import edu.iu.dsc.tws.tset.sets.BaseTSet;
  * @param <O> Collector type
  * @param <I> Input message content type
  */
-public class ComputeCollectorOp<O, I> extends BaseComputeOp<I> {
+public class ComputeCollectorOp<I, O> extends BaseComputeOp<I> {
 
-  private ComputeCollectorFunc<O, I> computeFunction;
+  private ComputeCollectorFunc<I, O> computeFunction;
   private RecordCollector<O> output;
 
   public ComputeCollectorOp() {
   }
 
-  public ComputeCollectorOp(ComputeCollectorFunc<O, I> computeFunction, BaseTSet origin,
+  public ComputeCollectorOp(ComputeCollectorFunc<I, O> computeFunction, BaseTSet origin,
                             Map<String, String> receivables) {
     super(origin, receivables);
     this.computeFunction = computeFunction;

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/ops/ComputeCollectorToTupleOp.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/ops/ComputeCollectorToTupleOp.java
@@ -24,14 +24,14 @@ import edu.iu.dsc.tws.api.tset.fn.RecordCollector;
 import edu.iu.dsc.tws.api.tset.fn.TFunction;
 import edu.iu.dsc.tws.tset.sets.BaseTSet;
 
-public class ComputeCollectorToTupleOp<K, O, I> extends BaseComputeOp<I> {
-  private ComputeCollectorFunc<Tuple<K, O>, I> compFunction;
+public class ComputeCollectorToTupleOp<I, K, O> extends BaseComputeOp<I> {
+  private ComputeCollectorFunc<I, Tuple<K, O>> compFunction;
   private RecordCollector<Tuple<K, O>> collector;
 
   public ComputeCollectorToTupleOp() {
   }
 
-  public ComputeCollectorToTupleOp(ComputeCollectorFunc<Tuple<K, O>, I> mapToTupFn,
+  public ComputeCollectorToTupleOp(ComputeCollectorFunc<I, Tuple<K, O>> mapToTupFn,
                                    BaseTSet origin, Map<String, String> receivables) {
     super(origin, receivables);
     this.compFunction = mapToTupFn;

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/ops/ComputeOp.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/ops/ComputeOp.java
@@ -22,14 +22,14 @@ import edu.iu.dsc.tws.tset.sets.BaseTSet;
 /**
  * Performs the compute function on the value received for the imessage and write it to edges
  */
-public class ComputeOp<O, I> extends BaseComputeOp<I> {
+public class ComputeOp<I, O> extends BaseComputeOp<I> {
 
-  private ComputeFunc<O, I> computeFunction;
+  private ComputeFunc<I, O> computeFunction;
 
   public ComputeOp() {
   }
 
-  public ComputeOp(ComputeFunc<O, I> computeFunction, BaseTSet origin,
+  public ComputeOp(ComputeFunc<I, O> computeFunction, BaseTSet origin,
                    Map<String, String> receivables) {
     super(origin, receivables);
     this.computeFunction = computeFunction;

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/ops/ComputeToTupleOp.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/ops/ComputeToTupleOp.java
@@ -21,14 +21,14 @@ import edu.iu.dsc.tws.api.tset.fn.ComputeFunc;
 import edu.iu.dsc.tws.api.tset.fn.TFunction;
 import edu.iu.dsc.tws.tset.sets.BaseTSet;
 
-public class ComputeToTupleOp<K, O, I> extends BaseComputeOp<I> {
-  private ComputeFunc<Tuple<K, O>, I> computeFunc;
+public class ComputeToTupleOp<I, K, O> extends BaseComputeOp<I> {
+  private ComputeFunc<I, Tuple<K, O>> computeFunc;
 
   public ComputeToTupleOp() {
 
   }
 
-  public ComputeToTupleOp(ComputeFunc<Tuple<K, O>, I> computeFn, BaseTSet origin,
+  public ComputeToTupleOp(ComputeFunc<I, Tuple<K, O>> computeFn, BaseTSet origin,
                           Map<String, String> receivables) {
     super(origin, receivables);
     this.computeFunc = computeFn;

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/ops/WindowComputeOp.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/ops/WindowComputeOp.java
@@ -31,7 +31,7 @@ import edu.iu.dsc.tws.task.window.core.BaseWindowedSink;
 import edu.iu.dsc.tws.task.window.util.WindowParameter;
 import edu.iu.dsc.tws.tset.sets.BaseTSet;
 
-public class WindowComputeOp<O, I> extends BaseWindowedSink<I> implements Receptor,
+public class WindowComputeOp<I, O> extends BaseWindowedSink<I> implements Receptor,
     Serializable {
 
   private TSetContext tSetContext = new TSetContext();
@@ -44,16 +44,16 @@ public class WindowComputeOp<O, I> extends BaseWindowedSink<I> implements Recept
 
   private MultiEdgeOpAdapter multiEdgeOpAdapter;
 
-  private ComputeFunc<O, Iterator<I>> computeFunction;
+  private ComputeFunc<Iterator<I>, O> computeFunction;
 
 
-  public WindowComputeOp(ComputeFunc<O, Iterator<I>> computeFunction,
+  public WindowComputeOp(ComputeFunc<Iterator<I>, O> computeFunction,
                          WindowParameter winParam) {
     this.computeFunction = computeFunction;
     this.windowParameter = winParam;
   }
 
-  public WindowComputeOp(ComputeFunc<O, Iterator<I>> computeFunction,
+  public WindowComputeOp(ComputeFunc<Iterator<I>, O> computeFunction,
                          BaseTSet originTSet, Map<String, String> receivables,
                          WindowParameter winParam) {
     this.computeFunction = computeFunction;
@@ -180,7 +180,7 @@ public class WindowComputeOp<O, I> extends BaseWindowedSink<I> implements Recept
     return tSetContext;
   }
 
-  public ComputeFunc<O, Iterator<I>> getFunction() {
+  public ComputeFunc<Iterator<I>, O> getFunction() {
     return computeFunction;
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/ops/row/RowComupteCollectorOp.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/ops/row/RowComupteCollectorOp.java
@@ -34,7 +34,7 @@ import edu.iu.dsc.tws.tset.sets.BaseTSet;
 
 public class RowComupteCollectorOp extends BaseComputeOp<Table> {
 
-  private ComputeCollectorFunc<Row, Iterator<Row>> computeFunction;
+  private ComputeCollectorFunc<Iterator<Row>, Row> computeFunction;
 
   private TableBuilder builder;
 
@@ -57,7 +57,7 @@ public class RowComupteCollectorOp extends BaseComputeOp<Table> {
   public RowComupteCollectorOp() {
   }
 
-  public RowComupteCollectorOp(ComputeCollectorFunc<Row, Iterator<Row>> computeFunction,
+  public RowComupteCollectorOp(ComputeCollectorFunc<Iterator<Row>, Row> computeFunction,
                                BaseTSet origin, Map<String, String> receivables) {
     super(origin, receivables);
     this.computeFunction = computeFunction;

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/ops/row/RowItrComputeCollectorOp.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/ops/row/RowItrComputeCollectorOp.java
@@ -33,7 +33,7 @@ import edu.iu.dsc.tws.tset.ops.BaseComputeOp;
 import edu.iu.dsc.tws.tset.sets.BaseTSet;
 
 public class RowItrComputeCollectorOp extends BaseComputeOp<Iterator<Table>> {
-  private ComputeCollectorFunc<Row, Iterator<Row>> computeFunction;
+  private ComputeCollectorFunc<Iterator<Row>, Row> computeFunction;
 
   private TableBuilder builder;
 
@@ -56,7 +56,7 @@ public class RowItrComputeCollectorOp extends BaseComputeOp<Iterator<Table>> {
   public RowItrComputeCollectorOp() {
   }
 
-  public RowItrComputeCollectorOp(ComputeCollectorFunc<Row, Iterator<Row>> computeFunction,
+  public RowItrComputeCollectorOp(ComputeCollectorFunc<Iterator<Row>, Row> computeFunction,
                                BaseTSet origin, Map<String, String> receivables) {
     super(origin, receivables);
     this.computeFunction = computeFunction;

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/BatchTSetImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/BatchTSetImpl.java
@@ -13,7 +13,6 @@
 package edu.iu.dsc.tws.tset.sets.batch;
 
 import java.util.Collection;
-import java.util.Iterator;
 
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
 import edu.iu.dsc.tws.api.tset.fn.MapFunc;
@@ -123,14 +122,14 @@ public abstract class BatchTSetImpl<T> extends BaseTSetWithSchema<T> implements 
   }
 
   @Override
-  public ComputeTSet<T, Iterator<T>> union(TSet<T> other) {
+  public ComputeTSet<T> union(TSet<T> other) {
 
     if (this.getParallelism() != ((BatchTSetImpl) other).getParallelism()) {
       throw new IllegalStateException("Parallelism of the TSets need to be the same in order to"
           + "perform a union operation");
     }
 
-    ComputeTSet<T, Iterator<T>> unionTSet = direct().compute("union",
+    ComputeTSet<T> unionTSet = direct().compute("union",
         new MapIterCompute<>(new IdentityFunction<>()));
     // now the following relationship is created
     // this -- directThis -- unionTSet
@@ -147,9 +146,9 @@ public abstract class BatchTSetImpl<T> extends BaseTSetWithSchema<T> implements 
   }
 
   @Override
-  public ComputeTSet<T, Iterator<T>> union(Collection<TSet<T>> tSets) {
+  public ComputeTSet<T> union(Collection<TSet<T>> tSets) {
 
-    ComputeTSet<T, Iterator<T>> unionTSet = direct().compute("union",
+    ComputeTSet<T> unionTSet = direct().compute("union",
         new MapIterCompute<>(new IdentityFunction<>()));
     // now the following relationship is created
     // this -- directThis -- unionTSet

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/BatchTSetImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/BatchTSetImpl.java
@@ -118,7 +118,7 @@ public abstract class BatchTSetImpl<T> extends BaseTSetWithSchema<T> implements 
 
   // todo: remove this direct() --> would be more efficient. can handle at the context write level
   @Override
-  public <K, V> KeyedTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T> mapToTupleFn) {
+  public <K, V> KeyedTSet<K, V> mapToTuple(MapFunc<T, Tuple<K, V>> mapToTupleFn) {
     return direct().mapToTuple(mapToTupleFn);
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/ComputeTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/ComputeTSet.java
@@ -22,59 +22,59 @@ import edu.iu.dsc.tws.tset.env.BatchEnvironment;
 import edu.iu.dsc.tws.tset.ops.ComputeCollectorOp;
 import edu.iu.dsc.tws.tset.ops.ComputeOp;
 
-public class ComputeTSet<O, I> extends BatchTSetImpl<O> {
-  private TFunction<I, O> computeFunc;
+public class ComputeTSet<O> extends BatchTSetImpl<O> {
+  private TFunction<?, O> computeFunc;
 
   public ComputeTSet() {
     //non arg constructor needed for kryo
     super();
   }
 
-  public ComputeTSet(BatchEnvironment tSetEnv, ComputeFunc<I, O> computeFn,
+  public ComputeTSet(BatchEnvironment tSetEnv, ComputeFunc<?, O> computeFn,
                      int parallelism, Schema inputSchema) {
     this(tSetEnv, "compute", computeFn, parallelism, inputSchema);
   }
 
-  public ComputeTSet(BatchEnvironment tSetEnv, ComputeCollectorFunc<I, O> computeFn,
+  public ComputeTSet(BatchEnvironment tSetEnv, ComputeCollectorFunc<?, O> computeFn,
                      int parallelism, Schema inputSchema) {
     this(tSetEnv, "computec", computeFn, parallelism, inputSchema);
   }
 
-  public ComputeTSet(BatchEnvironment tSetEnv, String name, ComputeFunc<I, O> computeFn,
+  public ComputeTSet(BatchEnvironment tSetEnv, String name, ComputeFunc<?, O> computeFn,
                      int parallelism, Schema inputSchema) {
     super(tSetEnv, name, parallelism, inputSchema);
     this.computeFunc = computeFn;
   }
 
   public ComputeTSet(BatchEnvironment tSetEnv, String name,
-                     ComputeCollectorFunc<I, O> computeFn, int parallelism, Schema inputSchema) {
+                     ComputeCollectorFunc<?, O> computeFn, int parallelism, Schema inputSchema) {
     super(tSetEnv, name, parallelism, inputSchema);
     this.computeFunc = computeFn;
   }
 
   @Override
-  public ComputeTSet<O, I> setName(String name) {
+  public ComputeTSet<O> setName(String name) {
     rename(name);
     return this;
   }
 
   @Override
-  public ComputeTSet<O, I> addInput(String key, StorableTBase<?> input) {
-    return (ComputeTSet<O, I>) super.addInput(key, input);
+  public ComputeTSet<O> addInput(String key, StorableTBase<?> input) {
+    return (ComputeTSet<O>) super.addInput(key, input);
   }
 
   @Override
-  public ComputeTSet<O, I> withSchema(Schema schema) {
-    return (ComputeTSet<O, I>) super.withSchema(schema);
+  public ComputeTSet<O> withSchema(Schema schema) {
+    return (ComputeTSet<O>) super.withSchema(schema);
   }
 
   @Override
-  public ICompute<I> getINode() {
+  public ICompute<?> getINode() {
 
     if (computeFunc instanceof ComputeFunc) {
-      return new ComputeOp<>((ComputeFunc<I, O>) computeFunc, this, getInputs());
+      return new ComputeOp<>((ComputeFunc<?, O>) computeFunc, this, getInputs());
     } else if (computeFunc instanceof ComputeCollectorFunc) {
-      return new ComputeCollectorOp<>((ComputeCollectorFunc<I, O>) computeFunc, this,
+      return new ComputeCollectorOp<>((ComputeCollectorFunc<?, O>) computeFunc, this,
           getInputs());
     }
 
@@ -86,7 +86,7 @@ public class ComputeTSet<O, I> extends BatchTSetImpl<O> {
    *
    * @return the compute function
    */
-  public TFunction<I, O> getComputeFunc() {
+  public TFunction<?, O> getComputeFunc() {
     return computeFunc;
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/ComputeTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/ComputeTSet.java
@@ -23,31 +23,31 @@ import edu.iu.dsc.tws.tset.ops.ComputeCollectorOp;
 import edu.iu.dsc.tws.tset.ops.ComputeOp;
 
 public class ComputeTSet<O, I> extends BatchTSetImpl<O> {
-  private TFunction<O, I> computeFunc;
+  private TFunction<I, O> computeFunc;
 
   public ComputeTSet() {
     //non arg constructor needed for kryo
     super();
   }
 
-  public ComputeTSet(BatchEnvironment tSetEnv, ComputeFunc<O, I> computeFn,
+  public ComputeTSet(BatchEnvironment tSetEnv, ComputeFunc<I, O> computeFn,
                      int parallelism, Schema inputSchema) {
     this(tSetEnv, "compute", computeFn, parallelism, inputSchema);
   }
 
-  public ComputeTSet(BatchEnvironment tSetEnv, ComputeCollectorFunc<O, I> computeFn,
+  public ComputeTSet(BatchEnvironment tSetEnv, ComputeCollectorFunc<I, O> computeFn,
                      int parallelism, Schema inputSchema) {
     this(tSetEnv, "computec", computeFn, parallelism, inputSchema);
   }
 
-  public ComputeTSet(BatchEnvironment tSetEnv, String name, ComputeFunc<O, I> computeFn,
+  public ComputeTSet(BatchEnvironment tSetEnv, String name, ComputeFunc<I, O> computeFn,
                      int parallelism, Schema inputSchema) {
     super(tSetEnv, name, parallelism, inputSchema);
     this.computeFunc = computeFn;
   }
 
   public ComputeTSet(BatchEnvironment tSetEnv, String name,
-                     ComputeCollectorFunc<O, I> computeFn, int parallelism, Schema inputSchema) {
+                     ComputeCollectorFunc<I, O> computeFn, int parallelism, Schema inputSchema) {
     super(tSetEnv, name, parallelism, inputSchema);
     this.computeFunc = computeFn;
   }
@@ -72,9 +72,9 @@ public class ComputeTSet<O, I> extends BatchTSetImpl<O> {
   public ICompute<I> getINode() {
 
     if (computeFunc instanceof ComputeFunc) {
-      return new ComputeOp<>((ComputeFunc<O, I>) computeFunc, this, getInputs());
+      return new ComputeOp<>((ComputeFunc<I, O>) computeFunc, this, getInputs());
     } else if (computeFunc instanceof ComputeCollectorFunc) {
-      return new ComputeCollectorOp<>((ComputeCollectorFunc<O, I>) computeFunc, this,
+      return new ComputeCollectorOp<>((ComputeCollectorFunc<I, O>) computeFunc, this,
           getInputs());
     }
 
@@ -86,7 +86,7 @@ public class ComputeTSet<O, I> extends BatchTSetImpl<O> {
    *
    * @return the compute function
    */
-  public TFunction<O, I> getComputeFunc() {
+  public TFunction<I, O> getComputeFunc() {
     return computeFunc;
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/KeyedTSet.java
@@ -32,7 +32,7 @@ import edu.iu.dsc.tws.tset.ops.ComputeToTupleOp;
  * @param <V> data (value) type
  */
 public class KeyedTSet<K, V> extends BatchTupleTSetImpl<K, V> {
-  private TFunction<Tuple<K, V>, ?> mapToTupleFunc;
+  private TFunction<?, Tuple<K, V>> mapToTupleFunc;
 
   private KeyedTSet() {
     //non arg constructor for kryo
@@ -43,7 +43,7 @@ public class KeyedTSet<K, V> extends BatchTupleTSetImpl<K, V> {
    * {@link edu.iu.dsc.tws.api.tset.link.TLink}. Hence the input schema is a not a
    * {@link KeyedSchema}
    */
-  public KeyedTSet(BatchEnvironment tSetEnv, TFunction<Tuple<K, V>, ?> mapFunc,
+  public KeyedTSet(BatchEnvironment tSetEnv, TFunction<?, Tuple<K, V>> mapFunc,
                    int parallelism, Schema inputSchema) {
     super(tSetEnv, "keyed", parallelism, inputSchema);
     this.mapToTupleFunc = mapFunc;
@@ -63,10 +63,10 @@ public class KeyedTSet<K, V> extends BatchTupleTSetImpl<K, V> {
   public ICompute getINode() {
 
     if (mapToTupleFunc instanceof ComputeFunc) {
-      return new ComputeToTupleOp<>((ComputeFunc<Tuple<K, V>, ?>) mapToTupleFunc, this,
+      return new ComputeToTupleOp<>((ComputeFunc<?, Tuple<K, V>>) mapToTupleFunc, this,
           getInputs());
     } else if (mapToTupleFunc instanceof ComputeCollectorFunc) {
-      return new ComputeCollectorToTupleOp<>((ComputeCollectorFunc<Tuple<K, V>, ?>) mapToTupleFunc,
+      return new ComputeCollectorToTupleOp<>((ComputeCollectorFunc<?, Tuple<K, V>>) mapToTupleFunc,
           this, getInputs());
     }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/StoredTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/StoredTSet.java
@@ -15,7 +15,6 @@ package edu.iu.dsc.tws.tset.sets.batch;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 
 import edu.iu.dsc.tws.api.comms.structs.Tuple;
@@ -124,12 +123,12 @@ public abstract class StoredTSet<T> extends BatchTSetImpl<T> implements Storable
   }
 
   @Override
-  public ComputeTSet<T, Iterator<T>> union(TSet<T> other) {
+  public ComputeTSet<T> union(TSet<T> other) {
     throw new UnsupportedOperationException("Union on StoredTSet is not supported");
   }
 
   @Override
-  public ComputeTSet<T, Iterator<T>> union(Collection<TSet<T>> tSets) {
+  public ComputeTSet<T> union(Collection<TSet<T>> tSets) {
     throw new UnsupportedOperationException("Union on StoredTSet is not supported");
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/StoredTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/StoredTSet.java
@@ -109,7 +109,7 @@ public abstract class StoredTSet<T> extends BatchTSetImpl<T> implements Storable
   }
 
   @Override
-  public <K, V> KeyedTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T> generateTuple) {
+  public <K, V> KeyedTSet<K, V> mapToTuple(MapFunc<T, Tuple<K, V>> generateTuple) {
     return getStoredSourceTSet().mapToTuple(generateTuple);
   }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/row/RowComputeTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/batch/row/RowComputeTSet.java
@@ -23,17 +23,17 @@ import edu.iu.dsc.tws.tset.ops.row.RowComupteCollectorOp;
 import edu.iu.dsc.tws.tset.ops.row.RowItrComputeCollectorOp;
 
 public class RowComputeTSet extends BatchRowTSetImpl {
-  private TFunction<Row, Iterator<Row>> computeFunc;
+  private TFunction<Iterator<Row>, Row> computeFunc;
   private boolean iterative;
 
   public RowComputeTSet(BatchEnvironment tSetEnv,
-                        ComputeCollectorFunc<Row, Iterator<Row>> computeFn, int parallelism,
+                        ComputeCollectorFunc<Iterator<Row>, Row> computeFn, int parallelism,
                         RowSchema inputSchema, boolean iterative) {
     this(tSetEnv, "computec", computeFn, parallelism, inputSchema, iterative);
   }
 
   public RowComputeTSet(BatchEnvironment tSetEnv, String name,
-                        ComputeCollectorFunc<Row, Iterator<Row>> computeFn,
+                        ComputeCollectorFunc<Iterator<Row>, Row> computeFn,
                         int parallelism, RowSchema inputSchema, boolean iterative) {
     super(tSetEnv, name, parallelism, inputSchema);
     this.computeFunc = computeFn;
@@ -44,10 +44,10 @@ public class RowComputeTSet extends BatchRowTSetImpl {
   public INode getINode() {
     if (computeFunc instanceof ComputeCollectorFunc) {
       if (!iterative) {
-        return new RowComupteCollectorOp((ComputeCollectorFunc<Row, Iterator<Row>>) computeFunc,
+        return new RowComupteCollectorOp((ComputeCollectorFunc<Iterator<Row>, Row>) computeFunc,
             this, getInputs());
       } else {
-        return new RowItrComputeCollectorOp((ComputeCollectorFunc<Row, Iterator<Row>>) computeFunc,
+        return new RowItrComputeCollectorOp((ComputeCollectorFunc<Iterator<Row>, Row>) computeFunc,
             this, getInputs());
       }
     }
@@ -60,7 +60,7 @@ public class RowComputeTSet extends BatchRowTSetImpl {
    *
    * @return the compute function
    */
-  public TFunction<Row, Iterator<Row>> getComputeFunc() {
+  public TFunction<Iterator<Row>, Row> getComputeFunc() {
     return computeFunc;
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SComputeTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SComputeTSet.java
@@ -24,26 +24,26 @@ import edu.iu.dsc.tws.tset.ops.ComputeCollectorOp;
 import edu.iu.dsc.tws.tset.ops.ComputeOp;
 
 public class SComputeTSet<O, I> extends StreamingTSetImpl<O> {
-  private TFunction<O, I> computeFunc;
+  private TFunction<I, O> computeFunc;
 
-  public SComputeTSet(StreamingEnvironment tSetEnv, ComputeFunc<O, I> computeFunction,
+  public SComputeTSet(StreamingEnvironment tSetEnv, ComputeFunc<I, O> computeFunction,
                       int parallelism, Schema inputSchema) {
     this(tSetEnv, "scompute", computeFunction, parallelism, inputSchema);
   }
 
-  public SComputeTSet(StreamingEnvironment tSetEnv, ComputeCollectorFunc<O, I> compOp,
+  public SComputeTSet(StreamingEnvironment tSetEnv, ComputeCollectorFunc<I, O> compOp,
                       int parallelism, Schema inputSchema) {
     this(tSetEnv, "scomputec", compOp, parallelism, inputSchema);
   }
 
   public SComputeTSet(StreamingEnvironment tSetEnv, String name,
-                      ComputeFunc<O, I> computeFunction, int parallelism, Schema inputSchema) {
+                      ComputeFunc<I, O> computeFunction, int parallelism, Schema inputSchema) {
     super(tSetEnv, name, parallelism, inputSchema);
     this.computeFunc = computeFunction;
   }
 
   public SComputeTSet(StreamingEnvironment tSetEnv, String name,
-                      ComputeCollectorFunc<O, I> compOp, int parallelism, Schema inputSchema) {
+                      ComputeCollectorFunc<I, O> compOp, int parallelism, Schema inputSchema) {
     super(tSetEnv, name, parallelism, inputSchema);
     this.computeFunc = compOp;
   }
@@ -63,10 +63,10 @@ public class SComputeTSet<O, I> extends StreamingTSetImpl<O> {
   public ICompute<I> getINode() {
     // todo: fix empty map
     if (computeFunc instanceof ComputeFunc) {
-      return new ComputeOp<>((ComputeFunc<O, I>) computeFunc, this,
+      return new ComputeOp<>((ComputeFunc<I, O>) computeFunc, this,
           Collections.emptyMap());
     } else if (computeFunc instanceof ComputeCollectorFunc) {
-      return new ComputeCollectorOp<>((ComputeCollectorFunc<O, I>) computeFunc, this,
+      return new ComputeCollectorOp<>((ComputeCollectorFunc<I, O>) computeFunc, this,
           Collections.emptyMap());
     }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SComputeTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SComputeTSet.java
@@ -23,50 +23,50 @@ import edu.iu.dsc.tws.tset.env.StreamingEnvironment;
 import edu.iu.dsc.tws.tset.ops.ComputeCollectorOp;
 import edu.iu.dsc.tws.tset.ops.ComputeOp;
 
-public class SComputeTSet<O, I> extends StreamingTSetImpl<O> {
-  private TFunction<I, O> computeFunc;
+public class SComputeTSet<O> extends StreamingTSetImpl<O> {
+  private final TFunction<?, O> computeFunc;
 
-  public SComputeTSet(StreamingEnvironment tSetEnv, ComputeFunc<I, O> computeFunction,
+  public SComputeTSet(StreamingEnvironment tSetEnv, ComputeFunc<?, O> computeFunction,
                       int parallelism, Schema inputSchema) {
     this(tSetEnv, "scompute", computeFunction, parallelism, inputSchema);
   }
 
-  public SComputeTSet(StreamingEnvironment tSetEnv, ComputeCollectorFunc<I, O> compOp,
+  public SComputeTSet(StreamingEnvironment tSetEnv, ComputeCollectorFunc<?, O> compOp,
                       int parallelism, Schema inputSchema) {
     this(tSetEnv, "scomputec", compOp, parallelism, inputSchema);
   }
 
   public SComputeTSet(StreamingEnvironment tSetEnv, String name,
-                      ComputeFunc<I, O> computeFunction, int parallelism, Schema inputSchema) {
+                      ComputeFunc<?, O> computeFunction, int parallelism, Schema inputSchema) {
     super(tSetEnv, name, parallelism, inputSchema);
     this.computeFunc = computeFunction;
   }
 
   public SComputeTSet(StreamingEnvironment tSetEnv, String name,
-                      ComputeCollectorFunc<I, O> compOp, int parallelism, Schema inputSchema) {
+                      ComputeCollectorFunc<?, O> compOp, int parallelism, Schema inputSchema) {
     super(tSetEnv, name, parallelism, inputSchema);
     this.computeFunc = compOp;
   }
 
   @Override
-  public SComputeTSet<O, I> setName(String name) {
+  public SComputeTSet<O> setName(String name) {
     rename(name);
     return this;
   }
 
   @Override
-  public SComputeTSet<O, I> withSchema(Schema schema) {
-    return (SComputeTSet<O, I>) super.withSchema(schema);
+  public SComputeTSet<O> withSchema(Schema schema) {
+    return (SComputeTSet<O>) super.withSchema(schema);
   }
 
   @Override
-  public ICompute<I> getINode() {
+  public ICompute<?> getINode() {
     // todo: fix empty map
     if (computeFunc instanceof ComputeFunc) {
-      return new ComputeOp<>((ComputeFunc<I, O>) computeFunc, this,
+      return new ComputeOp<>((ComputeFunc<?, O>) computeFunc, this,
           Collections.emptyMap());
     } else if (computeFunc instanceof ComputeCollectorFunc) {
-      return new ComputeCollectorOp<>((ComputeCollectorFunc<I, O>) computeFunc, this,
+      return new ComputeCollectorOp<>((ComputeCollectorFunc<?, O>) computeFunc, this,
           Collections.emptyMap());
     }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SKeyedTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/SKeyedTSet.java
@@ -34,9 +34,9 @@ import edu.iu.dsc.tws.tset.ops.ComputeToTupleOp;
  * @param <V> data (value) type
  */
 public class SKeyedTSet<K, V> extends StreamingTupleTSetImpl<K, V> {
-  private TFunction<Tuple<K, V>, ?> mapToTupleFunc;
+  private TFunction<?, Tuple<K, V>> mapToTupleFunc;
 
-  public SKeyedTSet(StreamingEnvironment tSetEnv, TFunction<Tuple<K, V>, ?> mapFn,
+  public SKeyedTSet(StreamingEnvironment tSetEnv, TFunction<?, Tuple<K, V>> mapFn,
                     int parallelism, Schema inputSchema) {
     super(tSetEnv, "skeyed", parallelism, inputSchema);
     this.mapToTupleFunc = mapFn;
@@ -57,13 +57,13 @@ public class SKeyedTSet<K, V> extends StreamingTupleTSetImpl<K, V> {
   public ICompute getINode() {
 
     if (mapToTupleFunc instanceof MapCompute) {
-      return new ComputeToTupleOp<>((MapCompute<Tuple<K, V>, ?>) mapToTupleFunc, this,
+      return new ComputeToTupleOp<>((MapCompute<?, Tuple<K, V>>) mapToTupleFunc, this,
           Collections.emptyMap());
     } else if (mapToTupleFunc instanceof MapIterCompute) {
-      return new ComputeCollectorToTupleOp<>((MapIterCompute<Tuple<K, V>, ?>) mapToTupleFunc, this,
+      return new ComputeCollectorToTupleOp<>((MapIterCompute<?, Tuple<K, V>>) mapToTupleFunc, this,
           Collections.emptyMap());
     } else if (mapToTupleFunc instanceof GatherMapCompute) {
-      return new ComputeCollectorToTupleOp<>((GatherMapCompute<Tuple<K, V>, ?>) mapToTupleFunc,
+      return new ComputeCollectorToTupleOp<>((GatherMapCompute<?, Tuple<K, V>>) mapToTupleFunc,
           this, Collections.emptyMap());
     }
 

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/StreamingTSetImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/StreamingTSetImpl.java
@@ -112,14 +112,14 @@ public abstract class StreamingTSetImpl<T> extends BaseTSetWithSchema<T> impleme
   }
 
   @Override
-  public SComputeTSet<T, T> union(TSet<T> other) {
+  public SComputeTSet<T> union(TSet<T> other) {
 
     if (this.getParallelism() != ((StreamingTSetImpl) other).getParallelism()) {
       throw new IllegalStateException("Parallelism of the TSets need to be the same in order to"
           + "perform a union operation");
     }
 
-    SComputeTSet<T, T> union = direct().compute("sunion",
+    SComputeTSet<T> union = direct().compute("sunion",
         new MapCompute<>((MapFunc<T, T>) input -> input));
     // now the following relationship is created
     // this -- directThis -- unionTSet
@@ -136,8 +136,8 @@ public abstract class StreamingTSetImpl<T> extends BaseTSetWithSchema<T> impleme
   }
 
   @Override
-  public SComputeTSet<T, T> union(Collection<TSet<T>> tSets) {
-    SComputeTSet<T, T> union = direct().compute("sunion",
+  public SComputeTSet<T> union(Collection<TSet<T>> tSets) {
+    SComputeTSet<T> union = direct().compute("sunion",
         new MapCompute<>((MapFunc<T, T>) input -> input));
     // now the following relationship is created
     // this -- directThis -- unionTSet

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/StreamingTSetImpl.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/StreamingTSetImpl.java
@@ -156,7 +156,7 @@ public abstract class StreamingTSetImpl<T> extends BaseTSetWithSchema<T> impleme
   }
 
   @Override
-  public <K, V> SKeyedTSet<K, V> mapToTuple(MapFunc<Tuple<K, V>, T> mapToTupleFn) {
+  public <K, V> SKeyedTSet<K, V> mapToTuple(MapFunc<T, Tuple<K, V>> mapToTupleFn) {
     return direct().mapToTuple(mapToTupleFn);
 //    throw new UnsupportedOperationException("Groupby is not avilable in streaming operations");
   }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/WindowComputeTSet.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sets/streaming/WindowComputeTSet.java
@@ -35,8 +35,8 @@ import edu.iu.dsc.tws.tset.ops.WindowComputeOp;
  * @param <O> Output type of TSet
  * @param <I> Input Type of TSet
  */
-public class WindowComputeTSet<O, I> extends StreamingTSetImpl<O> {
-  private TFunction<O, I> computeFunc;
+public class WindowComputeTSet<I, O> extends StreamingTSetImpl<O> {
+  private TFunction<I, O> computeFunc;
 
   private WindowParameter windowParameter;
 
@@ -78,7 +78,7 @@ public class WindowComputeTSet<O, I> extends StreamingTSetImpl<O> {
 //  }
 
   @Override
-  public WindowComputeTSet<O, I> setName(String name) {
+  public WindowComputeTSet<I, O> setName(String name) {
     rename(name);
     return this;
   }
@@ -88,14 +88,14 @@ public class WindowComputeTSet<O, I> extends StreamingTSetImpl<O> {
   public ICompute<I> getINode() {
     // todo: fix empty map (will have to handle inputs to window functions)
     if (computeFunc instanceof ComputeFunc) {
-      return new WindowComputeOp<>((ComputeFunc<O, Iterator<I>>) computeFunc, this,
+      return new WindowComputeOp<>((ComputeFunc<Iterator<I>, O>) computeFunc, this,
           Collections.emptyMap(), windowParameter);
     } else {
       throw new RuntimeException("Unknown function type for window compute: " + computeFunc);
     }
   }
 
-  public WindowComputeTSet<O, I> process(WindowComputeFunc<O, I> processFunction) {
+  public WindowComputeTSet<I, O> process(WindowComputeFunc<I, O> processFunction) {
     if (this.computeFunc == null) {
       this.computeFunc = processFunction;
       return this;
@@ -111,9 +111,9 @@ public class WindowComputeTSet<O, I> extends StreamingTSetImpl<O> {
    * @param aggregateFunction reduce function definition
    * @return reduced value of type O
    */
-  public WindowComputeTSet<O, I> aggregate(AggregateFunc<O> aggregateFunction) {
+  public WindowComputeTSet<I, O> aggregate(AggregateFunc<O> aggregateFunction) {
 
-    this.process(new WindowComputeFunc<O, I>() {
+    this.process(new WindowComputeFunc<I, O>() {
       @Override
       public O compute(I input) {
         O initial = null;
@@ -136,7 +136,7 @@ public class WindowComputeTSet<O, I> extends StreamingTSetImpl<O> {
     return this;
   }
 
-  public WindowComputeTSet<O, I> withSchema(Schema schema) {
-    return (WindowComputeTSet<O, I>) super.withSchema(schema);
+  public WindowComputeTSet<I, O> withSchema(Schema schema) {
+    return (WindowComputeTSet<I, O>) super.withSchema(schema);
   }
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/sources/HadoopSourceWithMap.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/sources/HadoopSourceWithMap.java
@@ -88,10 +88,10 @@ public class HadoopSourceWithMap<K, V, F extends InputFormat<K, V>, I>
   /**
    * Map function
    */
-  private MapFunc<I, Tuple<K, V>> mapFunc;
+  private MapFunc<Tuple<K, V>, I> mapFunc;
 
   public HadoopSourceWithMap(Configuration conf, Class<F> inputClazz,
-                             MapFunc<I, Tuple<K, V>> mapFunc) {
+                             MapFunc<Tuple<K, V>, I> mapFunc) {
     this.inputClazz = inputClazz;
     this.wrappedConfiguration = new HadoopConfSerializeWrapper(conf);
     this.mapFunc = mapFunc;


### PR DESCRIPTION
1. Swapping the generics order in TSets 
Previously TSets functions had generics as <O, I>. It is changed to <I, O>. (I= input type, O=output type). This is more in-line with other frameworks like Spark. 

2. Removed Input type generic from ComputeTsets. Previously the signature was `ComputeTSet<O, I>`. But input types do not serve any purpose for a TSet, because no subsequent communication operations, do not care how that TSet was created. So, the new signature was changed to `ComputeTSet<O>` that only follows output type. Same logic follows for `SComputeTSet<O>`, `KeyedTSet<K, V>` and `SKeyedTSet<K, V>`. 
