### PR TITLE
port conflict fix

### DIFF
--- a/twister2/api/src/java/edu/iu/dsc/tws/api/config/SchedulerContext.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/config/SchedulerContext.java
@@ -206,7 +206,7 @@ public class SchedulerContext extends Context {
     return cfg.getIntegerValue("twister2.worker.end.sync.time.ms", 30000);
   }
 
-  public static boolean useOpenMPI(Config cfg) {
+  public static boolean usingOpenMPI(Config cfg) {
     return networkClass(cfg).equals("edu.iu.dsc.tws.comms.mpi.TWSMPIChannel");
   }
 

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/config/SchedulerContext.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/config/SchedulerContext.java
@@ -40,6 +40,9 @@ public class SchedulerContext extends Context {
   public static final String THREADS_PER_WORKER = "twister2.exector.worker.threads";
   public static final String JOB_ARCHIVE_TEMP_DIR = "twister2.job.archive.temp.dir";
 
+  public static final String NETWORK_CLASS = "twister2.network.channel.class";
+  public static final String NETWORK_CLASS_DEFAULT = "edu.iu.dsc.tws.comms.mpi.TWSMPIChannel";
+
   public static final String SYSTEM_PACKAGE_URI = "twister2.resource.system.package.uri";
 
   // Internal configuration for job package url
@@ -114,6 +117,10 @@ public class SchedulerContext extends Context {
 
   public static String launcherClass(Config cfg) {
     return cfg.getStringValue(LAUNCHER_CLASS);
+  }
+
+  public static String networkClass(Config cfg) {
+    return cfg.getStringValue(NETWORK_CLASS, NETWORK_CLASS_DEFAULT);
   }
 
   public static String workerClass(Config cfg) {
@@ -200,8 +207,11 @@ public class SchedulerContext extends Context {
   }
 
   public static boolean useOpenMPI(Config cfg) {
-    return cfg.getStringValue("twister2.network.channel.class")
-        .equals("edu.iu.dsc.tws.comms.mpi.TWSMPIChannel");
+    return networkClass(cfg).equals("edu.iu.dsc.tws.comms.mpi.TWSMPIChannel");
+  }
+
+  public static boolean usingUCXChannel(Config cfg) {
+    return networkClass(cfg).equals("edu.iu.dsc.tws.comms.ucx.TWSUCXChannel");
   }
 
   public static String downloadMethod(Config cfg) {

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/resource/Network.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/resource/Network.java
@@ -44,6 +44,7 @@ import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.comms.channel.TWSChannel;
 import edu.iu.dsc.tws.api.config.Config;
+import edu.iu.dsc.tws.api.config.SchedulerContext;
 import edu.iu.dsc.tws.api.exceptions.Twister2RuntimeException;
 
 /**
@@ -57,9 +58,7 @@ public final class Network {
   }
 
   public static TWSChannel initializeChannel(Config config, IWorkerController wController) {
-    String channelClass = config.getStringValue(
-        "twister2.network.channel.class",
-        "edu.iu.dsc.tws.comms.mpi.TWSMPIChannel");
+    String channelClass = SchedulerContext.networkClass(config);
     try {
       return (TWSChannel) Network.class.getClassLoader()
           .loadClass(channelClass)

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/resource/WorkerEnvironment.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/resource/WorkerEnvironment.java
@@ -288,8 +288,8 @@ public final class WorkerEnvironment {
     putSharedValue(key, new WeakReference<>(value));
   }
 
-  public static void removeSharedValue(String key) {
-    sharedKeyValueStore.remove(key);
+  public static Object removeSharedValue(String key) {
+    return sharedKeyValueStore.remove(key);
   }
 
   public static Object getSharedValue(String key) {

--- a/twister2/api/src/java/edu/iu/dsc/tws/api/resource/WorkerEnvironment.java
+++ b/twister2/api/src/java/edu/iu/dsc/tws/api/resource/WorkerEnvironment.java
@@ -127,7 +127,7 @@ public final class WorkerEnvironment {
     // sometimes it takes some time to populate dns ip values in Kubernetes
     // although all workers is started, some workers may be unreachable by ip address
     if (Context.isKubernetesCluster(config)
-        && !SchedulerContext.useOpenMPI(config)
+        && !SchedulerContext.usingOpenMPI(config)
         && SchedulerContext.checkPodsReachable(config)) {
       checkAllPodsReachable();
     }

--- a/twister2/common/src/java/edu/iu/dsc/tws/common/util/NetworkUtils.java
+++ b/twister2/common/src/java/edu/iu/dsc/tws/common/util/NetworkUtils.java
@@ -17,11 +17,15 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import edu.iu.dsc.tws.api.exceptions.Twister2RuntimeException;
 import edu.iu.dsc.tws.api.resource.WorkerEnvironment;
 
 public final class NetworkUtils {
+  private static final Logger LOG = Logger.getLogger(NetworkUtils.class.getName());
+
   private NetworkUtils() {
   }
 
@@ -62,7 +66,7 @@ public final class NetworkUtils {
     try {
       for (String portName : portNames) {
         ServerSocket socket = new ServerSocket(0);
-        socket.setReuseAddress(false);
+        socket.setReuseAddress(true);
         freePorts.put(portName, socket.getLocalPort());
         sockets.add(socket);
       }
@@ -84,11 +88,16 @@ public final class NetworkUtils {
     List<ServerSocket> sockets =
         (List<ServerSocket>) WorkerEnvironment.removeSharedValue("socketsForFreePorts");
     boolean allSocketsClosed = true;
+    int port = 0;
     for (ServerSocket socket : sockets) {
       try {
+        port = socket.getLocalPort();
         socket.close();
+        LOG.fine("Temporary socket closed at the port: " + port);
       } catch (IOException ioException) {
         allSocketsClosed = false;
+        LOG.log(Level.SEVERE, "Exception when closing the temporary socket at the port: " + port,
+            ioException);
       }
     }
 

--- a/twister2/comms/src/java/edu/iu/dsc/tws/comms/ucx/TWSUCXChannel.java
+++ b/twister2/comms/src/java/edu/iu/dsc/tws/comms/ucx/TWSUCXChannel.java
@@ -80,7 +80,7 @@ public class TWSUCXChannel implements TWSChannel {
   private List<ReceiveProgress> receiveProgresses = new ArrayList<>();
   private Map<Integer, Map<Integer, Set<ReceiveProgress>>> groupReceives = new HashMap<>();
 
-  private static final int MAX_TRY_COUNT = 6;
+  private static final int MAX_TRY_COUNT = 8;
 
   public TWSUCXChannel(Config config,
                        IWorkerController workerController) {

--- a/twister2/comms/src/java/edu/iu/dsc/tws/comms/ucx/TWSUCXChannel.java
+++ b/twister2/comms/src/java/edu/iu/dsc/tws/comms/ucx/TWSUCXChannel.java
@@ -121,8 +121,9 @@ public class TWSUCXChannel implements TWSChannel {
 
       try {
         Thread.sleep(sleepDuration);
-      } catch (InterruptedException e) { }
-      
+      } catch (InterruptedException e) {
+      }
+
       // exponentially increase sleep duration between tries
       sleepDuration *= 2;
     }

--- a/twister2/comms/src/java/edu/iu/dsc/tws/comms/ucx/TWSUCXChannel.java
+++ b/twister2/comms/src/java/edu/iu/dsc/tws/comms/ucx/TWSUCXChannel.java
@@ -91,7 +91,7 @@ public class TWSUCXChannel implements TWSChannel {
         .setMtWorkersShared(false)
         .setConfig("SOCKADDR_CM_ENABLE", "y")
         .setConfig("SOCKADDR_TLS_PRIORITY", "tcp")
-        .setConfig("TCP_CM_ALLOW_ADDR_INUSE", "y")
+//        .setConfig("TCP_CM_ALLOW_ADDR_INUSE", "y")
     );
     this.closeables.push(context);
     this.ucpWorker = context.newWorker(new UcpWorkerParams().requestThreadSafety());

--- a/twister2/comms/src/java/edu/iu/dsc/tws/comms/ucx/TWSUCXChannel.java
+++ b/twister2/comms/src/java/edu/iu/dsc/tws/comms/ucx/TWSUCXChannel.java
@@ -13,6 +13,7 @@ package edu.iu.dsc.tws.comms.ucx;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -22,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Random;
 import java.util.Set;
 import java.util.Stack;
 import java.util.concurrent.ConcurrentHashMap;
@@ -31,6 +33,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.openucx.jucx.UcxCallback;
+import org.openucx.jucx.UcxException;
 import org.openucx.jucx.ucp.UcpContext;
 import org.openucx.jucx.ucp.UcpEndpoint;
 import org.openucx.jucx.ucp.UcpEndpointParams;
@@ -49,6 +52,7 @@ import edu.iu.dsc.tws.api.config.Config;
 import edu.iu.dsc.tws.api.exceptions.TimeoutException;
 import edu.iu.dsc.tws.api.exceptions.Twister2RuntimeException;
 import edu.iu.dsc.tws.api.resource.IWorkerController;
+import edu.iu.dsc.tws.api.resource.WorkerEnvironment;
 import edu.iu.dsc.tws.proto.jobmaster.JobMasterAPI;
 
 /**
@@ -80,8 +84,6 @@ public class TWSUCXChannel implements TWSChannel {
   private List<ReceiveProgress> receiveProgresses = new ArrayList<>();
   private Map<Integer, Map<Integer, Set<ReceiveProgress>>> groupReceives = new HashMap<>();
 
-  private static final int MAX_TRY_COUNT = 8;
-
   public TWSUCXChannel(Config config,
                        IWorkerController workerController) {
     this.workerId = workerController.getWorkerInfo().getWorkerID();
@@ -89,46 +91,54 @@ public class TWSUCXChannel implements TWSChannel {
   }
 
   private void createUXCWorker(IWorkerController iWorkerController) {
-    UcpContext context = new UcpContext(new UcpParams().requestTagFeature()
-        .setMtWorkersShared(false)
-        .setConfig("SOCKADDR_CM_ENABLE", "y")
-        .setConfig("SOCKADDR_TLS_PRIORITY", "tcp")
-//        .setConfig("TCP_CM_ALLOW_ADDR_INUSE", "y")
-    );
-    this.closeables.push(context);
-    this.ucpWorker = context.newWorker(new UcpWorkerParams().requestThreadSafety());
-    this.closeables.push(ucpWorker);
-
-    // start listener
-    UcpListenerParams ucpListenerParams = new UcpListenerParams().setSockAddr(
-        new InetSocketAddress(iWorkerController.getWorkerInfo().getWorkerIP(),
-            iWorkerController.getWorkerInfo().getPort())
-    );
-
-    // if binding to port fails, repeatedly try
+    UcpContext ucpContext = null;
     UcpListener ucpListener = null;
-    int tryCount = 0;
-    long sleepDuration = 100;
-    while (tryCount++ < MAX_TRY_COUNT) {
-      try {
-        ucpListener = ucpWorker.newListener(ucpListenerParams);
-        break;
-      } catch (org.openucx.jucx.UcxException ucxEx) {
-        if (tryCount == MAX_TRY_COUNT) {
-          throw new Twister2RuntimeException("Can not start TWSUCXChannel.", ucxEx);
+
+    // if UCX socket is already created, use that
+    // this happens in mpi clusters
+    Stack<Closeable> ucxObjects =
+        (Stack<Closeable>) WorkerEnvironment.getSharedValue("ucxSocketsForFreePorts");
+    if (ucxObjects != null && ucxObjects.size() > 2) {
+      //todo: handle the case when there are multiple ucp sockets
+      while (!ucxObjects.isEmpty()) {
+        Closeable ucxObj = ucxObjects.pop();
+        if (ucxObj instanceof UcpListener) {
+          ucpListener = (UcpListener) ucxObj;
+        } else if (ucxObj instanceof UcpContext) {
+          ucpContext = (UcpContext) ucxObj;
+        } else if (ucxObj instanceof UcpWorker) {
+          ucpWorker = (UcpWorker) ucxObj;
+        } else {
+          LOG.warning("Unrecognized UCX object: " + ucxObj);
         }
       }
 
+      // add them to closeables
+      closeables.push(ucpContext);
+      closeables.push(ucpWorker);
+      closeables.push(ucpListener);
+
+      // create UCX objects
+    } else {
+
+      ucpContext = initUcpContext();
+      this.closeables.push(ucpContext);
+      this.ucpWorker = ucpContext.newWorker(new UcpWorkerParams().requestThreadSafety());
+      this.closeables.push(ucpWorker);
+
+      UcpListenerParams ucpListenerParams = new UcpListenerParams().setSockAddr(
+          new InetSocketAddress(iWorkerController.getWorkerInfo().getWorkerIP(),
+              iWorkerController.getWorkerInfo().getPort())
+      );
+
+      // start listener
       try {
-        Thread.sleep(sleepDuration);
-      } catch (InterruptedException e) {
+        ucpListener = ucpWorker.newListener(ucpListenerParams);
+        closeables.push(ucpListener);
+      } catch (org.openucx.jucx.UcxException ucxEx) {
+        throw new Twister2RuntimeException("Can not start TWSUCXChannel.", ucxEx);
       }
-
-      // exponentially increase sleep duration between tries
-      sleepDuration *= 2;
     }
-
-    this.closeables.push(ucpListener);
 
     try {
       // wait till everyone add listeners
@@ -147,6 +157,75 @@ public class TWSUCXChannel implements TWSChannel {
         this.closeables.push(ucpEndpoint);
       }
     }
+  }
+
+  /**
+   * create Ucx sockets and return the ports
+   * save the created objects in the the static map of WorkerEnvironment,
+   * so that they can be reused when TWSUCXChannel is initialized
+   * @param portNames
+   * @param wIP
+   * @return
+   */
+  public static Map<String, Integer> findFreeUcxPorts(List<String> portNames, InetAddress wIP) {
+    UcpContext context = initUcpContext();
+
+    Stack<Closeable> ucxObjects = new Stack<>();
+    ucxObjects.push(context);
+
+    UcpWorker ucpWorker = context.newWorker(new UcpWorkerParams().requestThreadSafety());
+    ucxObjects.push(ucpWorker);
+
+    Map<String, Integer> freePorts = new HashMap<>();
+    for (String portName : portNames) {
+      UcpListener ucpListener = createUcpListener(ucpWorker, wIP);
+      ucxObjects.push(ucpListener);
+      int port = ucpListener.getAddress().getPort();
+      LOG.fine("workerPort for ucx channel: " + port);
+      freePorts.put(portName, ucpListener.getAddress().getPort());
+    }
+    WorkerEnvironment.putSharedValue("ucxSocketsForFreePorts", ucxObjects);
+    return freePorts;
+  }
+
+  /**
+   * create a UcpListener on a random port between 15k and 65k
+   * if a chosen port is taken, try other random ports
+   * @param ucpWorker
+   * @param wIP
+   * @return
+   */
+  private static UcpListener createUcpListener(UcpWorker ucpWorker, InetAddress wIP) {
+    Random rg = new Random();
+    UcpListenerParams ucpListenerParams = new UcpListenerParams();
+
+    int tryCount = 0;
+    int maxTryCount = 10;
+
+    while (tryCount++ < maxTryCount) {
+      // generate random port numbers in the range of 15k to 65k
+      int port = rg.nextInt(40000) + 15000;
+      ucpListenerParams.setSockAddr(new InetSocketAddress(wIP.getHostAddress(), port));
+      try {
+        UcpListener ucpListener = ucpWorker.newListener(ucpListenerParams);
+        return ucpListener;
+      } catch (UcxException ucxException) {
+        if (tryCount == maxTryCount) {
+          throw new Twister2RuntimeException(ucxException);
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private static UcpContext initUcpContext() {
+    return new UcpContext(new UcpParams().requestTagFeature()
+        .setMtWorkersShared(false)
+        .setConfig("SOCKADDR_CM_ENABLE", "y")
+        .setConfig("SOCKADDR_TLS_PRIORITY", "tcp")
+//        .setConfig("TCP_CM_ALLOW_ADDR_INUSE", "y")
+    );
   }
 
   @Override

--- a/twister2/config/src/yaml/conf/standalone/mpiworker.sh
+++ b/twister2/config/src/yaml/conf/standalone/mpiworker.sh
@@ -37,6 +37,8 @@ fi
 
 CLASSPATH=${CLASSPATH}:${SUBMITTING_TWISTER2_HOME}/lib
 
+export UCX_TCP_CM_ALLOW_ADDR_INUSE=y
+
 $JAVA_HOME/bin/java $illegal_access_warn $debug $profile \
    -Djava.util.logging.config.file=common/logger.properties \
    -Djava.library.path=${LD_LIBRARY_PATH} \

--- a/twister2/examples/src/java/edu/iu/dsc/tws/examples/utils/bench/BenchmarkUtils.java
+++ b/twister2/examples/src/java/edu/iu/dsc/tws/examples/utils/bench/BenchmarkUtils.java
@@ -49,7 +49,7 @@ public final class BenchmarkUtils {
           generateColumnLabelWithUnit(COLUMN_TOTAL_TIME, TIMING_ALL_SEND),
           time
       );
-      LOG.info("Total time for all iterations : " + time);
+      LOG.warning("Total time for all iterations : " + time);
     }
   }
 

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesLauncher.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/KubernetesLauncher.java
@@ -345,7 +345,7 @@ public class KubernetesLauncher implements ILauncher {
 
     // check the existence of Secret object on Kubernetes master
     // when OpenMPI is enabled, a Secret object has to be available in the cluster
-    if (SchedulerContext.useOpenMPI(config)) {
+    if (SchedulerContext.usingOpenMPI(config)) {
       String secretName = KubernetesContext.secretName(config);
       boolean secretExists = controller.existSecret(secretName);
 
@@ -511,7 +511,7 @@ public class KubernetesLauncher implements ILauncher {
 
     // when OpenMPI is enabled, all pods need to have equal numbers workers
     // we check whether all workersPerPod values are equal to first ComputeResource workersPerPod
-    if (SchedulerContext.useOpenMPI(config)) {
+    if (SchedulerContext.usingOpenMPI(config)) {
       int workersPerPod = job.getComputeResource(0).getWorkersPerPod();
       for (int i = 1; i < job.getComputeResourceList().size(); i++) {
         if (workersPerPod != job.getComputeResource(i).getWorkersPerPod()) {

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/RequestObjectBuilder.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/RequestObjectBuilder.java
@@ -205,7 +205,7 @@ public final class RequestObjectBuilder {
     }
 
     // if openmpi is used, we initialize a Secret volume on each pod
-    if (SchedulerContext.useOpenMPI(config)) {
+    if (SchedulerContext.usingOpenMPI(config)) {
       String secretName = KubernetesContext.secretName(config);
       V1Volume secretVolume = createSecretVolume(secretName);
       volumes.add(secretVolume);
@@ -216,7 +216,7 @@ public final class RequestObjectBuilder {
     int containersPerPod = computeResource.getWorkersPerPod();
 
     // if openmpi is used, we initialize only one container for each pod
-    if (SchedulerContext.useOpenMPI(config)) {
+    if (SchedulerContext.usingOpenMPI(config)) {
       containersPerPod = 1;
     }
 
@@ -306,7 +306,7 @@ public final class RequestObjectBuilder {
     double cpuPerContainer = computeResource.getCpu();
     int ramPerContainer = computeResource.getRamMegaBytes();
 
-    if (SchedulerContext.useOpenMPI(config)) {
+    if (SchedulerContext.usingOpenMPI(config)) {
       startScript = "./init_openmpi.sh";
       cpuPerContainer = cpuPerContainer * computeResource.getWorkersPerPod();
       ramPerContainer = ramPerContainer * computeResource.getWorkersPerPod();
@@ -347,7 +347,7 @@ public final class RequestObjectBuilder {
     }
 
     // mount Secret object as a volume
-    if (SchedulerContext.useOpenMPI(config)) {
+    if (SchedulerContext.usingOpenMPI(config)) {
       V1VolumeMount persVolumeMount = new V1VolumeMount();
       persVolumeMount.setName(KubernetesConstants.SECRET_VOLUME_NAME);
       persVolumeMount.setMountPath(KubernetesConstants.SECRET_VOLUME_MOUNT);
@@ -391,7 +391,7 @@ public final class RequestObjectBuilder {
         .value(jobMasterIP));
 
     String classToRun = "edu.iu.dsc.tws.rsched.schedulers.k8s.worker.K8sWorkerStarter";
-    if (SchedulerContext.useOpenMPI(config)) {
+    if (SchedulerContext.usingOpenMPI(config)) {
       classToRun = "edu.iu.dsc.tws.rsched.schedulers.k8s.mpi.MPIMasterStarter";
     }
 

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/driver/K8sScaler.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/k8s/driver/K8sScaler.java
@@ -62,7 +62,7 @@ public class K8sScaler implements IScalerPerCluster {
     }
 
     // if it is an OpenMPI job, it is not scalable
-    if (SchedulerContext.useOpenMPI(config)) {
+    if (SchedulerContext.usingOpenMPI(config)) {
       return false;
     }
 

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/mesos/MesosScheduler.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/mesos/MesosScheduler.java
@@ -194,7 +194,7 @@ public class MesosScheduler implements Scheduler {
                         + "edu.iu.dsc.tws.rsched.schedulers.mesos.master.MesosJobMasterStarter")
                     .build();
               } else {
-                if (SchedulerContext.useOpenMPI(config)) {
+                if (SchedulerContext.usingOpenMPI(config)) {
                   if (taskId.getValue().equals("1")) {
                     ((TaskInfo.Builder) taskBuilder).setName("MPI Master " + taskId);
                     classNameParam = Protos.Parameter.newBuilder().setKey("env")

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/mesos/driver/MesosScaler.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/mesos/driver/MesosScaler.java
@@ -64,7 +64,7 @@ public class MesosScaler implements IScalerPerCluster {
     }
 
     // if it is an OpenMPI job, it is not scalable
-    if (SchedulerContext.useOpenMPI(config)) {
+    if (SchedulerContext.usingOpenMPI(config)) {
       return false;
     }
 

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPILauncher.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPILauncher.java
@@ -34,7 +34,6 @@ import edu.iu.dsc.tws.api.scheduler.IController;
 import edu.iu.dsc.tws.api.scheduler.ILauncher;
 import edu.iu.dsc.tws.api.scheduler.Twister2JobState;
 import edu.iu.dsc.tws.checkpointing.util.CheckpointingContext;
-import edu.iu.dsc.tws.common.util.NetworkUtils;
 import edu.iu.dsc.tws.common.zk.ZKContext;
 import edu.iu.dsc.tws.master.JobMasterContext;
 import edu.iu.dsc.tws.master.server.JobMaster;
@@ -43,6 +42,7 @@ import edu.iu.dsc.tws.proto.system.job.JobAPI;
 import edu.iu.dsc.tws.proto.utils.NodeInfoUtils;
 import edu.iu.dsc.tws.rsched.schedulers.NullTerminator;
 import edu.iu.dsc.tws.rsched.utils.FileUtils;
+import edu.iu.dsc.tws.rsched.utils.NetworkUtils;
 import edu.iu.dsc.tws.rsched.utils.ProcessUtils;
 import edu.iu.dsc.tws.rsched.utils.ResourceSchedulerUtils;
 

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPIWorkerStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPIWorkerStarter.java
@@ -315,6 +315,9 @@ public final class MPIWorkerStarter {
       // init the logger
       initJMLogger(config);
 
+      // release the port for JM
+      NetworkUtils.releaseWorkerPorts();
+
       int port = JobMasterContext.jobMasterPort(config);
       String hostAddress = ResourceSchedulerUtils.getHostIP(config);
       LOG.log(Level.INFO, String.format("Starting the job master: %s:%d", hostAddress, port));

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPIWorkerStarter.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/schedulers/standalone/MPIWorkerStarter.java
@@ -615,7 +615,12 @@ public final class MPIWorkerStarter {
     File directory = new File(logDir);
     if (!directory.exists()) {
       if (!directory.mkdirs()) {
-        throw new RuntimeException("Failed to create log directory: " + logDir);
+        // this worker may have failed to created the directory,
+        // but another worker may have succeeded.
+        // test it to make sure
+        if (!directory.exists()) {
+          throw new RuntimeException("Failed to create log directory: " + logDir);
+        }
       }
     }
     LoggingHelper.setupLogging(cfg, logDir, "worker-" + workerID);

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/utils/JobUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/utils/JobUtils.java
@@ -222,7 +222,7 @@ public final class JobUtils {
     }
 
     // if it is an OpenMPI job, it is not scalable
-    if (SchedulerContext.useOpenMPI(config)) {
+    if (SchedulerContext.usingOpenMPI(config)) {
       return false;
     }
 

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/utils/ResourceSchedulerUtils.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/utils/ResourceSchedulerUtils.java
@@ -153,7 +153,7 @@ public final class ResourceSchedulerUtils {
    * @param interfaceNames
    * @return
    */
-  public static String getLocalIPFromNetworkInterfaces(List<String> interfaceNames) {
+  public static InetAddress getLocalIPFromNetworkInterfaces(List<String> interfaceNames) {
 
     try {
       for (String nwInterfaceName: interfaceNames) {
@@ -164,7 +164,7 @@ public final class ResourceSchedulerUtils {
           List<InterfaceAddress> addressList = networkInterface.getInterfaceAddresses();
           for (InterfaceAddress adress: addressList) {
             if (isValidIPv4(adress.getAddress().getHostAddress())) {
-              return adress.getAddress().getHostAddress();
+              return adress.getAddress();
             }
           }
         }

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/worker/MPIWorkerManager.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/worker/MPIWorkerManager.java
@@ -24,10 +24,10 @@ import edu.iu.dsc.tws.api.resource.IVolatileVolume;
 import edu.iu.dsc.tws.api.resource.IWorker;
 import edu.iu.dsc.tws.api.resource.IWorkerController;
 import edu.iu.dsc.tws.api.resource.IWorkerFailureListener;
-import edu.iu.dsc.tws.common.util.NetworkUtils;
 import edu.iu.dsc.tws.proto.jobmaster.JobMasterAPI;
 import edu.iu.dsc.tws.proto.system.job.JobAPI;
 import edu.iu.dsc.tws.rsched.core.WorkerRuntime;
+import edu.iu.dsc.tws.rsched.utils.NetworkUtils;
 
 public class MPIWorkerManager implements IWorkerFailureListener, IJobMasterFailureListener {
   private static final Logger LOG = Logger.getLogger(MPIWorkerManager.class.getName());

--- a/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/worker/MPIWorkerManager.java
+++ b/twister2/resource-scheduler/src/java/edu/iu/dsc/tws/rsched/worker/MPIWorkerManager.java
@@ -24,6 +24,7 @@ import edu.iu.dsc.tws.api.resource.IVolatileVolume;
 import edu.iu.dsc.tws.api.resource.IWorker;
 import edu.iu.dsc.tws.api.resource.IWorkerController;
 import edu.iu.dsc.tws.api.resource.IWorkerFailureListener;
+import edu.iu.dsc.tws.common.util.NetworkUtils;
 import edu.iu.dsc.tws.proto.jobmaster.JobMasterAPI;
 import edu.iu.dsc.tws.proto.system.job.JobAPI;
 import edu.iu.dsc.tws.rsched.core.WorkerRuntime;
@@ -57,6 +58,11 @@ public class MPIWorkerManager implements IWorkerFailureListener, IJobMasterFailu
       firstInitBarrierProceeded = true;
     } catch (TimeoutException e) {
       throw new Twister2RuntimeException("Could not pass through the init barrier", e);
+    }
+
+    // if it is executing for the first time, release worker ports
+    if (JobProgress.getWorkerExecuteCount() == 0) {
+      NetworkUtils.releaseWorkerPorts();
     }
 
     JobProgressImpl.setJobStatus(JobProgress.JobStatus.EXECUTING);


### PR DESCRIPTION
To assign each worker unique ports at MPI clusters,

- We create a socket when each worker is starting and hold it bound to a random port,
- We advertise this port to all other workers in the job so that other workers can connect to this worker
- We release this port after all workers passed INIT barrier

In the case of UCX: 
- UCX sometimes can not bind to the previously released port
- When UCX channel is used, we create the UCX socket when the workers are starting
- We use this socket when initializing UCX channel
