### PR TITLE
Ahmet/small fixes

### DIFF
--- a/docker/kubernetes/baseimage-j11/build-push.sh
+++ b/docker/kubernetes/baseimage-j11/build-push.sh
@@ -5,7 +5,7 @@ VERSION="0.8.0-SNAPSHOT"
 TWISTER2_BASE_IMAGE="twister2/twister2-k8s-base-j11"
 
 # build docker image
-docker build -t $TWISTER2_BASE_IMAGE":"${VERSION} -f Dockerfile .
+docker build -t ${TWISTER2_BASE_IMAGE}:${VERSION} -f Dockerfile .
 
 # check whether image build successful
 return_code=$?
@@ -16,4 +16,4 @@ fi
 
 # push image to Dockerhub
 echo "Pusing the image to Docker hub ..."
-docker push $TWISTER2_BASE_IMAGE
+docker push ${TWISTER2_BASE_IMAGE}:${VERSION}

--- a/docker/kubernetes/baseimage/build-push.sh
+++ b/docker/kubernetes/baseimage/build-push.sh
@@ -5,7 +5,7 @@ VERSION="0.8.0-SNAPSHOT"
 TWISTER2_BASE_IMAGE="twister2/twister2-k8s-base"
 
 # build docker image
-docker build -t $TWISTER2_BASE_IMAGE":"${VERSION} -f Dockerfile .
+docker build -t ${TWISTER2_BASE_IMAGE}:${VERSION} -f Dockerfile .
 
 # check whether image build successful
 return_code=$?
@@ -16,4 +16,4 @@ fi
 
 # push image to Dockerhub
 echo "Pusing the image to Docker hub ..."
