### PR TITLE
unified storage config

### DIFF
--- a/twister2/api/src/java/edu/iu/dsc/tws/api/comms/CommunicationContext.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/comms/CommunicationContext.java
@@ -13,13 +13,10 @@ package edu.iu.dsc.tws.api.comms;
 
 import java.nio.ByteOrder;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.config.Context;
-import edu.iu.dsc.tws.api.config.TokenSub;
 
 public class CommunicationContext extends Context {
   public static final String REDUCE = "reduce";
@@ -39,8 +36,6 @@ public class CommunicationContext extends Context {
   public static final String INTER_NODE_DEGREE = "twister2.network.routing.inter.node.degree";
   public static final String INTRA_NODE_DEGREE = "twister2.network.routing.intra.node.degree";
   public static final ByteOrder DEFAULT_BYTEORDER = ByteOrder.BIG_ENDIAN;
-  public static final String PERSISTENT_DIRECTORIES = "twister2.network.ops.persistent.dirs";
-  public static final String PERSISTENT_DIRECTORY_DEFAULT_VALUE = "${TWISTER2_HOME}/persistent/";
 
   public static final String ALLTOALL_ALGO_KEY =
       "twister2.network.alltoall.algorithm";
@@ -128,13 +123,6 @@ public class CommunicationContext extends Context {
 
   public static int intraNodeDegree(Config cfg, int defaultValue) {
     return getIntPropertyValue(cfg, INTRA_NODE_DEGREE, defaultValue);
-  }
-
-  public static List<String> persistentDirectory(Config cfg) {
-    return cfg.getListValue(PERSISTENT_DIRECTORIES,
-        Collections.singletonList(PERSISTENT_DIRECTORY_DEFAULT_VALUE))
-        .stream().map(dir -> TokenSub.substitute(cfg, dir, Context.substitutions))
-        .collect(Collectors.toList());
   }
 
   public static String partitionAlgorithm(Config cfg) {

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/comms/Communicator.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/comms/Communicator.java
@@ -12,14 +12,17 @@
 
 package edu.iu.dsc.tws.api.comms;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import edu.iu.dsc.tws.api.comms.channel.TWSChannel;
 import edu.iu.dsc.tws.api.config.Config;
+import edu.iu.dsc.tws.api.config.FileSystemContext;
 
 /**
  * Communicator that keeps the information about.
@@ -63,7 +66,10 @@ public class Communicator {
     this.config = config;
     // first lets try to retrieve through a config
     if (persDirs == null) {
-      this.persistentDirectories = CommunicationContext.persistentDirectory(config);
+      this.persistentDirectories = FileSystemContext.volatileStorageRoots(config);
+      persistentDirectories = persistentDirectories.stream()
+          .map(path -> path + File.separator + "iodata")
+          .collect(Collectors.toList());
       if (this.persistentDirectories.size() > 0) {
         LOG.log(Level.FINE, "The persistence operations will be load balanced between : "
             + this.persistentDirectories);

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/config/FileSystemContext.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/config/FileSystemContext.java
@@ -9,10 +9,13 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-package edu.iu.dsc.tws.api.data;
+package edu.iu.dsc.tws.api.config;
 
-import edu.iu.dsc.tws.api.config.Config;
-import edu.iu.dsc.tws.api.config.Context;
+import java.io.File;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import edu.iu.dsc.tws.api.exceptions.Twister2RuntimeException;
 
 public class FileSystemContext {
@@ -35,20 +38,31 @@ public class FileSystemContext {
       throw new Twister2RuntimeException(PERSISTENT_STORAGE_ROOT + " is not specified in configs");
     }
 
-    //TODO: we can replace slash with filesystem specific separator
-    //      however, slash should work with NFS and HDFS
-    return rootPath + "/" + Context.jobId(config);
+    return rootPath + File.separator + Context.jobId(config);
   }
 
   public static String volatileStorageRoot(Config config) {
-    String rootPath = config.getStringValue(VOLATILE_STORAGE_ROOT, VOLATILE_STORAGE_ROOT_DEFAULT);
+    List<String> rootPaths = config.getListValue(VOLATILE_STORAGE_ROOT);
+    String rootPath;
+    if (rootPaths == null || rootPaths.size() == 0) {
+      rootPath = VOLATILE_STORAGE_ROOT_DEFAULT;
+    } else {
+      rootPath = rootPaths.get(0);
+    }
 
-    //TODO: we can replace slash with filesystem specific separator
-    //      however, slash should work with NFS and HDFS
-    return rootPath + "/" + Context.jobId(config);
+    return rootPath + File.separator + Context.jobId(config);
   }
 
+  public static List<String> volatileStorageRoots(Config config) {
+    List<String> rootPaths = config.getListValue(VOLATILE_STORAGE_ROOT);
+    if (rootPaths == null || rootPaths.size() == 0) {
+      rootPaths = new LinkedList<>();
+      rootPaths.add(VOLATILE_STORAGE_ROOT_DEFAULT);
+    }
 
-
+    return rootPaths.stream()
+        .map(path -> path + File.separator + Context.jobId(config))
+        .collect(Collectors.toList());
+  }
 
 }

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/config/FileSystemContext.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/config/FileSystemContext.java
@@ -15,24 +15,36 @@ import java.io.File;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import edu.iu.dsc.tws.api.exceptions.Twister2RuntimeException;
 
 public class FileSystemContext {
 
   public static final String PERSISTENT_STORAGE_TYPE = "twister2.persistent.storage.type";
+  public static final String PERSISTENT_STORAGE_TYPE_DEFAULT = "mounted";
   public static final String PERSISTENT_STORAGE_ROOT = "twister2.persistent.storage.root";
 
   public static final String VOLATILE_STORAGE_ROOT_DEFAULT = "/tmp/twister2/volatile";
   public static final String VOLATILE_STORAGE_ROOT = "twister2.volatile.storage.root";
 
+  public static final String TSET_STORAGE_TYPE_DEFAULT = "mounted";
+  public static final String TSET_STORAGE_TYPE = "twister2.tset.storage.type";
+
   protected FileSystemContext() { }
 
   public static String persistentStorageType(Config config) {
-    return config.getStringValue(PERSISTENT_STORAGE_TYPE, "local");
+    return config.getStringValue(PERSISTENT_STORAGE_TYPE, PERSISTENT_STORAGE_TYPE_DEFAULT);
   }
 
   public static String persistentStorageRoot(Config config) {
+    if (Context.isKubernetesCluster(config)
+        && "mounted".equalsIgnoreCase(persistentStorageType(config))) {
+      // this is from: KubernetesConstants.PERSISTENT_VOLUME_MOUNT
+      // but we can not reference that from this location, because of its package
+      return "/persistent";
+    }
+
     String rootPath = config.getStringValue(PERSISTENT_STORAGE_ROOT);
     if (rootPath == null) {
       throw new Twister2RuntimeException(PERSISTENT_STORAGE_ROOT + " is not specified in configs");
@@ -42,6 +54,12 @@ public class FileSystemContext {
   }
 
   public static String volatileStorageRoot(Config config) {
+    if (Context.isKubernetesCluster(config)) {
+      // this is from: KubernetesConstants.POD_VOLATILE_VOLUME
+      // but we can not reference that from this location, because of its package
+      return "/twister2-volatile";
+    }
+
     List<String> rootPaths = config.getListValue(VOLATILE_STORAGE_ROOT);
     String rootPath;
     if (rootPaths == null || rootPaths.size() == 0) {
@@ -54,6 +72,12 @@ public class FileSystemContext {
   }
 
   public static List<String> volatileStorageRoots(Config config) {
+    if (Context.isKubernetesCluster(config)) {
+      // this is from: KubernetesConstants.POD_VOLATILE_VOLUME
+      // but we can not reference that from this location, because of its package
+      return Stream.of("/twister2-volatile").collect(Collectors.toList());
+    }
+
     List<String> rootPaths = config.getListValue(VOLATILE_STORAGE_ROOT);
     if (rootPaths == null || rootPaths.size() == 0) {
       rootPaths = new LinkedList<>();
@@ -63,6 +87,10 @@ public class FileSystemContext {
     return rootPaths.stream()
         .map(path -> path + File.separator + Context.jobId(config))
         .collect(Collectors.toList());
+  }
+
+  public static String tsetStorageType(Config config) {
+    return config.getStringValue(TSET_STORAGE_TYPE, TSET_STORAGE_TYPE_DEFAULT);
   }
 
 }

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/data/BUILD
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/data/BUILD
@@ -7,5 +7,6 @@ t2_java_lib(
     srcs = glob(["**/*.java"]),
     artifact_name = "Twiter2 Data API",
     deps = [
+      "//twister2/api/src/java/edu/iu/dsc/tws/api/config:config-api-java",
     ],
 )

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/data/BUILD
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/data/BUILD
@@ -6,7 +6,5 @@ t2_java_lib(
     name = "data-api-java",
     srcs = glob(["**/*.java"]),
     artifact_name = "Twiter2 Data API",
-    deps = [
-      "//twister2/api/src/java/edu/iu/dsc/tws/api/config:config-api-java",
-    ],
+    deps = [],
 )

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/data/FileSystemContext.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/data/FileSystemContext.java
@@ -13,12 +13,15 @@ package edu.iu.dsc.tws.api.data;
 
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.config.Context;
+import edu.iu.dsc.tws.api.exceptions.Twister2RuntimeException;
 
 public class FileSystemContext {
 
   public static final String PERSISTENT_STORAGE_TYPE = "twister2.persistent.storage.type";
-
   public static final String PERSISTENT_STORAGE_ROOT = "twister2.persistent.storage.root";
+
+  public static final String VOLATILE_STORAGE_ROOT_DEFAULT = "/tmp/twister2/volatile";
+  public static final String VOLATILE_STORAGE_ROOT = "twister2.volatile.storage.root";
 
   protected FileSystemContext() { }
 
@@ -29,7 +32,7 @@ public class FileSystemContext {
   public static String persistentStorageRoot(Config config) {
     String rootPath = config.getStringValue(PERSISTENT_STORAGE_ROOT);
     if (rootPath == null) {
-      return null;
+      throw new Twister2RuntimeException(PERSISTENT_STORAGE_ROOT + " is not specified in configs");
     }
 
     //TODO: we can replace slash with filesystem specific separator
@@ -37,26 +40,14 @@ public class FileSystemContext {
     return rootPath + "/" + Context.jobId(config);
   }
 
-  public static String checkpointingStoreClass(Config config) {
-    String type = persistentStorageType(config);
-    if (type == null) {
-      return null;
-    }
+  public static String volatileStorageRoot(Config config) {
+    String rootPath = config.getStringValue(VOLATILE_STORAGE_ROOT, VOLATILE_STORAGE_ROOT_DEFAULT);
 
-    switch (type) {
-      case "hdfs":
-        return "edu.iu.dsc.tws.checkpointing.stores.HDFSFileStateStore";
-
-      case "nfs":
-        return "edu.iu.dsc.tws.checkpointing.stores.LocalFileStateStore";
-
-      case "local":
-        return "edu.iu.dsc.tws.checkpointing.stores.LocalFileStateStore";
-
-      default:
-        return null;
-    }
+    //TODO: we can replace slash with filesystem specific separator
+    //      however, slash should work with NFS and HDFS
+    return rootPath + "/" + Context.jobId(config);
   }
+
 
 
 

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/data/FileSystemContext.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/data/FileSystemContext.java
@@ -1,0 +1,63 @@
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package edu.iu.dsc.tws.api.data;
+
+import edu.iu.dsc.tws.api.config.Config;
+import edu.iu.dsc.tws.api.config.Context;
+
+public class FileSystemContext {
+
+  public static final String PERSISTENT_STORAGE_TYPE = "twister2.persistent.storage.type";
+
+  public static final String PERSISTENT_STORAGE_ROOT = "twister2.persistent.storage.root";
+
+  protected FileSystemContext() { }
+
+  public static String persistentStorageType(Config config) {
+    return config.getStringValue(PERSISTENT_STORAGE_TYPE, "local");
+  }
+
+  public static String persistentStorageRoot(Config config) {
+    String rootPath = config.getStringValue(PERSISTENT_STORAGE_ROOT);
+    if (rootPath == null) {
+      return null;
+    }
+
+    //TODO: we can replace slash with filesystem specific separator
+    //      however, slash should work with NFS and HDFS
+    return rootPath + "/" + Context.jobId(config);
+  }
+
+  public static String checkpointingStoreClass(Config config) {
+    String type = persistentStorageType(config);
+    if (type == null) {
+      return null;
+    }
+
+    switch (type) {
+      case "hdfs":
+        return "edu.iu.dsc.tws.checkpointing.stores.HDFSFileStateStore";
+
+      case "nfs":
+        return "edu.iu.dsc.tws.checkpointing.stores.LocalFileStateStore";
+
+      case "local":
+        return "edu.iu.dsc.tws.checkpointing.stores.LocalFileStateStore";
+
+      default:
+        return null;
+    }
+  }
+
+
+
+}

--- a/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/stores/HDFSFileStateStore.java
+++ b/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/stores/HDFSFileStateStore.java
@@ -24,13 +24,12 @@ import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.data.FSDataInputStream;
 import edu.iu.dsc.tws.api.data.FSDataOutputStream;
 import edu.iu.dsc.tws.api.data.FileSystem;
+import edu.iu.dsc.tws.api.data.FileSystemContext;
 import edu.iu.dsc.tws.api.data.Path;
 import edu.iu.dsc.tws.data.utils.FileSystemUtils;
 
 public class HDFSFileStateStore implements StateStore {
 
-  private static final String CHECKPOINTING_STORE_HDFS_DIR
-      = "twister2.checkpointing.store.hdfs.dir";
   private static final String HDFS_PROTO = "hdfs://";
 
   private String parentPath;
@@ -38,8 +37,9 @@ public class HDFSFileStateStore implements StateStore {
 
   @Override
   public void init(Config config, String... path) {
-    String finalPath = HDFS_PROTO + String.join(File.separator,
-        config.getStringValue(CHECKPOINTING_STORE_HDFS_DIR), String.join(File.separator, path));
+    String finalPath =
+        HDFS_PROTO + String.join(File.separator, FileSystemContext.persistentStorageRoot(config),
+            String.join(File.separator, path));
     this.parentPath = finalPath;
     try {
       this.hdfs = FileSystemUtils.get(URI.create(finalPath), config);

--- a/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/stores/HDFSFileStateStore.java
+++ b/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/stores/HDFSFileStateStore.java
@@ -21,10 +21,10 @@ import org.apache.hadoop.io.IOUtils;
 
 import edu.iu.dsc.tws.api.checkpointing.StateStore;
 import edu.iu.dsc.tws.api.config.Config;
+import edu.iu.dsc.tws.api.config.FileSystemContext;
 import edu.iu.dsc.tws.api.data.FSDataInputStream;
 import edu.iu.dsc.tws.api.data.FSDataOutputStream;
 import edu.iu.dsc.tws.api.data.FileSystem;
-import edu.iu.dsc.tws.api.data.FileSystemContext;
 import edu.iu.dsc.tws.api.data.Path;
 import edu.iu.dsc.tws.data.utils.FileSystemUtils;
 

--- a/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/stores/LocalFileStateStore.java
+++ b/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/stores/LocalFileStateStore.java
@@ -71,19 +71,19 @@ import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.checkpointing.StateStore;
 import edu.iu.dsc.tws.api.config.Config;
+import edu.iu.dsc.tws.api.data.FileSystemContext;
 
 public class LocalFileStateStore implements StateStore {
 
   private static final Logger LOG = Logger.getLogger(LocalFileStateStore.class.getName());
 
-  public static final String CHECKPOINTING_STORE_FS_DIR = "twister2.checkpointing.store.fs.dir";
-
   private File rootFolder;
 
   @Override
   public void init(Config config, String... path) {
-    String finalPath = String.join(File.separator,
-        config.getStringValue(CHECKPOINTING_STORE_FS_DIR), String.join(File.separator, path));
+    String finalPath =
+        String.join(File.separator, FileSystemContext.persistentStorageRoot(config),
+            String.join(File.separator, path));
     this.rootFolder = new File(finalPath);
     LOG.info("Snapshot Store path : " + this.rootFolder.getAbsolutePath());
     if (!this.rootFolder.exists()) {

--- a/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/stores/LocalFileStateStore.java
+++ b/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/stores/LocalFileStateStore.java
@@ -71,7 +71,7 @@ import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.checkpointing.StateStore;
 import edu.iu.dsc.tws.api.config.Config;
-import edu.iu.dsc.tws.api.data.FileSystemContext;
+import edu.iu.dsc.tws.api.config.FileSystemContext;
 
 public class LocalFileStateStore implements StateStore {
 

--- a/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/util/CheckpointingContext.java
+++ b/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/util/CheckpointingContext.java
@@ -12,7 +12,7 @@
 package edu.iu.dsc.tws.checkpointing.util;
 
 import edu.iu.dsc.tws.api.config.Config;
-import edu.iu.dsc.tws.api.data.FileSystemContext;
+import edu.iu.dsc.tws.api.config.FileSystemContext;
 import edu.iu.dsc.tws.checkpointing.stores.HDFSFileStateStore;
 import edu.iu.dsc.tws.checkpointing.stores.LocalFileStateStore;
 

--- a/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/util/CheckpointingContext.java
+++ b/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/util/CheckpointingContext.java
@@ -13,6 +13,7 @@ package edu.iu.dsc.tws.checkpointing.util;
 
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.config.FileSystemContext;
+import edu.iu.dsc.tws.api.exceptions.Twister2RuntimeException;
 import edu.iu.dsc.tws.checkpointing.stores.HDFSFileStateStore;
 import edu.iu.dsc.tws.checkpointing.stores.LocalFileStateStore;
 
@@ -45,14 +46,14 @@ public final class CheckpointingContext {
       case "hdfs":
         return HDFSFileStateStore.class.getCanonicalName();
 
-      case "nfs":
+      case "mounted":
         return LocalFileStateStore.class.getCanonicalName();
 
-      case "local":
-        return LocalFileStateStore.class.getCanonicalName();
+      case "none":
+        return null;
 
       default:
-        return LocalFileStateStore.class.getCanonicalName();
+        throw new Twister2RuntimeException("unsupported persistent storage type: " + type);
     }
   }
 

--- a/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/util/CheckpointingContext.java
+++ b/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/util/CheckpointingContext.java
@@ -12,6 +12,8 @@
 package edu.iu.dsc.tws.checkpointing.util;
 
 import edu.iu.dsc.tws.api.config.Config;
+import edu.iu.dsc.tws.api.data.FileSystemContext;
+import edu.iu.dsc.tws.checkpointing.stores.HDFSFileStateStore;
 import edu.iu.dsc.tws.checkpointing.stores.LocalFileStateStore;
 
 public final class CheckpointingContext {
@@ -37,8 +39,21 @@ public final class CheckpointingContext {
   }
 
   public static String getCheckpointingStoreClass(Config config) {
-    return config.getStringValue(CHECKPOINTING_STORE_CLASS,
-        LocalFileStateStore.class.getCanonicalName());
+    String type = FileSystemContext.persistentStorageType(config);
+
+    switch (type) {
+      case "hdfs":
+        return HDFSFileStateStore.class.getCanonicalName();
+
+      case "nfs":
+        return LocalFileStateStore.class.getCanonicalName();
+
+      case "local":
+        return LocalFileStateStore.class.getCanonicalName();
+
+      default:
+        return LocalFileStateStore.class.getCanonicalName();
+    }
   }
 
   public static boolean startingFromACheckpoint(Config config) {

--- a/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/worker/CheckpointingWorkerEnv.java
+++ b/twister2/checkpointing/src/java/edu/iu/dsc/tws/checkpointing/worker/CheckpointingWorkerEnv.java
@@ -31,13 +31,11 @@ import edu.iu.dsc.tws.checkpointing.api.SnapshotImpl;
 import edu.iu.dsc.tws.checkpointing.util.CheckpointUtils;
 import edu.iu.dsc.tws.proto.checkpoint.Checkpoint;
 
-import static edu.iu.dsc.tws.api.config.Context.JOB_ID;
-
 public final class CheckpointingWorkerEnv {
   private static final Logger LOG = Logger.getLogger(CheckpointingWorkerEnv.class.getName());
 
   private static final String WORKER_CHECKPOINT_FAMILY = "worker";
-  private static final String WORKER_CHECKPOINT_DIR = "twister2-checkpoints";
+  private static final String WORKER_CHECKPOINT_DIR = "worker-checkpoints";
 
   private final int workerId;
   private long latestVersion;
@@ -115,8 +113,7 @@ public final class CheckpointingWorkerEnv {
 
       StateStore localCheckpointStore = CheckpointUtils.getStateStore(config);
       // one snapshot store for worker. Each node may have snapshots of multiple  workers
-      localCheckpointStore.init(config, WORKER_CHECKPOINT_DIR, config.getStringValue(JOB_ID),
-          Integer.toString(workerId));
+      localCheckpointStore.init(config, WORKER_CHECKPOINT_DIR, Integer.toString(workerId));
 
       Set<Integer> workerIDs = Collections.emptySet();
       if (workerId == 0) {

--- a/twister2/common/src/java/edu/iu/dsc/tws/common/logging/LoggingHelper.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/logging/LoggingHelper.java
@@ -116,11 +116,11 @@ public final class LoggingHelper {
         foundAndInit = true;
       }
     }
-    if (!foundAndInit) {
-      Twister2FileLogHandler twister2FileLogHandler = new Twister2FileLogHandler();
-      twister2FileLogHandler.init(logDir, logFile, config);
-      LoggingHelper.addLoggingHandler(twister2FileLogHandler);
-    }
+//    if (!foundAndInit) {
+//      Twister2FileLogHandler twister2FileLogHandler = new Twister2FileLogHandler();
+//      twister2FileLogHandler.init(logDir, logFile, config);
+//      LoggingHelper.addLoggingHandler(twister2FileLogHandler);
+//    }
   }
 
   /**

--- a/twister2/config/src/yaml/conf/common/checkpoint.yaml
+++ b/twister2/config/src/yaml/conf/common/checkpoint.yaml
@@ -1,15 +1,18 @@
 # Enable or disable checkpointing
 twister2.checkpointing.enable: false
 
-# The implementation of the store to be used
-#twister2.checkpointing.store: edu.iu.dsc.tws.checkpointing.stores.HDFSFileStateStore
-twister2.checkpointing.store: edu.iu.dsc.tws.checkpointing.stores.LocalFileStateStore
+# persistent storage type
+# could be: hdfs, nfs, local
+# by default, it is local
+twister2.persistent.storage.type: hdfs
 
-# Root directory of local file system based store
-twister2.checkpointing.store.fs.dir: "${TWISTER2_HOME}/persistent/"
-
-# Root directory of hdfs based store
-twister2.checkpointing.store.hdfs.dir: "/twister2/persistent/"
+# persistent storage root
+# a directory with jobID is created under this directory
+# all persistent storage related files are stored under that directory for the job
+# for hdfs, it can be something like:
+twister2.persistent.storage.root: "/twister2/"
+# for nfs or local, it can be something like
+# twister2.persistent.storage.root: "${HOME}/.twister2/jobs/"
 
 # Source triggering frequency
 # in milliseconds

--- a/twister2/config/src/yaml/conf/common/checkpoint.yaml
+++ b/twister2/config/src/yaml/conf/common/checkpoint.yaml
@@ -1,19 +1,6 @@
 # Enable or disable checkpointing
 twister2.checkpointing.enable: false
 
-# persistent storage type
-# could be: hdfs, nfs, local
-# by default, it is local
-twister2.persistent.storage.type: hdfs
-
-# persistent storage root
-# a directory with jobID is created under this directory
-# all persistent storage related files are stored under that directory for the job
-# for hdfs, it can be something like:
-twister2.persistent.storage.root: "/twister2/"
-# for nfs or local, it can be something like
-# twister2.persistent.storage.root: "${HOME}/.twister2/jobs/"
-
 # Source triggering frequency
 # in milliseconds
 # twister2.checkpointing.source.frequency: 1000

--- a/twister2/config/src/yaml/conf/common/data.yaml
+++ b/twister2/config/src/yaml/conf/common/data.yaml
@@ -1,3 +1,36 @@
+###################################################################
+# Persistent and Volatile Storage related settings
+###################################################################
+
+# persistent storage type
+# could be: hdfs, nfs, local
+# by default, it is local
+# twister2.persistent.storage.type: "local"
+
+# persistent storage root
+# a directory with jobID is created under this directory
+# all persistent storage related files are stored under that directory for the job
+# for hdfs, it can be something like:
+# twister2.persistent.storage.root: "/twister2"
+# for nfs or local, it can be something like
+twister2.persistent.storage.root: "${HOME}/.twister2/jobs"
+
+# volatile storage root
+# when twister2 can not fit the tset data into the memory and useDisk is specified,
+# it saves to this location during the computation
+# by default, it is "/tmp/twister2/volatile"
+# twister2.volatile.storage.root: "/tmp/twister2/volatile"
+
+# tset data can be saved to disk when the data can not fit into the memory
+# by default, it is saved to the local disk
+# it can also be saved to hdfs
+# supported values: "local" or "hdfs"
+# twister2.tset.storage.type: "local"
+
+###################################################################
+# HDFS related settings
+###################################################################
+
 #Home directory of the hadoop
 twister2.data.hadoop.home: "${HADOOP_HOME}"
 
@@ -12,10 +45,3 @@ twister2.data.hdfs.namenode: "localhost"
 
 #Specify the namenode port
 twister2.data.hdfs.namenode.port: "9001"
-
-# twister2.data.fs.root: "${TWISTER2_HOME}/persistent/data"
-twister2.data.fs.root: "${TWISTER2_HOME}/persistent"
-
-twister2.data.hdfs.root: "/twister2/persistent/data"
-
-twister2.tset.data.persist.fs: "local"

--- a/twister2/config/src/yaml/conf/common/data.yaml
+++ b/twister2/config/src/yaml/conf/common/data.yaml
@@ -33,6 +33,13 @@ twister2.persistent.storage.root: "${HOME}/.twister2/jobs"
 # supported values: "local" or "hdfs"
 # twister2.tset.storage.type: "local"
 
+# logging storage type
+# twister2 can save logs to volatile or persistent storage
+# however, we do not support hdfs as the persistent storage for logging yet
+# supported values: "volatile" or "persistent"
+# by default, it is "volatile"
+twister2.logging.storage.type: "volatile"
+
 ###################################################################
 # HDFS related settings
 ###################################################################

--- a/twister2/config/src/yaml/conf/common/data.yaml
+++ b/twister2/config/src/yaml/conf/common/data.yaml
@@ -3,16 +3,17 @@
 ###################################################################
 
 # persistent storage type
-# could be: hdfs, nfs, local
-# by default, it is local
-# twister2.persistent.storage.type: "local"
+# could be: hdfs, mounted, none
+# mounted can be local disk or a network mounted disk such as nfs
+# by default, it is "mounted"
+# twister2.persistent.storage.type: "mounted"
 
 # persistent storage root
 # a directory with jobID is created under this directory
 # all persistent storage related files are stored under that directory for the job
 # for hdfs, it can be something like:
 # twister2.persistent.storage.root: "/twister2"
-# for nfs or local, it can be something like
+# for mounted disks, it can be something like
 twister2.persistent.storage.root: "${HOME}/.twister2/jobs"
 
 # volatile storage root
@@ -28,17 +29,17 @@ twister2.persistent.storage.root: "${HOME}/.twister2/jobs"
 # twister2.volatile.storage.root: ["/tmp/twister2/volatile"]
 
 # tset data can be saved to disk when the data can not fit into the memory
-# by default, it is saved to the local disk
+# by default, it is saved to the mounted disk
 # it can also be saved to hdfs
-# supported values: "local" or "hdfs"
-# twister2.tset.storage.type: "local"
+# supported values: "mounted" or "hdfs"
+# twister2.tset.storage.type: "mounted"
 
 # logging storage type
 # twister2 can save logs to volatile or persistent storage
 # however, we do not support hdfs as the persistent storage for logging yet
 # supported values: "volatile" or "persistent"
 # by default, it is "volatile"
-twister2.logging.storage.type: "volatile"
+# twister2.logging.storage.type: "volatile"
 
 ###################################################################
 # HDFS related settings

--- a/twister2/config/src/yaml/conf/common/data.yaml
+++ b/twister2/config/src/yaml/conf/common/data.yaml
@@ -17,9 +17,15 @@ twister2.persistent.storage.root: "${HOME}/.twister2/jobs"
 
 # volatile storage root
 # when twister2 can not fit the tset data into the memory and useDisk is specified,
-# it saves to this location during the computation
-# by default, it is "/tmp/twister2/volatile"
-# twister2.volatile.storage.root: "/tmp/twister2/volatile"
+#   it saves to this location during the computation
+# when twister2 networking can not fit the data into the allocated memory,
+#   it saves to this location
+# networking component may also save to multiple disks concurrently
+#   for that to happen, multiple roots need to be specified
+#   tset component currently saves to a single disk only.
+#   (first one in the list when there are multiple)
+# by default, it is ["/tmp/twister2/volatile"]
+# twister2.volatile.storage.root: ["/tmp/twister2/volatile"]
 
 # tset data can be saved to disk when the data can not fit into the memory
 # by default, it is saved to the local disk

--- a/twister2/config/src/yaml/conf/common/network.yaml
+++ b/twister2/config/src/yaml/conf/common/network.yaml
@@ -39,11 +39,6 @@ twister2.network.message.group.high_water_mark: 16
 # within partial receivers
 twister2.network.message.grouping.size: 10
 
-# For disk based operations, this directory list will be used to persist incoming messages.
-# This can be used to balance the load between multiple devices, by specifying directory locations
-# from different devices.
-twister2.network.ops.persistent.dirs: ["/mnt/data/persistent/"]
-
 # the maximum amount of bytes kept in memory for operations that goes to disk
 twister2.network.shuffle.memory.bytes.max: 102400000
 

--- a/twister2/config/src/yaml/conf/kubernetes/core.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/core.yaml
@@ -21,11 +21,6 @@
 # if this value is 0, volatile volume is not setup for job master
 # twister2.job.master.volatile.volume.size: 0.0
 
-# twister2 job master persistent volume size in GB
-# default value is 0.0 Gi
-# if this value is 0, persistent volume is not setup for job master
-# twister2.job.master.persistent.volume.size: 0.0
-
 # twister2 job master cpu request
 # default value is 0.2 percentage
 # twister2.job.master.cpu: 0.2

--- a/twister2/config/src/yaml/conf/kubernetes/data.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/data.yaml
@@ -1,2 +1,43 @@
-# checkpointing data directory
-twister2.data.fs.root: "/persistent"
+###################################################################
+# Persistent and Volatile Storage related settings
+###################################################################
+
+# persistent storage type
+# for kubernetes, it could be: hdfs, mounted or none
+# by default, it is "mounted"
+# "mounted" means any k8s persistent volume mounted to the twister2 pods
+# to mount a persistent volume, please specify "persistent volume related settings" in resource.yaml
+# twister2.persistent.storage.type: "mounted"
+
+# persistent storage root
+# persistent storage root is specified only for hdfs in Kubernetes
+# it is "/persistent" for mounted persistent volumes in Kubernetes.
+#    That can not be changed with config parameters
+# for hdfs, a directory with jobID is created under this directory
+# all persistent storage related files are stored under that directory for the job
+# for hdfs, it can be something like:
+# twister2.persistent.storage.root: "/twister2"
+
+# volatile storage root
+# when twister2 can not fit the tset data into the memory and useDisk is specified,
+#   it saves to this location during the computation
+# when twister2 networking can not fit the data into the allocated memory,
+#   it saves to this location
+# in Kubernetes, volatile storage root is always "/twister2-volatile".
+# volatile root path can not be changed in Kubernetes
+# volatile disk is specified when creating Twister2Job object.
+
+# tset data can be saved to disk when the data can not fit into the memory
+# by default, it is saved to the mounted disk
+# it can also be saved to hdfs
+# supported values: "mounted" or "hdfs"
+# twister2.tset.storage.type: "mounted"
+
+# logging storage type
+# twister2 can save logs to volatile or persistent storage
+# however, we do not support hdfs as the persistent storage for logging yet
+# supported values: "volatile" or "persistent"
+# by default, it is "volatile"
+# you can also save the logs to the submitting client by enabling the following parameter in resource.yaml:
+#    kubernetes.log.in.client
+# twister2.logging.storage.type: "volatile"

--- a/twister2/config/src/yaml/conf/kubernetes/resource.yaml
+++ b/twister2/config/src/yaml/conf/kubernetes/resource.yaml
@@ -76,6 +76,11 @@ twister2.resource.class.launcher: edu.iu.dsc.tws.rsched.schedulers.k8s.Kubernete
 # when this value is zero, twister2 will not try to set up persistent storage for this job
 # twister2.resource.persistent.volume.per.worker: 0.0
 
+# twister2 job master persistent volume size in GB
+# default value is 0.0 Gi
+# if this value is 0, persistent volume is not setup for job master
+# twister2.job.master.persistent.volume.size: 0.0
+
 # cluster admin should provide a storage provisioner.
 # please specify the storage class name that is used by the provisioner
 # Minikube has a default provisioner with storageClass of "standard"

--- a/twister2/data/src/main/java/edu/iu/dsc/tws/dataset/partition/DiskBackedCollectionPartition.java
+++ b/twister2/data/src/main/java/edu/iu/dsc/tws/dataset/partition/DiskBackedCollectionPartition.java
@@ -18,8 +18,8 @@ import java.net.URI;
 
 import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.config.Config;
+import edu.iu.dsc.tws.api.config.FileSystemContext;
 import edu.iu.dsc.tws.api.data.FileSystem;
-import edu.iu.dsc.tws.api.data.FileSystemContext;
 import edu.iu.dsc.tws.api.data.Path;
 import edu.iu.dsc.tws.api.exceptions.Twister2RuntimeException;
 import edu.iu.dsc.tws.data.utils.FileSystemUtils;

--- a/twister2/data/src/main/java/edu/iu/dsc/tws/dataset/partition/DiskBackedCollectionPartition.java
+++ b/twister2/data/src/main/java/edu/iu/dsc/tws/dataset/partition/DiskBackedCollectionPartition.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.data.FileSystem;
+import edu.iu.dsc.tws.api.data.FileSystemContext;
 import edu.iu.dsc.tws.api.data.Path;
 import edu.iu.dsc.tws.api.exceptions.Twister2RuntimeException;
 import edu.iu.dsc.tws.data.utils.FileSystemUtils;
@@ -26,9 +27,7 @@ import edu.iu.dsc.tws.data.utils.FileSystemUtils;
 @SuppressWarnings("rawtypes")
 public class DiskBackedCollectionPartition<T> extends BufferedCollectionPartition<T> {
 
-  private static final String CONFIG_FS_ROOT = "twister2.data.fs.root";
   private static final String FS_PROTO = "file://";
-
   public static final String CONFIG = "local";
 
   public DiskBackedCollectionPartition(long maxFramesInMemory, MessageType dataType,
@@ -60,9 +59,8 @@ public class DiskBackedCollectionPartition<T> extends BufferedCollectionPartitio
   }
 
   protected String getRootPathStr(Config config) {
-    return FS_PROTO + String.join(File.separator,
-        config.getStringValue(CONFIG_FS_ROOT, "/tmp"), String.join(File.separator,
-            this.getReference()));
+    return FS_PROTO + String.join(File.separator, FileSystemContext.volatileStorageRoot(config),
+        "tsetdata", this.getReference());
   }
 
   @Override

--- a/twister2/data/src/main/java/edu/iu/dsc/tws/dataset/partition/DiskBackedCollectionPartition.java
+++ b/twister2/data/src/main/java/edu/iu/dsc/tws/dataset/partition/DiskBackedCollectionPartition.java
@@ -28,7 +28,7 @@ import edu.iu.dsc.tws.data.utils.FileSystemUtils;
 public class DiskBackedCollectionPartition<T> extends BufferedCollectionPartition<T> {
 
   private static final String FS_PROTO = "file://";
-  public static final String CONFIG = "local";
+  public static final String CONFIG = "mounted";
 
   public DiskBackedCollectionPartition(long maxFramesInMemory, MessageType dataType,
                                        long bufferedBytes, Config config, String reference) {

--- a/twister2/data/src/main/java/edu/iu/dsc/tws/dataset/partition/HDFSBackedCollectionPartition.java
+++ b/twister2/data/src/main/java/edu/iu/dsc/tws/dataset/partition/HDFSBackedCollectionPartition.java
@@ -18,15 +18,14 @@ import java.net.URI;
 import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.data.FileSystem;
+import edu.iu.dsc.tws.api.data.FileSystemContext;
 import edu.iu.dsc.tws.api.data.Path;
 import edu.iu.dsc.tws.api.exceptions.Twister2RuntimeException;
 import edu.iu.dsc.tws.data.utils.FileSystemUtils;
 
 public class HDFSBackedCollectionPartition<T> extends BufferedCollectionPartition<T> {
 
-  private static final String CONFIG_HDFS_ROOT = "twister2.data.hdfs.root";
   private static final String HDFS_PROTO = "hdfs://";
-
   public static final String CONFIG = "hdfs";
 
   public HDFSBackedCollectionPartition(int maxFramesInMemory, MessageType dataType,
@@ -56,9 +55,8 @@ public class HDFSBackedCollectionPartition<T> extends BufferedCollectionPartitio
   }
 
   protected String getRootPathStr(Config config) {
-    return HDFS_PROTO + String.join(File.separator,
-        config.getStringValue(CONFIG_HDFS_ROOT), String.join(File.separator,
-            this.getReference()));
+    return HDFS_PROTO + String.join(File.separator, FileSystemContext.persistentStorageRoot(config),
+        "tsetdata", this.getReference());
   }
 
   @Override

--- a/twister2/data/src/main/java/edu/iu/dsc/tws/dataset/partition/HDFSBackedCollectionPartition.java
+++ b/twister2/data/src/main/java/edu/iu/dsc/tws/dataset/partition/HDFSBackedCollectionPartition.java
@@ -17,8 +17,8 @@ import java.net.URI;
 
 import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.config.Config;
+import edu.iu.dsc.tws.api.config.FileSystemContext;
 import edu.iu.dsc.tws.api.data.FileSystem;
-import edu.iu.dsc.tws.api.data.FileSystemContext;
 import edu.iu.dsc.tws.api.data.Path;
 import edu.iu.dsc.tws.api.exceptions.Twister2RuntimeException;
 import edu.iu.dsc.tws.data.utils.FileSystemUtils;

--- a/twister2/master/src/java/edu/iu/dsc/tws/master/server/JobMaster.java
+++ b/twister2/master/src/java/edu/iu/dsc/tws/master/server/JobMaster.java
@@ -327,7 +327,7 @@ public class JobMaster {
     //initialize checkpoint manager
     if (CheckpointingContext.isCheckpointingEnabled(config)) {
       StateStore stateStore = CheckpointUtils.getStateStore(config);
-      stateStore.init(config, job.getJobId());
+      stateStore.init(config, "checkpoint-manager");
       this.checkpointManager = new CheckpointManager(
           this.rrServer,
           stateStore,

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/master/JobMasterStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/master/JobMasterStarter.java
@@ -32,6 +32,7 @@ import edu.iu.dsc.tws.common.zk.ZKEphemStateManager;
 import edu.iu.dsc.tws.common.zk.ZKEventsManager;
 import edu.iu.dsc.tws.common.zk.ZKPersStateManager;
 import edu.iu.dsc.tws.common.zk.ZKUtils;
+import edu.iu.dsc.tws.master.JobMasterContext;
 import edu.iu.dsc.tws.master.server.JobMaster;
 import edu.iu.dsc.tws.proto.jobmaster.JobMasterAPI;
 import edu.iu.dsc.tws.proto.jobmaster.JobMasterAPI.JobMasterState;
@@ -87,7 +88,8 @@ public final class JobMasterStarter {
         .build();
 
     // init logger
-    K8sWorkerUtils.initLogger(config, "jobMaster");
+    K8sWorkerUtils
+        .initLogger(config, "jobMaster", JobMasterContext.persistentVolumeRequested(config));
 
     LOG.info("JobMaster is starting. Current time: " + System.currentTimeMillis());
     LOG.info("Number of configuration parameters: " + config.size());

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/mpi/MPIMasterStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/mpi/MPIMasterStarter.java
@@ -78,7 +78,8 @@ public final class MPIMasterStarter {
 
     config = K8sWorkerUtils.loadConfig(configDir);
 
-    K8sWorkerUtils.initLogger(config, "mpiMaster");
+    K8sWorkerUtils
+        .initLogger(config, "mpiMaster", KubernetesContext.persistentVolumeRequested(config));
 
     // read job description file
     String jobDescFileName = SchedulerContext.createJobDescriptionFileName(jobID);

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/nomad/NomadJobMasterStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/nomad/NomadJobMasterStarter.java
@@ -12,7 +12,6 @@
 package edu.iu.dsc.tws.rsched.schedulers.nomad;
 
 
-import java.io.File;
 import java.net.Inet4Address;
 import java.net.UnknownHostException;
 import java.util.logging.Level;
@@ -33,13 +32,13 @@ import edu.iu.dsc.tws.api.driver.IScalerPerCluster;
 import edu.iu.dsc.tws.api.driver.NullScaler;
 import edu.iu.dsc.tws.api.exceptions.Twister2Exception;
 import edu.iu.dsc.tws.common.config.ConfigLoader;
-import edu.iu.dsc.tws.common.logging.LoggingHelper;
 import edu.iu.dsc.tws.common.zk.ZKJobMasterRegistrar;
 import edu.iu.dsc.tws.master.JobMasterContext;
 import edu.iu.dsc.tws.master.server.JobMaster;
 import edu.iu.dsc.tws.proto.jobmaster.JobMasterAPI;
 import edu.iu.dsc.tws.proto.system.job.JobAPI;
 import edu.iu.dsc.tws.rsched.schedulers.NullTerminator;
+import edu.iu.dsc.tws.rsched.schedulers.standalone.MPIWorkerStarter;
 import edu.iu.dsc.tws.rsched.utils.JobUtils;
 import edu.iu.dsc.tws.rsched.utils.ResourceSchedulerUtils;
 
@@ -223,7 +222,7 @@ public final class NomadJobMasterStarter {
 
     int workerID = Integer.valueOf(indexEnv);
 
-    initLogger(config, workerID);
+    MPIWorkerStarter.initJMLogger(config);
     LOG.log(Level.INFO, String.format("Worker id = %s and index = %d", idEnv, workerID));
     ZKJobMasterRegistrar registrar = null;
     int port = JobMasterContext.jobMasterPort(config);
@@ -331,47 +330,4 @@ public final class NomadJobMasterStarter {
         jobPackageURI,
         Context.verbose(config));
   }
-
-  /**
-   * Initialize the loggers to log into the task local directory
-   *
-   * @param cfg the configuration
-   * @param workerID worker id
-   */
-  private void initLogger(Config cfg, int workerID) {
-    // we can not initialize the logger fully yet,
-    // but we need to set the format as the first thing
-    LoggingHelper.setLoggingFormat(LoggingHelper.DEFAULT_FORMAT);
-
-    String jobWorkingDirectory = NomadContext.workingDirectory(cfg);
-    //String jobID = NomadContext.jobId(cfg);
-    String jobID = NomadContext.jobId(cfg);
-
-    NomadPersistentVolume pv =
-        new NomadPersistentVolume(controller.createPersistentJobDirName(jobID), workerID);
-    String persistentJobDir = pv.getJobDir().getAbsolutePath();
-    //LOG.log(Level.INFO, "PERSISTENT LOG DIR is ......: " + persistentJobDir);
-    //String persistentJobDir = getTaskDirectory();
-    // if no persistent volume requested, return
-    if (persistentJobDir == null) {
-      return;
-    }
-
-//    if (NomadContext.getLoggingSandbox(cfg)) {
-//      persistentJobDir = Paths.get(jobWorkingDirectory, jobID).toString();
-//    }
-    //nfs/shared/twister2/
-    //String logDir = "/etc/nomad.d/"; //"/nfs/shared/twister2" + "/logs";
-    String logDir = persistentJobDir + "/logs";
-
-    LOG.log(Level.INFO, "LOG DIR is ......: " + logDir);
-    File directory = new File(logDir);
-    if (!directory.exists()) {
-      if (!directory.mkdirs()) {
-        throw new RuntimeException("Failed to create log directory: " + logDir);
-      }
-    }
-    LoggingHelper.setupLogging(cfg, logDir, "worker-" + workerID);
-  }
-
 }

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/TSetUtils.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/TSetUtils.java
@@ -18,6 +18,7 @@ import java.util.StringJoiner;
 import edu.iu.dsc.tws.api.comms.messaging.types.MessageType;
 import edu.iu.dsc.tws.api.comms.messaging.types.MessageTypes;
 import edu.iu.dsc.tws.api.config.Config;
+import edu.iu.dsc.tws.api.config.FileSystemContext;
 import edu.iu.dsc.tws.api.exceptions.Twister2RuntimeException;
 import edu.iu.dsc.tws.api.tset.TBase;
 import edu.iu.dsc.tws.api.tset.TSetContext;
@@ -26,8 +27,6 @@ import edu.iu.dsc.tws.dataset.partition.DiskBackedCollectionPartition;
 import edu.iu.dsc.tws.dataset.partition.HDFSBackedCollectionPartition;
 
 public final class TSetUtils {
-
-  private static final String CONFIG_PERSIST_FS = "twister2.tset.storage.type";
 
   private TSetUtils() {
   }
@@ -88,7 +87,7 @@ public final class TSetUtils {
   public static <T> BufferedCollectionPartition<T> getCollectionPartition(int maxFramesInMemory,
                                                                           Config config,
                                                                           String reference) {
-    switch (config.getStringValue(CONFIG_PERSIST_FS, DiskBackedCollectionPartition.CONFIG)) {
+    switch (FileSystemContext.tsetStorageType(config)) {
       case DiskBackedCollectionPartition.CONFIG:
         return new DiskBackedCollectionPartition<>(maxFramesInMemory, config, reference);
       case HDFSBackedCollectionPartition.CONFIG:

--- a/twister2/tset/src/java/edu/iu/dsc/tws/tset/TSetUtils.java
+++ b/twister2/tset/src/java/edu/iu/dsc/tws/tset/TSetUtils.java
@@ -27,7 +27,7 @@ import edu.iu.dsc.tws.dataset.partition.HDFSBackedCollectionPartition;
 
 public final class TSetUtils {
 
-  private static final String CONFIG_PERSIST_FS = "twister2.tset.data.persist.fs";
+  private static final String CONFIG_PERSIST_FS = "twister2.tset.storage.type";
 
   private TSetUtils() {
   }


### PR DESCRIPTION
I created two types of storage config parameters: volatile and persistent
I put both parameters to common/data.yaml 

Persistent storage can be: hdfs, mounted, none (mounted means local or nfs)
Persistent storage parameters: 

- twister2.persistent.storage.type
- twister2.persistent.storage.root

We create a directory under the root directory with jobID. All persistent files are saved in there. 
CheckpointManager and CheckpointClient always save to the persistent volume. 
They save to the following directories: 

- \<persRoot\>/\<jobID\>/checkpoint-manager/
- \<persRoot\>/\<jobID\>/worker-checkpoints/

Volatile storage root is by default: 

- twister2.volatile.storage.root: ["/tmp/twister2/volatile"]

We create a directory with jobID under the volatile root. 
There can be multiple roots for volatile storage, since networking component can save to multiple disks simultaneously.  

Networking data is saved to the following directory:

- \<volatileRoot\>/\<jobID\>/iodata/

Tset data can be saved to either the persistent or the volatile directory. Following parameter determines that: 

- twister2.tset.storage.type: "mounted" or "hdfs"

Tset data directory:

- \<root\>/\<jobID\>/tsetdata/


Logs can be saved to either persistent or volatile directory. However, logs can not be saved to hdfs. 
Following parameter determines the location of logs data: 

- twister2.logging.storage.type: "volatile" or "persistent"

Logging directory is: 

- \<root\>/\<jobID\>/logs/

In Kubernetes, we do not create the jobID directory under the volatile or persistent directory, since those directories are created for each jobs.