-docker push $TWISTER2_BASE_IMAGE
+docker push ${TWISTER2_BASE_IMAGE}:${VERSION}

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/faulttolerance/FaultToleranceContext.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/faulttolerance/FaultToleranceContext.java
@@ -30,9 +30,10 @@ public class FaultToleranceContext extends Context {
   public static final String MAX_WORKER_RESTARTS = "twister2.fault.tolerance.max.worker.restarts";
   public static final int MAX_WORKER_RESTARTS_DEFAULT = 5;
 
-  // maximum number of times to re-start mpi jobs in vase of failures
+  // maximum number of times to re-start mpi jobs in case of failures
+  // by default it is 1. We do not resubmit failed mpi jobs
   public static final String MAX_MPIJOB_RESTARTS = "twister2.fault.tolerance.max.mpijob.restarts";
-  public static final int MAX_MPIJOB_RESTARTS_DEFAULT = 3;
+  public static final int MAX_MPIJOB_RESTARTS_DEFAULT = 1;
 
   public static int sessionTimeout(Config cfg) {
     return cfg.getIntegerValue(FAILURE_TIMEOUT, FAILURE_TIMEOUT_DEFAULT);

--- a/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/client/CheckpointingClientImpl.java
+++ b/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/client/CheckpointingClientImpl.java
@@ -47,8 +47,6 @@ public final class CheckpointingClientImpl implements MessageHandler, Checkpoint
 
   private static final Logger LOG = Logger.getLogger(CheckpointingClientImpl.class.getName());
 
-  public static final String CONFIG_WAIT_TIME = "twister2.checkpointing.request.timeout";
-
   private RRClient rrClient;
   private long waitTime;
   private Map<RequestID, Message> blockingResponse = new ConcurrentHashMap<>();

--- a/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/util/CheckpointingContext.java
+++ b/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/util/CheckpointingContext.java
@@ -22,6 +22,10 @@ public final class CheckpointingContext {
   public static final String CHECKPOINTING_SOURCE_FREQUNCY
       = "twister2.checkpointing.source.frequency";
 
+  // by default 600 seconds
+  public static final int REQUEST_TIMEOUT_DEFAULT = 600;
+  public static final String REQUEST_TIMEOUT = "twister2.checkpointing.request.timeout";
+
   public static final String CHECKPOINTING_RESTORE_JOB = "twister2.checkpointing.restore.job";
 
   private CheckpointingContext() {
@@ -43,6 +47,10 @@ public final class CheckpointingContext {
 
   public static long getCheckPointingFrequency(Config config) {
     return config.getLongValue(CHECKPOINTING_SOURCE_FREQUNCY, 1000);
+  }
+
+  public static long getRequestTimeout(Config config) {
+    return 1000L * config.getIntegerValue(REQUEST_TIMEOUT, REQUEST_TIMEOUT_DEFAULT);
   }
 
   //todo: can checkpointing data be saved to nfs even above parameter is LocalFileStateStore

--- a/twister2/config/src/yaml/conf/common/checkpoint.yaml
+++ b/twister2/config/src/yaml/conf/common/checkpoint.yaml
@@ -12,10 +12,12 @@ twister2.checkpointing.store.fs.dir: "${TWISTER2_HOME}/persistent/"
 twister2.checkpointing.store.hdfs.dir: "/twister2/persistent/"
 
 # Source triggering frequency
-twister2.checkpointing.source.frequency: 1000
+# in milliseconds
+# twister2.checkpointing.source.frequency: 1000
 
 # Checkpointing message request timeout
-twister2.checkpointing.request.timeout: 10000
+# in seconds
+# twister2.checkpointing.request.timeout: 600
 
 ###################################################################
 # Fault Tolerance configurations
@@ -24,16 +26,17 @@ twister2.checkpointing.request.timeout: 10000
 # a timeout value to determine whether a worker failed
 # If a worker does not send heartbeat messages for this duration in milli seconds,
 # It is assumed failed
-twister2.fault.tolerance.failure.timeout: 10000
+# by default it is 10 seconds
+# twister2.fault.tolerance.failure.timeout: 10000
 
 # maximum number of times to re-execute IWorker after some other workers failed in the job
 # default value is 5
-twister2.fault.tolerance.max.reexecutes: 5
+# twister2.fault.tolerance.max.reexecutes: 5
 
 # maximum number of times to re-start a worker from JVM
 # default value is 5
-twister2.fault.tolerance.max.worker.restarts: 5
+# twister2.fault.tolerance.max.worker.restarts: 5
 
 # maximum number of times to re-start mpi jobs in case of failures
-# default value is 3
-twister2.fault.tolerance.max.mpijob.restarts: 1
+# default value is 1
+# twister2.fault.tolerance.max.mpijob.restarts: 1

--- a/twister2/config/src/yaml/conf/common/checkpoint.yaml
+++ b/twister2/config/src/yaml/conf/common/checkpoint.yaml
@@ -36,4 +36,4 @@ twister2.fault.tolerance.max.worker.restarts: 5
 
 # maximum number of times to re-start mpi jobs in case of failures
 # default value is 3
-twister2.fault.tolerance.max.mpijob.restarts: 3
+twister2.fault.tolerance.max.mpijob.restarts: 1

--- a/twister2/config/src/yaml/conf/common/core.yaml
+++ b/twister2/config/src/yaml/conf/common/core.yaml
@@ -21,16 +21,20 @@
 # Twister2 Job Master related settings
 ###################################################################
 
-twister2.job.master.used: true
+# by default, job master is used
+# twister2.job.master.used: true
 
 # if true, the job master runs in the submitting client
 # if false, job master runs as a separate process in the cluster
-# by default, it is true
 # when the job master runs in the submitting client,
-#  this client has to be submitting the job from a machine in the cluster
-twister2.job.master.runs.in.client: true
+# Twister2 client has to be submitting the job from a machine in the cluster
+# by default, it is false
+# twister2.job.master.runs.in.client: false
 
-twister2.worker.to.job.master.response.wait.duration: 100000
+# the amount of time workers will wait for a response from Job Master
+# for request/response messages
+# by default, it is 100000ms (100 seconds)
+# twister2.worker.to.job.master.response.wait.duration: 100000
 
 ###################################################################################
 # WorkerController related config parameters

--- a/twister2/config/src/yaml/conf/common/core.yaml
+++ b/twister2/config/src/yaml/conf/common/core.yaml
@@ -42,17 +42,18 @@
 
 # amount of timeout for all workers to join the job
 # in milli seconds
-twister2.worker.controller.max.wait.time.for.all.workers.to.join: 100000
+# by default it is 100000 ms (100 seconds)
+# twister2.worker.controller.max.wait.time.for.all.workers.to.join: 100000
 
 # maximum amount of timeout to wait on default barrier for all workers to arrive
 # in milli seconds
-# default is 100 seconds
-twister2.worker.controller.max.wait.time.on.barrier: 100000
+# by default, it is 100 seconds
+# twister2.worker.controller.max.wait.time.on.barrier: 100000
 
 # maximum amount of timeout to wait on init barrier for all workers to arrive
 # in milli seconds
-# default is 10 minutes
-twister2.worker.controller.max.wait.time.on.init.barrier: 600000
+# by default, it is 10 minutes
+# twister2.worker.controller.max.wait.time.on.init.barrier: 600000
 
 ###################################################################################
 # Common thread pool config parameters

--- a/twister2/config/src/yaml/conf/kubernetes/core.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/core.yaml
@@ -6,7 +6,7 @@
 # By default, it is %80
 # If memory based volume is used more, or
 # you want to give OpenMPI or UCX more memory, this can be decreased.
-twister2.kubernetes.jvm.memory.fraction: 0.8
+# twister2.kubernetes.jvm.memory.fraction: 0.8
 
 ###################################################################
 # Twister2 Job Master related settings
@@ -14,7 +14,7 @@ twister2.kubernetes.jvm.memory.fraction: 0.8
 
 # if true, the job master runs in the submitting client
 # if false, job master runs as a separate process in the cluster 
-# by default, it is true
+# by default, it is false
 # when the job master runs in the submitting client,
 # this client has to be submitting the job from a machine in the cluster
 # getLocalHost must return a reachable IP address to the job master
@@ -22,30 +22,30 @@ twister2.job.master.runs.in.client: false
 
 # twister2 job master port number
 # default value is 11011
-twister2.job.master.port: 11011
+# twister2.job.master.port: 11011
 
 # worker to job master response wait time in milliseconds
 # this is for messages that wait for a response from the job master
 # default value is 10seconds = 10000
-twister2.worker.to.job.master.response.wait.duration: 10000
+# twister2.worker.to.job.master.response.wait.duration: 10000
 
 # twister2 job master volatile volume size in GB
-# default value is 1.0 Gi
+# default value is 0.0 Gi
 # if this value is 0, volatile volume is not setup for job master
-twister2.job.master.volatile.volume.size: 0.0
+# twister2.job.master.volatile.volume.size: 0.0
 
 # twister2 job master persistent volume size in GB
-# default value is 1.0 Gi
+# default value is 0.0 Gi
 # if this value is 0, persistent volume is not setup for job master
-twister2.job.master.persistent.volume.size: 0.0
+# twister2.job.master.persistent.volume.size: 0.0
 
 # twister2 job master cpu request
 # default value is 0.2 percentage
-twister2.job.master.cpu: 0.2
+# twister2.job.master.cpu: 0.2
 
 # twister2 job master RAM request in MB
 # default value is 1024 MB
-twister2.job.master.ram: 1024
+# twister2.job.master.ram: 1024
 
 ###################################################################
 # Dashboard related settings
@@ -59,5 +59,5 @@ twister2.job.master.ram: 1024
 # Dashboard server host address and port
 # if this parameter is not specified, then job master will not try to connect to Dashboard
 # twister2.dashboard.host: "http://<ip-or-host>:<port>"
-# if dashboard is running as a statefulset in the cluster
-twister2.dashboard.host: "http://twister2-dashboard.default.svc.cluster.local"
+# if dashboard is running as a statefulset in the cluster, set it as:
+# twister2.dashboard.host: "http://twister2-dashboard.default.svc.cluster.local"

--- a/twister2/config/src/yaml/conf/kubernetes/core.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/core.yaml
@@ -12,22 +12,9 @@
 # Twister2 Job Master related settings
 ###################################################################
 
-# if true, the job master runs in the submitting client
-# if false, job master runs as a separate process in the cluster 
-# by default, it is false
-# when the job master runs in the submitting client,
-# this client has to be submitting the job from a machine in the cluster
-# getLocalHost must return a reachable IP address to the job master
-twister2.job.master.runs.in.client: false
-
 # twister2 job master port number
 # default value is 11011
 # twister2.job.master.port: 11011
-
-# worker to job master response wait time in milliseconds
-# this is for messages that wait for a response from the job master
-# default value is 10seconds = 10000
-# twister2.worker.to.job.master.response.wait.duration: 10000
 
 # twister2 job master volatile volume size in GB
 # default value is 0.0 Gi

--- a/twister2/config/src/yaml/conf/kubernetes/resource.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/resource.yaml
@@ -1,12 +1,10 @@
 ################################################################################
-# Kubernetes Docker Image and related settings
+# Kubernetes Docker Image and Launcher class
 ################################################################################
 # Twister2 Docker image for Kubernetes
 twister2.resource.kubernetes.docker.image: "twister2/twister2-k8s:0.8.0-SNAPSHOT"
 
-# the package uri
-twister2.resource.system.package.uri: "${TWISTER2_DIST}/twister2-core-0.8.0-SNAPSHOT.tar.gz"
-
+# Launcher class for Kubernetes
 twister2.resource.class.launcher: edu.iu.dsc.tws.rsched.schedulers.k8s.KubernetesLauncher
 
 ########################################################################
@@ -16,13 +14,14 @@ twister2.resource.class.launcher: edu.iu.dsc.tws.rsched.schedulers.k8s.Kubernete
 # default value is "default"
 # kubernetes.namespace: "default"
 
-# image pull policy, by default is IfNotPresent
-# it could also be Always
+# image pull policy, by default it is IfNotPresent
+# it could also be set as Always
+# kubernetes.image.pull.policy: "IfNotPresent"
 # kubernetes.image.pull.policy: "Always"
 
-# get log messages to twister2 client and save in files
+# get log messages to twister2 client and save in files under $HOME/.twister2 directory
 # it is false by default
-# kubernetes.log.in.client: true
+# kubernetes.log.in.client: false
 
 # before connecting to other pods in the job,
 # check whether all pods are reachable from each pod
@@ -30,7 +29,7 @@ twister2.resource.class.launcher: edu.iu.dsc.tws.rsched.schedulers.k8s.Kubernete
 # when there are networking issues, pods may not be reachable immediately,
 # so this makes sure to wait before all pods become reachable
 # it is false by default
-# kubernetes.check.pods.reachable: true
+# kubernetes.check.pods.reachable: false
 
 ################################################################################
 # Job configuration parameters for submission of twister2 jobs
@@ -39,38 +38,28 @@ twister2.resource.class.launcher: edu.iu.dsc.tws.rsched.schedulers.k8s.Kubernete
 ################################################################################
 
 # twister2 job name
-twister2.resource.job.name: "t2-job"
+# twister2.resource.job.name: "t2-job"
+
+# worker class to run
+# twister2.resource.job.worker.class: "edu.iu.dsc.tws.examples.basic.HelloWorld"
+# twister2.resource.job.worker.class: "edu.iu.dsc.tws.examples.internal.rsched.BasicK8sWorker"
 
 # A Twister2 job can have multiple sets of compute resources
 # Four fields are mandatory: cpu, ram, disk and instances
 # instances shows the number of compute resources to be started with this specification
 # workersPerPod shows the number of workers on each pod in Kubernetes.
 #    May be omitted in other clusters. default value is 1.
-twister2.resource.worker.compute.resources:
-  - cpu: 0.2  # number of cores for each worker, may be fractional such as 0.5 or 2.4
-    ram: 1024 # ram for each worker as Mega bytes
-    disk: 1.0 # volatile disk for each worker as Giga bytes
-    instances: 4 # number of compute resource instances with this specification
-    scalable: true # only one ComputeResource can be scalable in a job
-    workersPerPod: 1 # number of workers on each pod in Kubernetes. May be omitted in other clusters.
+# twister2.resource.worker.compute.resources:
+#   - cpu: 0.2  # number of cores for each worker, may be fractional such as 0.5 or 2.4
+#     ram: 1024 # ram for each worker as Mega bytes
+#     disk: 1.0 # volatile disk for each worker as Giga bytes
+#     instances: 4 # number of compute resource instances with this specification
+#     scalable: true # only one ComputeResource can be scalable in a job
+#     workersPerPod: 1 # number of workers on each pod in Kubernetes. May be omitted in other clusters.
     # number of workers using this compute resource: instances * workersPerPod
-
-#- cpu: 0.5  # number of cores for each worker, may be fractional such as 0.5 or 2.4
-#  ram: 1024 # ram for each worker as Mega bytes
-#  disk: 1.0 # volatile disk for each worker as Giga bytes
-#  instances: 2 # number of compute resource instances with this specification
-#  scalable: false # only one ComputeResource can be scalable in a job
-#  workersPerPod: 1 # number of workers on each pod in Kubernetes. May be omitted in other clusters.
 
 # driver class to run
 # twister2.resource.job.driver.class: "edu.iu.dsc.tws.examples.internal.rsched.DriverExample"
-
-# worker class to run
-# twister2.resource.job.worker.class: "edu.iu.dsc.tws.examples.internal.rsched.BasicK8sWorker"
-twister2.resource.job.worker.class: "edu.iu.dsc.tws.examples.basic.HelloWorld"
-# twister2.resource.job.worker.class: "edu.iu.dsc.tws.examples.internal.BasicNetworkTest"
-# twister2.resource.job.worker.class: "edu.iu.dsc.tws.examples.comms.batch.BReduceExample"
-# twister2.resource.job.worker.class: "edu.iu.dsc.tws.examples.internal.BasicNetworkTest"
 
 # by default each worker has one port
 # additional ports can be requested for all workers in a job
@@ -85,20 +74,19 @@ twister2.resource.job.worker.class: "edu.iu.dsc.tws.examples.basic.HelloWorld"
 # default value is 0.0Gi
 # set this value to zero, if you have not persistent disk support
 # when this value is zero, twister2 will not try to set up persistent storage for this job
-twister2.resource.persistent.volume.per.worker: 0.0
+# twister2.resource.persistent.volume.per.worker: 0.0
 
 # cluster admin should provide a storage provisioner.
 # please specify the storage class name that is used by the provisioner
-twister2.resource.kubernetes.persistent.storage.class: "twister2-nfs-storage"
 # Minikube has a default provisioner with storageClass of "standard"
-# twister2.resource.kubernetes.persistent.storage.class: "standard"
+twister2.resource.kubernetes.persistent.storage.class: "twister2-nfs-storage"
 
 # persistent storage access mode.
 # It shows the access mode for workers to access the shared persistent storage.
-# if it is "ReadWriteMany", many workers can read and write
+# by default it is "ReadWriteMany"
 # other alternatives: "ReadWriteOnce", "ReadOnlyMany"
 # https://kubernetes.io/docs/concepts/storage/persistent-volumes
-twister2.resource.kubernetes.storage.access.mode: "ReadWriteMany"
+# twister2.resource.kubernetes.storage.access.mode: "ReadWriteMany"
 
 #########################################################################
 # K8sUploader Settings
@@ -144,13 +132,13 @@ twister2.resource.class.uploader: "edu.iu.dsc.tws.rsched.uploaders.k8s.K8sUpload
 # To use S3Uploader:
 #   Uncomment uploader class below.
 #   Specify bucket name
-#   If your job will run more than 2 hours and it is fault tolerant, update link.expiration.duration
+#   If your job will run more than 2 hours, update link.expiration.duration
 
 # twister2.resource.class.uploader: "edu.iu.dsc.tws.rsched.uploaders.s3.S3Uploader"
 
 # s3 bucket name to upload the job package
 # workers will download the job package from this location
-twister2.s3.bucket.name: "s3://[bucket-name]"
+# twister2.s3.bucket.name: "s3://[bucket-name]"
 
 # job package link will be available this much time
 # by default, it is 2 hours
@@ -162,12 +150,12 @@ twister2.s3.bucket.name: "s3://[bucket-name]"
 
 # If this parameter is set as true,
 # Twister2 will use the below lists for node locations:
-#   kubernetes.datacenters.list
-#   kubernetes.racks.list
+#   twister2.resource.datacenters.list
+#   twister2.resource.racks.list
 # Otherwise, it will try to get these information by querying Kubernetes Master
 # It will use below two labels when querying node locations
 # For this to work, submitting client has to have admin privileges
-twister2.resource.kubernetes.node.locations.from.config: false
+# twister2.resource.kubernetes.node.locations.from.config: false
 
 # rack label key for Kubernetes nodes in a cluster
 # each rack should have a unique label
@@ -176,7 +164,7 @@ twister2.resource.kubernetes.node.locations.from.config: false
 # Better data locality can be achieved
 # Example: rack=rack1, rack=rack2, rack=rack3, etc
 # no default value is specified
-twister2.resource.rack.labey.key: rack
+# twister2.resource.rack.labey.key: rack
 
 # data center label key
 # each data center should have a unique label
@@ -185,16 +173,16 @@ twister2.resource.rack.labey.key: rack
 # Better data locality can be achieved
 # Example: datacenter=dc1, datacenter=dc1, datacenter=dc1, etc
 # no default value is specified
-twister2.resource.datacenter.labey.key: datacenter
+# twister2.resource.datacenter.labey.key: datacenter
 
 # Data center list with rack names
-twister2.resource.datacenters.list:
-  - echo: ['blue-rack', 'green-rack']
+# twister2.resource.datacenters.list:
+#   - echo: ['blue-rack', 'green-rack']
 
 # Rack list with node IPs in them
-twister2.resource.racks.list:
-  - blue-rack: ['node01.ip', 'node02.ip', 'node03.ip']
-  - green-rack: ['node11.ip', 'node12.ip', 'node13.ip']
+# twister2.resource.racks.list:
+#   - blue-rack: ['node01.ip', 'node02.ip', 'node03.ip']
+#   - green-rack: ['node11.ip', 'node12.ip', 'node13.ip']
 
 ###################################################################################
 # Kubernetes Mapping and Binding parameters
@@ -204,27 +192,26 @@ twister2.resource.racks.list:
 # Workers do not move from the CPU they are started during computation
 # twister2.cpu_per_container has to be an integer
 # by default, its value is false
-# kubernetes.bind.worker.to.cpu: true
+# kubernetes.bind.worker.to.cpu: false
 
 # kubernetes can map workers to nodes as specified by the user
 # default value is false
-# kubernetes.worker.to.node.mapping: true
+# kubernetes.worker.to.node.mapping: false
 
 # the label key on the nodes that will be used to map workers to nodes
-twister2.resource.kubernetes.worker.mapping.key: "kubernetes.io/hostname"
+# twister2.resource.kubernetes.worker.mapping.key: "kubernetes.io/hostname"
 
-# operator to use when mapping workers to nodes based on key value
+# operator to use when mapping workers to nodes based on the key value
 # possible values: In, NotIn, Exists, DoesNotExist, Gt, Lt
 # Exists/DoesNotExist checks only the existence of the specified key in the node.
 # Ref https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
-twister2.resource.kubernetes.worker.mapping.operator: "In"
+# twister2.resource.kubernetes.worker.mapping.operator: "In"
 
 # values for the mapping key
 # when the mapping operator is either Exists or DoesNotExist, values list must be empty.
-twister2.resource.kubernetes.worker.mapping.values: ['e012', 'e013']
-# kubernetes.worker.mapping.values: []
+# twister2.resource.kubernetes.worker.mapping.values: ['e012', 'e013']
 
 # uniform worker mapping
 # Valid values: all-same-node, all-separate-nodes, none
 # default value is none
-# kubernetes.worker.mapping.uniform: "all-same-node"
+# kubernetes.worker.mapping.uniform: "none"

--- a/twister2/config/src/yaml/conf/mesos/core.yaml
+++ b/twister2/config/src/yaml/conf/mesos/core.yaml
@@ -38,18 +38,6 @@ twister2.job.master.ram: 1000
 
 twister2.job.master.ip: "149.165.150.81"
 
-###################################################################################
-# WorkerController related config parameters
-###################################################################################
-
-# amount of timeout for all workers to join the job
-# in milli seconds
-twister2.worker.controller.max.wait.time.for.all.workers.to.join: 100000
-
-# amount of timeout on barriers for all workers to arrive
-# in milli seconds
-twister2.worker.controller.max.wait.time.on.barrier: 100000
-
 ###################################################################
 # Dashboard related settings
 ###################################################################

--- a/twister2/config/src/yaml/conf/nomad/core.yaml
+++ b/twister2/config/src/yaml/conf/nomad/core.yaml
@@ -39,18 +39,6 @@ twister2.job.master.ram: 1000
 #twister2.job.master.ip: "149.165.xxx.xx"
 twister2.job.master.ip: "localhost"
 
-###################################################################################
-# WorkerController related config parameters
-###################################################################################
-
-# amount of timeout for all workers to join the job
-# in milli seconds
-twister2.worker.controller.max.wait.time.for.all.workers.to.join: 1000000
-
-# amount of timeout on barriers for all workers to arrive
-# in milli seconds
-twister2.worker.controller.max.wait.time.on.barrier: 1000000
-
 ###################################################################
 # Dashboard related settings
 ###################################################################

--- a/twister2/config/src/yaml/conf/slurm/core.yaml
+++ b/twister2/config/src/yaml/conf/slurm/core.yaml
@@ -1,3 +1,6 @@
+###################################################################
+# Twister2 Job Master related settings
+###################################################################
 # by default we are setting this to false for slurm as we are only supporting MPI at the moment
 twister2.job.master.used: false
 

--- a/twister2/config/src/yaml/conf/slurm/core.yaml
+++ b/twister2/config/src/yaml/conf/slurm/core.yaml
@@ -4,18 +4,6 @@
 # by default we are setting this to false for slurm as we are only supporting MPI at the moment
 twister2.job.master.used: false
 
-###################################################################################
-# WorkerController related config parameters
-###################################################################################
-
-# amount of timeout for all workers to join the job
-# in milli seconds
-twister2.worker.controller.max.wait.time.for.all.workers.to.join: 100000
-
-# amount of timeout on barriers for all workers to arrive
-# in milli seconds
-twister2.worker.controller.max.wait.time.on.barrier: 100000
-
 ###################################################################
 # Dashboard related settings
 ###################################################################

--- a/twister2/config/src/yaml/conf/standalone/core.yaml
+++ b/twister2/config/src/yaml/conf/standalone/core.yaml
@@ -1,0 +1,10 @@
+###################################################################
+# Twister2 Job Master related settings
+###################################################################
+
+# by default Job Master does not run in the client.
+# in standalone clusters, by default,
+# we run the JobMaster in the client
+# Job submitting client has to be running in a machine in the cluster,
+# so that workers can connect to it.
+twister2.job.master.runs.in.client: true

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/batch/terasort/TeraSort.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/batch/terasort/TeraSort.java
@@ -89,6 +89,7 @@ public class TeraSort implements Twister2Worker {
   private static final String ARG_RESOURCE_MEMORY = "instanceMemory";
   private static final String ARG_RESOURCE_INSTANCES = "instances";
   private static final String ARG_RESOURCE_VOLATILE_DISK = "volatileDisk";
+  private static final String ARG_WORKERS_PER_POD = "workersPerPod";
 
   private static final String ARG_TASKS_SOURCES = "sources";
   private static final String ARG_TASKS_SINKS = "sinks";
@@ -565,6 +566,8 @@ public class TeraSort implements Twister2Worker {
         "No. of instances", true));
     options.addOption(createOption(ARG_RESOURCE_VOLATILE_DISK, true,
         "Volatile Disk for each worker at K8s", false));
+    options.addOption(createOption(ARG_WORKERS_PER_POD, true,
+        "Workers per pod in Kubernetes", false));
 
     //tasks and sources counts
     options.addOption(createOption(ARG_TASKS_SOURCES, true,
@@ -622,11 +625,17 @@ public class TeraSort implements Twister2Worker {
       volatileDisk = Double.valueOf(cmd.getOptionValue(ARG_RESOURCE_VOLATILE_DISK));
     }
 
+    // default value is 1
+    int workersPerPod = 1;
+    if (cmd.hasOption(ARG_WORKERS_PER_POD)) {
+      workersPerPod = Integer.valueOf(cmd.getOptionValue(ARG_WORKERS_PER_POD));
+    }
+
     jobConfig.put(ARG_TASKS_SOURCES, Integer.valueOf(cmd.getOptionValue(ARG_TASKS_SOURCES)));
     jobConfig.put(ARG_TASKS_SINKS, Integer.valueOf(cmd.getOptionValue(ARG_TASKS_SINKS)));
 
     jobConfig.put(ARG_RESOURCE_INSTANCES,
-        Integer.valueOf(cmd.getOptionValue(ARG_RESOURCE_INSTANCES)));
+        Integer.valueOf(cmd.getOptionValue(ARG_RESOURCE_INSTANCES)) * workersPerPod);
 
     if (cmd.hasOption(ARG_TUNE_MAX_BYTES_IN_MEMORY)) {
       long maxBytesInMemory = Long.valueOf(cmd.getOptionValue(ARG_TUNE_MAX_BYTES_IN_MEMORY));
@@ -666,7 +675,8 @@ public class TeraSort implements Twister2Worker {
             Double.valueOf(cmd.getOptionValue(ARG_RESOURCE_CPU)),
             Integer.valueOf(cmd.getOptionValue(ARG_RESOURCE_MEMORY)),
             volatileDisk,
-            Integer.valueOf(cmd.getOptionValue(ARG_RESOURCE_INSTANCES))
+            Integer.valueOf(cmd.getOptionValue(ARG_RESOURCE_INSTANCES)),
+            workersPerPod
         )
         .setConfig(jobConfig)
         .build();

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/JobMasterContext.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/JobMasterContext.java
@@ -46,11 +46,11 @@ public class JobMasterContext extends Context {
   public static final String JOB_MASTER_RAM = "twister2.job.master.ram";
 
   // job master volatile disk size in GB
-  public static final double VOLATILE_VOLUME_DEFAULT = 1.0;
+  public static final double VOLATILE_VOLUME_DEFAULT = 0.0;
   public static final String VOLATILE_VOLUME = "twister2.job.master.volatile.volume.size";
 
   // job master volatile disk size in GB
-  public static final double PERSISTENT_VOLUME_DEFAULT = 1.0;
+  public static final double PERSISTENT_VOLUME_DEFAULT = 0.0;
   public static final String PERSISTENT_VOLUME = "twister2.job.master.persistent.volume.size";
 
   // the number of http connections from job master to Twister2 Dashboard

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/JobMasterContext.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/JobMasterContext.java
@@ -19,6 +19,7 @@ import edu.iu.dsc.tws.api.config.Context;
  */
 public class JobMasterContext extends Context {
   // weather to use job master
+  public static final boolean JOB_MASTER_USED_DEFAULT = true;
   public static final String JOB_MASTER_USED = "twister2.job.master.used";
 
   // if true, the job master runs in the submitting client
@@ -33,7 +34,7 @@ public class JobMasterContext extends Context {
   public static final String DASHBOARD_HOST = "twister2.dashboard.host";
 
   // worker to master response wait time in milliseconds
-  public static final long WORKER_TO_JOB_MASTER_RESPONSE_WAIT_DURATION_DEFAULT = 1000;
+  public static final long WORKER_TO_JOB_MASTER_RESPONSE_WAIT_DURATION_DEFAULT = 100000;
   public static final String WORKER_TO_JOB_MASTER_RESPONSE_WAIT_DURATION
       = "twister2.worker.to.job.master.response.wait.duration";
 
@@ -108,7 +109,7 @@ public class JobMasterContext extends Context {
   }
 
   public static boolean isJobMasterUsed(Config cfg) {
-    return cfg.getBooleanValue(JOB_MASTER_USED, true);
+    return cfg.getBooleanValue(JOB_MASTER_USED, JOB_MASTER_USED_DEFAULT);
   }
 
   public static Config updateDashboardHost(Config cfg, String dashAddress) {

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/worker/JMWorkerAgent.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/worker/JMWorkerAgent.java
@@ -31,6 +31,7 @@ import edu.iu.dsc.tws.api.resource.IReceiverFromDriver;
 import edu.iu.dsc.tws.api.resource.IScalerListener;
 import edu.iu.dsc.tws.api.resource.IWorkerFailureListener;
 import edu.iu.dsc.tws.checkpointing.client.CheckpointingClientImpl;
+import edu.iu.dsc.tws.checkpointing.util.CheckpointingContext;
 import edu.iu.dsc.tws.common.net.tcp.Progress;
 import edu.iu.dsc.tws.common.net.tcp.request.RRClient;
 import edu.iu.dsc.tws.master.JobMasterContext;
@@ -194,10 +195,8 @@ public final class JMWorkerAgent {
     rrClient.registerResponseHandler(JobMasterAPI.AllJoined.newBuilder(), handler);
 
     // create checkpointing client
-    this.checkpointClient = new CheckpointingClientImpl(rrClient, this.config.getLongValue(
-        CheckpointingClientImpl.CONFIG_WAIT_TIME,
-        10000
-    ));
+    this.checkpointClient =
+        new CheckpointingClientImpl(rrClient, CheckpointingContext.getRequestTimeout(config));
 
     workerController = new JMWorkerController(
         config, thisWorker, numberOfWorkers, restartCount, rrClient, this.checkpointClient);

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesContext.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesContext.java
@@ -30,7 +30,7 @@ public class KubernetesContext extends SchedulerContext {
   public static final int K8S_WORKER_BASE_PORT_DEFAULT = 9000;
   public static final String K8S_WORKER_BASE_PORT = "kubernetes.worker.base.port";
 
-  public static final boolean NODE_LOCATIONS_FROM_CONFIG_DEFAULT = true;
+  public static final boolean NODE_LOCATIONS_FROM_CONFIG_DEFAULT = false;
   public static final String NODE_LOCATIONS_FROM_CONFIG
       = "twister2.resource.kubernetes.node.locations.from.config";
 


### PR DESCRIPTION
Many small fixes mostly related to config files:
Added optional workersPerPod parameter to TeraSort for running at k8s
A small bug is fixed in the script to push the base Kubernetes Docker image to Docker Hub.
Set the default value for mpijob restarts on failures to 1.
Set the default checkpointing timeout to 600 seconds. Checkpointing may take a long time in large jobs. 
Moved all cluster independent JobMaster config parameters to common/core.yaml. Deleted them from other cluster specific yamls.
Moved WorkerController config parameters to common/core.yaml. Deleted them from cluster specific yamls. 
Commented out default config values. 